### PR TITLE
EEDF reaction file names can now be specified

### DIFF
--- a/include/actions/ChemicalReactionsBase.h
+++ b/include/actions/ChemicalReactionsBase.h
@@ -60,6 +60,7 @@ protected:
   std::vector<int> _num_products;
   std::vector<std::string> _rate_equation_string;
   std::vector<std::string> _reaction_identifier;
+  std::vector<bool> _is_identified;
   std::vector<int> _eedf_reaction_number;
   std::vector<std::string> _reaction_species;
   int _eedf_reaction_counter;

--- a/src/actions/AddScalarReactions.C
+++ b/src/actions/AddScalarReactions.C
@@ -162,7 +162,14 @@ AddScalarReactions::act()
           InputParameters params = _factory.getValidParams("DataReadScalar");
           params.set<AuxVariableName>("variable") = {_aux_var_name[i]};
           params.set<std::vector<VariableName>>("sampler") = {getParam<std::string>("sampling_variable")};
-          params.set<FileName>("property_file") = "reaction_"+_reaction[i]+".txt";
+          if (_is_identified[i])
+          {
+            params.set<FileName>("property_file") = _reaction_identifier[_eedf_reaction_number[i]];
+          }
+          else
+          {
+            params.set<FileName>("property_file") = "reaction_"+_reaction[i]+".txt";
+          }
           params.set<std::string>("file_location") = getParam<std::string>("file_location");
           params.set<ExecFlagEnum>("execute_on") = "TIMESTEP_BEGIN";
           _problem->addAuxScalarKernel("DataReadScalar", "aux_rate"+std::to_string(i), params);

--- a/src/actions/ChemicalReactionsBase.C
+++ b/src/actions/ChemicalReactionsBase.C
@@ -173,12 +173,14 @@ ChemicalReactionsBase::ChemicalReactionsBase(InputParameters params)
 
     if (rxn_identifier_start != std::string::npos && !_rate_equation[counter])
     {
+      _is_identified.push_back(true);
       _reaction_identifier.push_back(token.substr(rxn_identifier_start + 1, rxn_identifier_end-rxn_identifier_start-1));
       _eedf_reaction_number.push_back(_eedf_reaction_counter);
       _eedf_reaction_counter += 1; // Counts the number of EEDF reactions (this is the only instance in which a reaction identifier is used)
     }
     else
     {
+      _is_identified.push_back(false);
       // _reaction_identifier.push_back("NONE");
       _eedf_reaction_number.push_back(123456);
     }


### PR DESCRIPTION
This PR adds functionality to the EEDF rate coefficient identifier. Instead of forcing the user to create files that are named based on the reaction, they can now specify which file to look for by enclosing the file name in parentheses, e.g. 
e + Ar -> e + e + Ar+  : EEDF (file_name.txt)