### PR TITLE
Add fixups for -Werror with gcc

### DIFF
--- a/src/actions/AddScalarReactionsOld.C
+++ b/src/actions/AddScalarReactionsOld.C
@@ -117,7 +117,8 @@ AddScalarReactionsOld::AddScalarReactionsOld(InputParameters params)
     _input_reactions(getParam<std::string>("reactions")),
     _r_units(getParam<Real>("position_units")),
     _sampling_format(getParam<std::string>("sampling_format")),
-    _use_log(getParam<bool>("use_log"))
+    _use_log(getParam<bool>("use_log")),
+    _energy_change(false)
 {
   std::istringstream iss(_input_reactions);
   std::string token;
@@ -136,8 +137,6 @@ AddScalarReactionsOld::AddScalarReactionsOld(InputParameters params)
   while (std::getline(iss >> std::ws,
                       token)) // splits by \n character (default) and ignores leading whitespace
   {
-    // Define check for change of energy
-    bool _energy_change = false;
     pos = token.find(':'); // Looks for colon, which separates reaction and rate coefficients
 
     // Brackets enclose the energy gain/loss (if applicable)

--- a/src/actions/AddZapdosReactions.C
+++ b/src/actions/AddZapdosReactions.C
@@ -88,7 +88,6 @@ AddZapdosReactions::act()
   bool find_aux;
   std::vector<bool> include_species;
   unsigned int target; // stores index of target species for electron-impact reactions
-  unsigned int aux_target;
   std::string product_kernel_name;
   std::string reactant_kernel_name;
   std::string energy_kernel_name;
@@ -164,7 +163,6 @@ AddZapdosReactions::act()
             if (_reactants[i][k] == _aux_species[j])
             {
               target_species_aux = true;
-              aux_target = k;
               break;
             }
           }

--- a/src/actions/ChemicalReactions.C
+++ b/src/actions/ChemicalReactions.C
@@ -125,8 +125,8 @@ ChemicalReactions::ChemicalReactions(InputParameters params)
     _coefficient_format(getParam<std::string>("reaction_coefficient_format")),
     _sampling_format(getParam<std::string>("sampling_format")),
     _use_log(getParam<bool>("use_log")),
-    _scalar_problem(getParam<bool>("scalar_problem"))
-// _scalar_problem(getParam<bool>("scalar_problem"))
+    _scalar_problem(getParam<bool>("scalar_problem")),
+    _energy_change(false)
 {
   // 1) split into reactants and products
   // 2) split products into products and reaction rate
@@ -151,8 +151,6 @@ ChemicalReactions::ChemicalReactions(InputParameters params)
   while (std::getline(iss >> std::ws,
                       token)) // splits by \n character (default) and ignores leading whitespace
   {
-    // Define check for change of energy
-    bool _energy_change = false;
     pos = token.find(':'); // Looks for colon, which separates reaction and rate coefficients
 
     // Brackets enclose the energy gain/loss (if applicable)

--- a/src/scalarkernels/Reactant2BodyScalar.C
+++ b/src/scalarkernels/Reactant2BodyScalar.C
@@ -78,12 +78,7 @@ Reactant2BodyScalar::computeQpJacobian()
 Real
 Reactant2BodyScalar::computeQpOffDiagJacobian(unsigned int jvar)
 {
-  Real mult1;
   Real rate_constant;
-  if (isCoupledScalar("v"))
-    mult1 = _v[_i];
-  else
-    mult1 = _n_gas;
 
   // if (_rate_constant_equation)
   rate_constant = _rate_coefficient[_i];


### PR DESCRIPTION
These variables were all local variables that were unused. In the `_energy_change` case you actually had the dangerous behavior that you were modifying a local when you probably thought you were operating on the class member variable.