### PR TITLE
Fixing electron_density requirement bug

### DIFF
--- a/include/actions/AddScalarReactions.h
+++ b/include/actions/AddScalarReactions.h
@@ -21,7 +21,6 @@ public:
 
 protected:
   std::vector<std::string> _aux_species;
-  bool _use_bolsig;
 
 
 };

--- a/include/actions/ChemicalReactionsBase.h
+++ b/include/actions/ChemicalReactionsBase.h
@@ -67,6 +67,7 @@ protected:
   unsigned int _num_reactions;
   std::vector<bool> _electron_energy_term;
   std::vector<NonlinearVariableName> _energy_variable;
+  bool _use_bolsig;
 };
 
 #endif // CHEMICALREACTIONSBASE_H

--- a/src/actions/AddScalarReactions.C
+++ b/src/actions/AddScalarReactions.C
@@ -41,7 +41,6 @@ validParams<AddScalarReactions>()
 
   InputParameters params = validParams<ChemicalReactionsBase>();
   params.addParam<std::vector<std::string>>("aux_species", "Auxiliary species that are not included in nonlinear solve.");
-  params.addParam<bool>("use_bolsig", false, "Whether or not to use Bolsig+ (or bolos) to compute EEDF rate coefficients.");
   params.addParam<std::string>("boltzmann_input_file", "The name of the input file being used for Bolsig+.");
   params.addParam<bool>("output_table", false, "Whether or not to use an output table used for Bolsig+. If false, Bolsig+ should be run every timestep.");
   params.addParam<std::string>("cross_section_data", "The file name of the cross section data used for Bolsig+.");
@@ -58,8 +57,8 @@ validParams<AddScalarReactions>()
 
 AddScalarReactions::AddScalarReactions(InputParameters params)
   : ChemicalReactionsBase(params),
-    _aux_species(getParam<std::vector<std::string>>("aux_species")),
-    _use_bolsig(getParam<bool>("use_bolsig"))
+    _aux_species(getParam<std::vector<std::string>>("aux_species"))
+    // _use_bolsig(getParam<bool>("use_bolsig"))
 {
 }
 

--- a/src/actions/ChemicalReactionsBase.C
+++ b/src/actions/ChemicalReactionsBase.C
@@ -42,6 +42,7 @@ validParams<ChemicalReactionsBase>()
   MooseEnum orders(AddVariableAction::getNonlinearVariableOrders());
 
   InputParameters params = validParams<AddVariableAction>();
+  params.addParam<bool>("use_bolsig", false, "Whether or not to use Bolsig+ (or bolos) to compute EEDF rate coefficients.");
   params.addRequiredParam<std::vector<NonlinearVariableName>>(
     "species", "List of (tracked) species included in reactions (both products and reactants)");
   params.addParam<std::vector<Real>>("reaction_coefficient", "The reaction coefficients.");
@@ -94,7 +95,8 @@ ChemicalReactionsBase::ChemicalReactionsBase(InputParameters params)
     _input_reactions(getParam<std::string>("reactions")),
     _r_units(getParam<Real>("position_units")),
     _sampling_variable(getParam<std::string>("sampling_variable")),
-    _use_log(getParam<bool>("use_log"))
+    _use_log(getParam<bool>("use_log")),
+    _use_bolsig(getParam<bool>("use_bolsig"))
     // _use_moles(getParam<bool>("use_moles"))
 {
   std::istringstream iss(_input_reactions);
@@ -320,7 +322,7 @@ ChemicalReactionsBase::ChemicalReactionsBase(InputParameters params)
 
     for (unsigned int k = 0; k < _reactants[i].size(); ++k)
     {
-      if (_rate_type[i] == "EEDF")
+      if (_rate_type[i] == "EEDF" && _use_bolsig)
       {
         if (!isParamValid("electron_density"))
         {


### PR DESCRIPTION
Previous updates required electron_density to be set even if Bolsig+ was not being run on-the-fly, which was an unintended bug. This PR corrects the issue.