### PR TITLE
Adding Multiple Action Blocks

### DIFF
--- a/include/kernels/ProductFirstOrder.h
+++ b/include/kernels/ProductFirstOrder.h
@@ -31,11 +31,10 @@ public:
 protected:
   Real computeQpResidual() override;
   Real computeQpJacobian() override;
-  Real computeQpOffDiagJacobian(unsigned int) override;
+  Real computeQpOffDiagJacobian(unsigned int jvar) override;
 
   const VariableValue & _v;
   unsigned int _v_id;
-  // const MaterialProperty<Real> & _n_gas;
 
   // The reaction coefficient
   const MaterialProperty<Real> & _reaction_coeff;

--- a/include/kernels/ProductFirstOrderLog.h
+++ b/include/kernels/ProductFirstOrderLog.h
@@ -35,7 +35,7 @@ protected:
 
   const VariableValue & _v;
   unsigned int _v_id;
-  const MaterialProperty<Real> & _n_gas;
+  // const MaterialProperty<Real> & _n_gas;
 
   // The reaction coefficient
   const MaterialProperty<Real> & _reaction_coeff;

--- a/include/kernels/ProductSecondOrder.h
+++ b/include/kernels/ProductSecondOrder.h
@@ -39,7 +39,6 @@ protected:
   const VariableValue & _w;
   unsigned int _v_id;
   unsigned int _w_id;
-  const MaterialProperty<Real> & _n_gas;
 
   // The reaction coefficient
   const MaterialProperty<Real> & _reaction_coeff;

--- a/include/kernels/ProductSecondOrderLog.h
+++ b/include/kernels/ProductSecondOrderLog.h
@@ -33,20 +33,15 @@ protected:
   virtual Real computeQpJacobian();
   virtual Real computeQpOffDiagJacobian(unsigned int jvar);
 
-  // MooseVariable & _coupled_var_A;
-  // MooseVariable & _coupled_var_B;
   const VariableValue & _v;
   const VariableValue & _w;
   unsigned int _v_id;
   unsigned int _w_id;
-  // const MaterialProperty<Real> & _n_gas;
 
   // The reaction coefficient
   const MaterialProperty<Real> & _reaction_coeff;
   Real _stoichiometric_coeff;
   bool _v_eq_u;
   bool _w_eq_u;
-  bool _v_coupled;
-  bool _w_coupled;
 };
 #endif // PRODUCTSECONDORDERLOG_H

--- a/include/kernels/ProductSecondOrderLog.h
+++ b/include/kernels/ProductSecondOrderLog.h
@@ -39,7 +39,7 @@ protected:
   const VariableValue & _w;
   unsigned int _v_id;
   unsigned int _w_id;
-  const MaterialProperty<Real> & _n_gas;
+  // const MaterialProperty<Real> & _n_gas;
 
   // The reaction coefficient
   const MaterialProperty<Real> & _reaction_coeff;

--- a/include/kernels/ProductThirdOrder.h
+++ b/include/kernels/ProductThirdOrder.h
@@ -41,7 +41,6 @@ protected:
   unsigned int _v_id;
   unsigned int _w_id;
   unsigned int _x_id;
-  const MaterialProperty<Real> & _n_gas;
 
   // The reaction coefficient
   const MaterialProperty<Real> & _reaction_coeff;

--- a/include/kernels/ProductThirdOrderLog.h
+++ b/include/kernels/ProductThirdOrderLog.h
@@ -33,8 +33,6 @@ protected:
   virtual Real computeQpJacobian();
   virtual Real computeQpOffDiagJacobian(unsigned int jvar);
 
-  // MooseVariable & _coupled_var_A;
-  // MooseVariable & _coupled_var_B;
   const VariableValue & _v;
   const VariableValue & _w;
   const VariableValue & _x;
@@ -44,12 +42,7 @@ protected:
   bool _v_eq_u;
   bool _w_eq_u;
   bool _x_eq_u;
-  bool _v_coupled;
-  bool _w_coupled;
-  bool _x_coupled;
-  // const MaterialProperty<Real> & _n_gas;
 
-  // The reaction coefficient
   const MaterialProperty<Real> & _reaction_coeff;
   Real _stoichiometric_coeff;
 };

--- a/include/kernels/ProductThirdOrderLog.h
+++ b/include/kernels/ProductThirdOrderLog.h
@@ -47,7 +47,7 @@ protected:
   bool _v_coupled;
   bool _w_coupled;
   bool _x_coupled;
-  const MaterialProperty<Real> & _n_gas;
+  // const MaterialProperty<Real> & _n_gas;
 
   // The reaction coefficient
   const MaterialProperty<Real> & _reaction_coeff;

--- a/include/kernels/ReactantFirstOrderLog.h
+++ b/include/kernels/ReactantFirstOrderLog.h
@@ -33,11 +33,7 @@ protected:
   Real computeQpJacobian() override;
   Real computeQpOffDiagJacobian(unsigned int) override;
 
-  // The reaction coefficient
-  // MooseVariable & _coupled_var_A;
   const MaterialProperty<Real> & _reaction_coeff;
-  // const MaterialProperty<Real> & _diff_rate;
-  // const MaterialProperty<Real> & _n_gas;
   Real _stoichiometric_coeff;
 };
 #endif // REACTANTFIRSTORDERLOG_H

--- a/include/kernels/ReactantSecondOrder.h
+++ b/include/kernels/ReactantSecondOrder.h
@@ -34,11 +34,9 @@ protected:
   virtual Real computeQpOffDiagJacobian(unsigned int jvar);
 
   // The reaction coefficient
-  // MooseVariable & _coupled_var_A;
   const MaterialProperty<Real> & _reaction_coeff;
   const VariableValue & _v;
   unsigned int _v_id;
-  const MaterialProperty<Real> & _n_gas;
   Real _stoichiometric_coeff;
   bool _v_eq_u;
 

--- a/include/kernels/ReactantSecondOrderLog.h
+++ b/include/kernels/ReactantSecondOrderLog.h
@@ -38,9 +38,8 @@ protected:
   const MaterialProperty<Real> & _reaction_coeff;
   const VariableValue & _v;
   unsigned int _v_id;
-  const MaterialProperty<Real> & _n_gas;
+  // const MaterialProperty<Real> & _n_gas;
   Real _stoichiometric_coeff;
   bool _v_eq_u;
-
 };
 #endif // REACTANTSECONDORDERLOG_H

--- a/include/kernels/ReactantThirdOrder.h
+++ b/include/kernels/ReactantThirdOrder.h
@@ -40,7 +40,6 @@ protected:
   const VariableValue & _w;
   unsigned int _v_id;
   unsigned int _w_id;
-  const MaterialProperty<Real> & _n_gas;
   Real _stoichiometric_coeff;
   bool _v_eq_u;
   bool _w_eq_u;

--- a/include/kernels/ReactantThirdOrderLog.h
+++ b/include/kernels/ReactantThirdOrderLog.h
@@ -33,8 +33,6 @@ protected:
   Real computeQpJacobian() override;
   Real computeQpOffDiagJacobian(unsigned int) override;
 
-  // The reaction coefficient
-  // MooseVariable & _coupled_var_A;
   const MaterialProperty<Real> & _reaction_coeff;
   const VariableValue & _v;
   const VariableValue & _w;
@@ -42,9 +40,6 @@ protected:
   unsigned int _w_id;
   bool _v_eq_u;
   bool _w_eq_u;
-  bool _v_coupled;
-  bool _w_coupled;
-  //  const MaterialProperty<Real> & _n_gas;
   Real _stoichiometric_coeff;
 };
 #endif // REACTANTTHIRDORDERLOG_H

--- a/include/kernels/ReactantThirdOrderLog.h
+++ b/include/kernels/ReactantThirdOrderLog.h
@@ -44,7 +44,7 @@ protected:
   bool _w_eq_u;
   bool _v_coupled;
   bool _w_coupled;
-  const MaterialProperty<Real> & _n_gas;
+  //  const MaterialProperty<Real> & _n_gas;
   Real _stoichiometric_coeff;
 };
 #endif // REACTANTTHIRDORDERLOG_H

--- a/src/actions/AddZapdosReactions.C
+++ b/src/actions/AddZapdosReactions.C
@@ -397,13 +397,21 @@ AddZapdosReactions::act()
             else
             {
               InputParameters params = _factory.getValidParams(energy_kernel_name);
-              if (find_other || find_aux)
-                params.set<std::vector<VariableName>>("v") = {_reactants[i][non_electron_index]};
+              // if (find_other || find_aux)
+              //  params.set<std::vector<VariableName>>("v") = {_reactants[i][non_electron_index]};
               params.set<NonlinearVariableName>("variable") = _electron_energy[0];
               params.set<std::vector<VariableName>>("em") = {"em"};
               if (_coefficient_format == "townsend")
+              {
                 params.set<std::vector<VariableName>>("potential") =
                     getParam<std::vector<VariableName>>("potential");
+              }
+              else
+              {
+                // If rate format, the target species is needed.
+                if (find_other || find_aux)
+                  params.set<std::vector<VariableName>>("v") = {_reactants[i][non_electron_index]};
+              }
               // params.set<std::vector<VariableName>>("v") = {"Ar"};
               params.set<std::string>("reaction") = _reaction[i];
               params.set<Real>("threshold_energy") = energy_sign * _threshold_energy[i];
@@ -544,6 +552,8 @@ AddZapdosReactions::act()
               InputParameters params = _factory.getValidParams(reactant_kernel_name);
               params.set<NonlinearVariableName>("variable") = _species[j];
               params.set<Real>("coefficient") = _species_count[i][j];
+              // std::cout << getParam<std::vector<SubdomainName>>("block")[0] << ", " <<  _species_count[i][j] << std::endl;
+              // mooseError("TESTING");
               params.set<std::string>("reaction") = _reaction[i];
               if (find_other || find_aux)
               {

--- a/src/actions/AddZapdosReactions.C
+++ b/src/actions/AddZapdosReactions.C
@@ -182,7 +182,8 @@ AddZapdosReactions::act()
         params.set<std::vector<SubdomainName>>("block") =
             getParam<std::vector<SubdomainName>>("block");
         _problem->addMaterial("EEDFRateConstantTownsend",
-                              "reaction_" + std::to_string(i) + std::to_string(i),
+                              "reaction_" + std::to_string(i) + std::to_string(i) + "_" +
+                                  getParam<std::vector<SubdomainName>>("block")[0],
                               params);
       }
       else if (_rate_type[i] == "EEDF" && _coefficient_format == "rate")

--- a/src/base/CraneApp.C
+++ b/src/base/CraneApp.C
@@ -38,11 +38,13 @@ CraneApp::registerAll(Factory & f, ActionFactory & af, Syntax & s)
   s.registerActionSyntax("ChemicalReactionsBase", "ChemicalReactions/Network");
 
   // Zapdos network actions
-  s.registerActionSyntax("AddZapdosReactions", "ChemicalReactions/ZapdosNetwork");
-  s.registerActionSyntax("ChemicalReactionsBase", "ChemicalReactions/ZapdosNetwork");
+//  s.registerActionSyntax("AddZapdosReactions", "ChemicalReactions/ZapdosNetwork");
+//  s.registerActionSyntax("ChemicalReactionsBase", "ChemicalReactions/ZapdosNetwork");
 
   s.registerActionSyntax("AddScalarReactions", "GlobalReactions/*");
-  s.registerActionSyntax("AddZapdosReactions", "ZapdosReactions/*");
+  s.registerActionSyntax("AddZapdosReactions", "Reactions/*");
+
+  s.registerActionSyntax("AddZapdosReactions", "ChemicalReactions/ZapdosNetwork/*");
 }
 
 void

--- a/src/base/CraneApp.C
+++ b/src/base/CraneApp.C
@@ -40,6 +40,9 @@ CraneApp::registerAll(Factory & f, ActionFactory & af, Syntax & s)
   // Zapdos network actions
   s.registerActionSyntax("AddZapdosReactions", "ChemicalReactions/ZapdosNetwork");
   s.registerActionSyntax("ChemicalReactionsBase", "ChemicalReactions/ZapdosNetwork");
+
+  s.registerActionSyntax("AddScalarReactions", "GlobalReactions/*");
+  s.registerActionSyntax("AddZapdosReactions", "ZapdosReactions/*");
 }
 
 void

--- a/src/kernels/ProductFirstOrder.C
+++ b/src/kernels/ProductFirstOrder.C
@@ -10,7 +10,7 @@ InputParameters
 validParams<ProductFirstOrder>()
 {
   InputParameters params = validParams<Kernel>();
-  params.addCoupledVar("v", "The first variable that is reacting to create u.");
+  params.addRequiredCoupledVar("v", "The first variable that is reacting to create u.");
   params.addRequiredParam<std::string>("reaction", "The full reaction equation.");
   params.addRequiredParam<Real>("coefficient", "The stoichiometric coeffient.");
   params.addParam<bool>("_v_eq_u", false, "Whether or not v and u are the same variable.");
@@ -19,8 +19,8 @@ validParams<ProductFirstOrder>()
 
 ProductFirstOrder::ProductFirstOrder(const InputParameters & parameters)
   : Kernel(parameters),
-    _v(isCoupled("v") ? coupledValue("v") : _zero),
-    _v_id(isCoupled("v") ? coupled("v") : 0),
+    _v(coupledValue("v")),
+    _v_id(coupled("v")),
     _reaction_coeff(getMaterialProperty<Real>("k_" + getParam<std::string>("reaction"))),
     _stoichiometric_coeff(getParam<Real>("coefficient")),
     _v_eq_u(getParam<bool>("_v_eq_u"))
@@ -30,44 +30,23 @@ ProductFirstOrder::ProductFirstOrder(const InputParameters & parameters)
 Real
 ProductFirstOrder::computeQpResidual()
 {
-  if (isCoupled("v"))
-  {
-    return -_test[_i][_qp] * (_stoichiometric_coeff)*_reaction_coeff[_qp] * _v[_qp];
-  }
-  else
-  {
-    return -_test[_i][_qp] * (_stoichiometric_coeff)*_reaction_coeff[_qp] *
-           getMaterialProperty<Real>("n_gas")[_qp];
-  }
+  return -_test[_i][_qp] * (_stoichiometric_coeff)*_reaction_coeff[_qp] * _v[_qp];
 }
 
 Real
 ProductFirstOrder::computeQpJacobian()
 {
-  // return 0.0;
-  if (isCoupled("v"))
-  {
-    if (_v_eq_u)
-      return -_test[_i][_qp] * _stoichiometric_coeff * _reaction_coeff[_qp] * _phi[_j][_qp];
-    else
-      return 0.0;
-  }
+  if (_v_eq_u)
+    return -_test[_i][_qp] * _stoichiometric_coeff * _reaction_coeff[_qp] * _phi[_j][_qp];
   else
     return 0.0;
 }
 
 Real
-ProductFirstOrder::computeQpOffDiagJacobian(unsigned int)
+ProductFirstOrder::computeQpOffDiagJacobian(unsigned int jvar)
 {
-  if (isCoupled("v"))
-  {
-    if (!_v_eq_u)
-      return -_test[_i][_qp] * (_stoichiometric_coeff)*_reaction_coeff[_qp] * _phi[_j][_qp];
-    else
-      return 0.0;
-  }
+  if (!_v_eq_u && jvar == _v_id)
+    return -_test[_i][_qp] * _stoichiometric_coeff * _reaction_coeff[_qp] * _phi[_j][_qp];
   else
-  {
-    return 0;
-  }
+    return 0.0;
 }

--- a/src/kernels/ProductFirstOrderLog.C
+++ b/src/kernels/ProductFirstOrderLog.C
@@ -23,7 +23,7 @@ ProductFirstOrderLog::ProductFirstOrderLog(const InputParameters & parameters)
   : Kernel(parameters),
     _v(isCoupled("v") ? coupledValue("v") : _zero),
     _v_id(isCoupled("v") ? coupled("v") : 0),
-    _n_gas(getMaterialProperty<Real>("n_gas")),
+    // _n_gas(getMaterialProperty<Real>("n_gas")),
     _reaction_coeff(getMaterialProperty<Real>("k_" + getParam<std::string>("reaction"))),
     _stoichiometric_coeff(getParam<Real>("coefficient")),
     _v_eq_u(getParam<bool>("_v_eq_u"))
@@ -35,12 +35,12 @@ ProductFirstOrderLog::computeQpResidual()
 {
   Real mult1;
 
-  if (isCoupled("v"))
-    mult1 = std::exp(_v[_qp]);
-  else
-  {
-    mult1 = _n_gas[_qp];
-  }
+  // if (isCoupled("v"))
+  mult1 = std::exp(_v[_qp]);
+  // else
+  //{
+  //    mult1 = _n_gas[_qp];
+  //}
 
   return -_test[_i][_qp] * _stoichiometric_coeff * _reaction_coeff[_qp] * mult1;
 }
@@ -53,17 +53,16 @@ ProductFirstOrderLog::computeQpJacobian()
   eq_u_mult = 1.0;
   gas_mult = 1.0;
 
-  if (isCoupled("v"))
-    mult1 = std::exp(_v[_qp]);
-  else
-    mult1 = _n_gas[_qp];
+  // if (isCoupled("v"))
+  mult1 = std::exp(_v[_qp]);
+  // else
+  //  mult1 = _n_gas[_qp];
 
   if (_v_eq_u)
   {
     power += 1.0;
     eq_u_mult *= mult1;
   }
-
   gas_mult *= mult1;
 
   if (!_v_eq_u)
@@ -72,7 +71,8 @@ ProductFirstOrderLog::computeQpJacobian()
   }
   else
   {
-    return -_test[_i][_qp] * _stoichiometric_coeff * power * _reaction_coeff[_qp] * gas_mult * _phi[_j][_qp];
+    return -_test[_i][_qp] * _stoichiometric_coeff * power * _reaction_coeff[_qp] * gas_mult *
+           _phi[_j][_qp];
   }
 }
 
@@ -83,8 +83,8 @@ ProductFirstOrderLog::computeQpOffDiagJacobian(unsigned int jvar)
   if (isCoupled("v"))
   {
     if (jvar == _v_id)
-      return -_test[_i][_qp] * _stoichiometric_coeff * _reaction_coeff[_qp] *
-              std::exp(_v[_qp]) * _phi[_j][_qp];
+      return -_test[_i][_qp] * _stoichiometric_coeff * _reaction_coeff[_qp] * std::exp(_v[_qp]) *
+             _phi[_j][_qp];
     else
       return 0.0;
   }

--- a/src/kernels/ProductFirstOrderLog.C
+++ b/src/kernels/ProductFirstOrderLog.C
@@ -10,20 +10,17 @@ InputParameters
 validParams<ProductFirstOrderLog>()
 {
   InputParameters params = validParams<Kernel>();
-  params.addCoupledVar("v", "The first variable that is reacting to create u.");
-  params.addCoupledVar("w", "The second variable that is reacting to create u.");
+  params.addRequiredCoupledVar("v", "The first variable that is reacting to create u.");
   params.addRequiredParam<std::string>("reaction", "The full reaction equation.");
   params.addRequiredParam<Real>("coefficient", "The stoichiometric coeffient.");
   params.addParam<bool>("_v_eq_u", false, "If v == u.");
-  params.addParam<bool>("_w_eq_u", false, "If w == u.");
   return params;
 }
 
 ProductFirstOrderLog::ProductFirstOrderLog(const InputParameters & parameters)
   : Kernel(parameters),
-    _v(isCoupled("v") ? coupledValue("v") : _zero),
-    _v_id(isCoupled("v") ? coupled("v") : 0),
-    // _n_gas(getMaterialProperty<Real>("n_gas")),
+    _v(coupledValue("v")),
+    _v_id(coupled("v")),
     _reaction_coeff(getMaterialProperty<Real>("k_" + getParam<std::string>("reaction"))),
     _stoichiometric_coeff(getParam<Real>("coefficient")),
     _v_eq_u(getParam<bool>("_v_eq_u"))
@@ -33,37 +30,19 @@ ProductFirstOrderLog::ProductFirstOrderLog(const InputParameters & parameters)
 Real
 ProductFirstOrderLog::computeQpResidual()
 {
-  Real mult1;
-
-  // if (isCoupled("v"))
-  mult1 = std::exp(_v[_qp]);
-  // else
-  //{
-  //    mult1 = _n_gas[_qp];
-  //}
-
-  return -_test[_i][_qp] * _stoichiometric_coeff * _reaction_coeff[_qp] * mult1;
+  return -_test[_i][_qp] * _stoichiometric_coeff * _reaction_coeff[_qp] * std::exp(_v[_qp]);
 }
 
 Real
 ProductFirstOrderLog::computeQpJacobian()
 {
-  Real mult1, power, eq_u_mult, gas_mult;
+  Real power;
   power = 0.0;
-  eq_u_mult = 1.0;
-  gas_mult = 1.0;
-
-  // if (isCoupled("v"))
-  mult1 = std::exp(_v[_qp]);
-  // else
-  //  mult1 = _n_gas[_qp];
 
   if (_v_eq_u)
   {
     power += 1.0;
-    eq_u_mult *= mult1;
   }
-  gas_mult *= mult1;
 
   if (!_v_eq_u)
   {
@@ -71,22 +50,18 @@ ProductFirstOrderLog::computeQpJacobian()
   }
   else
   {
-    return -_test[_i][_qp] * _stoichiometric_coeff * power * _reaction_coeff[_qp] * gas_mult *
-           _phi[_j][_qp];
+    return -_test[_i][_qp] * _stoichiometric_coeff * power * _reaction_coeff[_qp] *
+           std::exp(_v[_qp]) * _phi[_j][_qp];
   }
 }
 
 Real
 ProductFirstOrderLog::computeQpOffDiagJacobian(unsigned int jvar)
 {
-
-  if (isCoupled("v"))
+  if (!_v_eq_u && jvar == _v_id)
   {
-    if (jvar == _v_id)
-      return -_test[_i][_qp] * _stoichiometric_coeff * _reaction_coeff[_qp] * std::exp(_v[_qp]) *
-             _phi[_j][_qp];
-    else
-      return 0.0;
+    return -_test[_i][_qp] * _stoichiometric_coeff * _reaction_coeff[_qp] * std::exp(_v[_qp]) *
+           _phi[_j][_qp];
   }
   else
   {

--- a/src/kernels/ProductSecondOrder.C
+++ b/src/kernels/ProductSecondOrder.C
@@ -10,8 +10,8 @@ InputParameters
 validParams<ProductSecondOrder>()
 {
   InputParameters params = validParams<Kernel>();
-  params.addCoupledVar("v", "The first variable that is reacting to create u.");
-  params.addCoupledVar("w", "The second variable that is reacting to create u.");
+  params.addRequiredCoupledVar("v", "The first variable that is reacting to create u.");
+  params.addRequiredCoupledVar("w", "The second variable that is reacting to create u.");
   params.addRequiredParam<std::string>("reaction", "The full reaction equation.");
   params.addRequiredParam<Real>("coefficient", "The stoichiometric coeffient.");
   params.addParam<bool>("_v_eq_u", false, "Whether or not v and u are the same variable.");
@@ -21,11 +21,10 @@ validParams<ProductSecondOrder>()
 
 ProductSecondOrder::ProductSecondOrder(const InputParameters & parameters)
   : Kernel(parameters),
-    _v(isCoupled("v") ? coupledValue("v") : _zero),
-    _w(isCoupled("w") ? coupledValue("w") : _zero),
-    _v_id(isCoupled("v") ? coupled("v") : 0),
-    _w_id(isCoupled("w") ? coupled("w") : 0),
-    _n_gas(getMaterialProperty<Real>("n_gas")),
+    _v(coupledValue("v")),
+    _w(coupledValue("w")),
+    _v_id(coupled("v")),
+    _w_id(coupled("w")),
     _reaction_coeff(getMaterialProperty<Real>("k_" + getParam<std::string>("reaction"))),
     _stoichiometric_coeff(getParam<Real>("coefficient")),
     _v_eq_u(getParam<bool>("_v_eq_u")),
@@ -36,57 +35,50 @@ ProductSecondOrder::ProductSecondOrder(const InputParameters & parameters)
 Real
 ProductSecondOrder::computeQpResidual()
 {
-  Real mult1, mult2;
-
-  if (isCoupled("v"))
-    mult1 = _v[_qp];
-  else
-  {
-    mult1 = _n_gas[_qp];
-  }
-
-  if (isCoupled("w"))
-    mult2 = _w[_qp];
-  else
-  {
-    mult2 = _n_gas[_qp];
-  }
-  return -_test[_i][_qp] * _stoichiometric_coeff * _reaction_coeff[_qp] *  mult1 * mult2;
+  return -_test[_i][_qp] * _stoichiometric_coeff * _reaction_coeff[_qp] * _v[_qp] * _w[_qp];
 }
 
 Real
 ProductSecondOrder::computeQpJacobian()
 {
-  Real mult1, mult2, power, eq_u_mult, gas_mult;
+  if (_v_eq_u && _w_eq_u)
+  {
+    return -_test[_i][_qp] * _stoichiometric_coeff * _reaction_coeff[_qp] * 2.0 * _v[_qp] *
+           _phi[_j][_qp];
+  }
+  else if (_v_eq_u && !_w_eq_u)
+  {
+    return -_test[_i][_qp] * _stoichiometric_coeff * _reaction_coeff[_qp] * _w[_qp] * _phi[_j][_qp];
+  }
+  else if (!_v_eq_u && _w_eq_u)
+  {
+    return -_test[_i][_qp] * _stoichiometric_coeff * _reaction_coeff[_qp] * _v[_qp] * _phi[_j][_qp];
+  }
+  else
+  {
+    return 0.0;
+  }
+  /*
+  Real power, eq_u_mult, gas_mult;
   power = 0.0;
   eq_u_mult = 1.0;
   gas_mult = 1.0;
 
-  if (isCoupled("v"))
-    mult1 = _v[_qp];
-  else
-    mult1 = _n_gas[_qp];
-
-  if (isCoupled("w"))
-    mult2 = _w[_qp];
-  else
-    mult2 = _n_gas[_qp];
-
-  if (isCoupled("v") && _v_eq_u)
+  if (_v_eq_u)
   {
     power += 1.0;
-    eq_u_mult *= mult1;
+    eq_u_mult *= _v[_qp];
   }
   else
-    gas_mult *= mult1;
+    gas_mult *= _v[_qp];
 
-  if (isCoupled("w") && _w_eq_u)
+  if (_w_eq_u)
   {
     power += 1.0;
-    eq_u_mult *= mult2;
+    eq_u_mult *= _w[_qp];
   }
   else
-    gas_mult *= mult2;
+    gas_mult *= _w[_qp];
 
   if (!_v_eq_u && !_w_eq_u)
   {
@@ -94,40 +86,90 @@ ProductSecondOrder::computeQpJacobian()
   }
   else
   {
-    return -_test[_i][_qp] * _stoichiometric_coeff * power * _reaction_coeff[_qp] *  std::pow(eq_u_mult, power-1) * gas_mult * _phi[_j][_qp];
+    return -_test[_i][_qp] * _stoichiometric_coeff * power * _reaction_coeff[_qp] *
+           std::pow(eq_u_mult, power - 1) * gas_mult * _phi[_j][_qp];
   }
+  */
 }
 
 Real
 ProductSecondOrder::computeQpOffDiagJacobian(unsigned int jvar)
 {
-  Real mult1, mult2;
-
-  if (isCoupled("v"))
-    mult1 = _v[_qp];
+  if (_v_eq_u && !_w_eq_u)
+  {
+    if (jvar == _w_id)
+      return -_test[_i][_qp] * _stoichiometric_coeff * _reaction_coeff[_qp] * _v[_qp] *
+             _phi[_j][_qp];
+    else
+      return 0.0;
+  }
+  else if (!_v_eq_u && _w_eq_u)
+  {
+    if (jvar == _w_id)
+      return -_test[_i][_qp] * _stoichiometric_coeff * _reaction_coeff[_qp] * _w[_qp] *
+             _phi[_j][_qp];
+    else
+      return 0.0;
+  }
+  else if (!_v_eq_u && !_w_eq_u)
+  {
+    if (jvar == _v_id && jvar == _w_id)
+      return -_test[_i][_qp] * _stoichiometric_coeff * _reaction_coeff[_qp] * 2.0 * _v[_qp] *
+             _phi[_j][_qp];
+    else if (jvar == _v_id && jvar != _w_id)
+      return -_test[_i][_qp] * _stoichiometric_coeff * _reaction_coeff[_qp] * _w[_qp] *
+             _phi[_j][_qp];
+    else if (jvar != _v_id && jvar == _w_id)
+      return -_test[_i][_qp] * _stoichiometric_coeff * _reaction_coeff[_qp] * _v[_qp] *
+             _phi[_j][_qp];
+    else
+      return 0.0;
+  }
   else
-    mult1 = _n_gas[_qp];
+    return 0.0;
+  /*
+  Real eq_u_mult, j_mult, power;
+  eq_u_mult = 1.0;
+  j_mult = 1.0;
+  power = 0.0;
 
-  if (isCoupled("w"))
-    mult2 = _w[_qp];
-  else
-    mult2 = _n_gas[_qp];
+  if (_v_eq_u)
+  {
+    eq_u_mult *= _v[_qp];
+  }
+  else if (jvar == _v_id)
+  {
+    power += 1.0;
+    j_mult *= _v[_qp];
+  }
 
-  if ((_v_eq_u && !isCoupled("w")) || (_w_eq_u && !isCoupled("v")) || (!isCoupled("v") && !isCoupled("w")) || (_v_eq_u && _w_eq_u))
+  if (_w_eq_u)
+  {
+    eq_u_mult *= _w[_qp];
+  }
+  else if (jvar == _w_id)
+  {
+    power += 1.0;
+    j_mult *= _w[_qp];
+  }
+
+  return -_test[_i][_qp] * _stoichiometric_coeff * _reaction_coeff[_qp] * std::pow(j_mult, power) *
+         eq_u_mult * _phi[_j][_qp];
+
+  */
+
+  /*if (_v_eq_u && _w_eq_u)
   {
     return 0.0;
   }
-  else if ((isCoupled("v") && !_v_eq_u) && !isCoupled("w"))
+  else if (!_v_eq_u && jvar == _v_id)
   {
-    if (jvar == _v_id)
-      return -_test[_i][_qp] * _stoichiometric_coeff * _reaction_coeff[_qp] *  mult2 * _phi[_j][_qp];
-    else
-      return 0.0;
+    return -_test[_i][_qp] * _stoichiometric_coeff * _reaction_coeff[_qp] * *_phi[_j][_qp];
   }
   else if ((isCoupled("w") && !_w_eq_u) && !isCoupled("v"))
   {
     if (jvar == _w_id)
-      return -_test[_i][_qp] * _stoichiometric_coeff * _reaction_coeff[_qp] *  mult1 * _phi[_j][_qp];
+      return -_test[_i][_qp] * _stoichiometric_coeff * _reaction_coeff[_qp] * mult1 * _phi[_j][_qp];
     else
       return 0.0;
   }
@@ -138,16 +180,19 @@ ProductSecondOrder::computeQpOffDiagJacobian(unsigned int jvar)
       if (_v_id != _w_id)
       {
         if (jvar == _v_id)
-          return -_test[_i][_qp] * _stoichiometric_coeff * _reaction_coeff[_qp] *  mult2 * _phi[_j][_qp];
+          return -_test[_i][_qp] * _stoichiometric_coeff * _reaction_coeff[_qp] * mult2 *
+                 _phi[_j][_qp];
         else if (jvar == _w_id)
-          return -_test[_i][_qp] * _stoichiometric_coeff * _reaction_coeff[_qp] *  mult1 * _phi[_j][_qp];
+          return -_test[_i][_qp] * _stoichiometric_coeff * _reaction_coeff[_qp] * mult1 *
+                 _phi[_j][_qp];
         else
           return 0.0;
       }
       else
       {
         if (jvar == _v_id)
-          return -_test[_i][_qp] * _stoichiometric_coeff * _reaction_coeff[_qp] * 2.0 * mult1 * _phi[_j][_qp];
+          return -_test[_i][_qp] * _stoichiometric_coeff * _reaction_coeff[_qp] * 2.0 * mult1 *
+                 _phi[_j][_qp];
         else
           return 0.0;
       }
@@ -155,25 +200,27 @@ ProductSecondOrder::computeQpOffDiagJacobian(unsigned int jvar)
     else if (_v_eq_u && !_w_eq_u)
     {
       if (jvar == _w_id)
-        return -_test[_i][_qp] * _stoichiometric_coeff * _reaction_coeff[_qp] *  mult1 * _phi[_j][_qp];
+        return -_test[_i][_qp] * _stoichiometric_coeff * _reaction_coeff[_qp] * mult1 *
+               _phi[_j][_qp];
       else
         return 0.0;
     }
     else if (!_v_eq_u && _w_eq_u)
     {
       if (jvar == _v_id)
-        return -_test[_i][_qp] * _stoichiometric_coeff * _reaction_coeff[_qp] *  mult2 * _phi[_j][_qp];
+        return -_test[_i][_qp] * _stoichiometric_coeff * _reaction_coeff[_qp] * mult2 *
+               _phi[_j][_qp];
       else
         return 0.0;
     }
     else
       return 0.0;
-
   }
   else
   {
-    // std::cout << getParam<std::string>("reaction") << ": " << _v_eq_u << ", " << _w_eq_u << std::endl;
-    mooseError("ProductSecondOrder, computeQpOffDiagJacobian: this is not yet implemented for the current case.");
-  }
-
+    // std::cout << getParam<std::string>("reaction") << ": " << _v_eq_u << ", " << _w_eq_u <<
+    // std::endl;
+    mooseError("ProductSecondOrder, computeQpOffDiagJacobian: this is not yet implemented for the "
+               "current case.");
+  }*/
 }

--- a/src/kernels/ProductSecondOrderLog.C
+++ b/src/kernels/ProductSecondOrderLog.C
@@ -10,8 +10,8 @@ InputParameters
 validParams<ProductSecondOrderLog>()
 {
   InputParameters params = validParams<Kernel>();
-  params.addCoupledVar("v", "The first variable that is reacting to create u.");
-  params.addCoupledVar("w", "The second variable that is reacting to create u.");
+  params.addRequiredCoupledVar("v", "The first variable that is reacting to create u.");
+  params.addRequiredCoupledVar("w", "The second variable that is reacting to create u.");
   params.addRequiredParam<std::string>("reaction", "The full reaction equation.");
   params.addRequiredParam<Real>("coefficient", "The stoichiometric coeffient.");
   params.addParam<bool>("_v_eq_u", false, "If v == u.");
@@ -21,70 +21,35 @@ validParams<ProductSecondOrderLog>()
 
 ProductSecondOrderLog::ProductSecondOrderLog(const InputParameters & parameters)
   : Kernel(parameters),
-    _v(isCoupled("v") ? coupledValue("v") : _zero),
-    _w(isCoupled("w") ? coupledValue("w") : _zero),
-    _v_id(isCoupled("v") ? coupled("v") : 0),
-    _w_id(isCoupled("w") ? coupled("w") : 0),
-    // _n_gas(getMaterialProperty<Real>("n_gas")),
+    _v(coupledValue("v")),
+    _w(coupledValue("w")),
+    _v_id(coupled("v")),
+    _w_id(coupled("w")),
     _reaction_coeff(getMaterialProperty<Real>("k_" + getParam<std::string>("reaction"))),
     _stoichiometric_coeff(getParam<Real>("coefficient")),
     _v_eq_u(getParam<bool>("_v_eq_u")),
-    _w_eq_u(getParam<bool>("_w_eq_u")),
-    _v_coupled(isCoupled("v") ? true : false),
-    _w_coupled(isCoupled("w") ? true : false)
+    _w_eq_u(getParam<bool>("_w_eq_u"))
 {
-  if (!isCoupled("v") || !isCoupled("w"))
-  {
-    mooseError("Missing coupled variable(s) in reaction {" + getParam<std::string>("reaction") +
-               "}! \nMake sure all reactants are either nonlinear or auxiliary variables.");
-  }
 }
 
 Real
 ProductSecondOrderLog::computeQpResidual()
 {
-  Real mult1, mult2;
-  // if (_v_coupled)
-  mult1 = std::exp(_v[_qp]);
-  // else
-  //{
-  //  mult1 = _n_gas[_qp];
-  //}
-
-  // if (_w_coupled)
-  mult2 = std::exp(_w[_qp]);
-  // else
-  //{
-  //  mult2 = _n_gas[_qp];
-  //}
-
-  return -_test[_i][_qp] * _stoichiometric_coeff * _reaction_coeff[_qp] * mult1 * mult2;
+  return -_test[_i][_qp] * _stoichiometric_coeff * _reaction_coeff[_qp] * std::exp(_v[_qp]) *
+         std::exp(_w[_qp]);
 }
 
 Real
 ProductSecondOrderLog::computeQpJacobian()
 {
-  Real mult1, mult2, power, gas_mult;
+  Real power;
   power = 0.0;
-  gas_mult = 1.0;
 
-  // if (_v_coupled)
-  mult1 = std::exp(_v[_qp]);
-  // else
-  //  mult1 = _n_gas[_qp];
-
-  // if (_w_coupled)
-  mult2 = std::exp(_w[_qp]);
-  // else
-  //  mult2 = _n_gas[_qp];
-
-  if (_v_coupled && _v_eq_u)
+  if (_v_eq_u)
     power += 1.0;
 
-  if (_w_coupled && _w_eq_u)
+  if (_w_eq_u)
     power += 1.0;
-
-  gas_mult *= mult1 * mult2;
 
   if (!_v_eq_u && !_w_eq_u)
   {
@@ -92,37 +57,23 @@ ProductSecondOrderLog::computeQpJacobian()
   }
   else
   {
-    return -_test[_i][_qp] * _stoichiometric_coeff * power * _reaction_coeff[_qp] * gas_mult *
-           _phi[_j][_qp];
+    return -_test[_i][_qp] * _stoichiometric_coeff * power * _reaction_coeff[_qp] *
+           std::exp(_v[_qp]) * std::exp(_w[_qp]) * _phi[_j][_qp];
   }
 }
 
 Real
 ProductSecondOrderLog::computeQpOffDiagJacobian(unsigned int jvar)
 {
-  Real power, mult1, mult2;
-  Real gas_mult;
-  // Real rate_constant;
+  Real power;
   power = 0;
-  gas_mult = 1;
-  // if (_v_coupled)
-  mult1 = std::exp(_v[_qp]);
-  // else
-  //  mult1 = _n_gas[_qp];
 
-  // if (_w_coupled)
-  mult2 = std::exp(_w[_qp]);
-  // else
-  //  mult2 = _n_gas[_qp];
-
-  if (_v_coupled && !_v_eq_u && jvar == _v_id)
+  if (!_v_eq_u && jvar == _v_id)
     power += 1;
 
-  if (_w_coupled && !_w_eq_u && jvar == _w_id)
+  if (!_w_eq_u && jvar == _w_id)
     power += 1;
 
-  gas_mult = mult1 * mult2;
-
-  return -_test[_i][_qp] * _stoichiometric_coeff * _reaction_coeff[_qp] * gas_mult * power *
-         _phi[_j][_qp];
+  return -_test[_i][_qp] * _stoichiometric_coeff * _reaction_coeff[_qp] * std::exp(_v[_qp]) *
+         std::exp(_w[_qp]) * power * _phi[_j][_qp];
 }

--- a/src/kernels/ProductSecondOrderLog.C
+++ b/src/kernels/ProductSecondOrderLog.C
@@ -25,7 +25,7 @@ ProductSecondOrderLog::ProductSecondOrderLog(const InputParameters & parameters)
     _w(isCoupled("w") ? coupledValue("w") : _zero),
     _v_id(isCoupled("v") ? coupled("v") : 0),
     _w_id(isCoupled("w") ? coupled("w") : 0),
-    _n_gas(getMaterialProperty<Real>("n_gas")),
+    // _n_gas(getMaterialProperty<Real>("n_gas")),
     _reaction_coeff(getMaterialProperty<Real>("k_" + getParam<std::string>("reaction"))),
     _stoichiometric_coeff(getParam<Real>("coefficient")),
     _v_eq_u(getParam<bool>("_v_eq_u")),
@@ -35,7 +35,8 @@ ProductSecondOrderLog::ProductSecondOrderLog(const InputParameters & parameters)
 {
   if (!isCoupled("v") || !isCoupled("w"))
   {
-    mooseError("Missing coupled variable(s) in reaction {"+getParam<std::string>("reaction")+"}! \nMake sure all reactants are either nonlinear or auxiliary variables.");
+    mooseError("Missing coupled variable(s) in reaction {" + getParam<std::string>("reaction") +
+               "}! \nMake sure all reactants are either nonlinear or auxiliary variables.");
   }
 }
 
@@ -43,19 +44,19 @@ Real
 ProductSecondOrderLog::computeQpResidual()
 {
   Real mult1, mult2;
-  if (_v_coupled)
-    mult1 = std::exp(_v[_qp]);
-  else
-  {
-    mult1 = _n_gas[_qp];
-  }
+  // if (_v_coupled)
+  mult1 = std::exp(_v[_qp]);
+  // else
+  //{
+  //  mult1 = _n_gas[_qp];
+  //}
 
-  if (_w_coupled)
-    mult2 = std::exp(_w[_qp]);
-  else
-  {
-    mult2 = _n_gas[_qp];
-  }
+  // if (_w_coupled)
+  mult2 = std::exp(_w[_qp]);
+  // else
+  //{
+  //  mult2 = _n_gas[_qp];
+  //}
 
   return -_test[_i][_qp] * _stoichiometric_coeff * _reaction_coeff[_qp] * mult1 * mult2;
 }
@@ -67,15 +68,15 @@ ProductSecondOrderLog::computeQpJacobian()
   power = 0.0;
   gas_mult = 1.0;
 
-  if (_v_coupled)
-    mult1 = std::exp(_v[_qp]);
-  else
-    mult1 = _n_gas[_qp];
+  // if (_v_coupled)
+  mult1 = std::exp(_v[_qp]);
+  // else
+  //  mult1 = _n_gas[_qp];
 
-  if (_w_coupled)
-    mult2 = std::exp(_w[_qp]);
-  else
-    mult2 = _n_gas[_qp];
+  // if (_w_coupled)
+  mult2 = std::exp(_w[_qp]);
+  // else
+  //  mult2 = _n_gas[_qp];
 
   if (_v_coupled && _v_eq_u)
     power += 1.0;
@@ -91,7 +92,8 @@ ProductSecondOrderLog::computeQpJacobian()
   }
   else
   {
-    return -_test[_i][_qp] * _stoichiometric_coeff * power * _reaction_coeff[_qp] * gas_mult * _phi[_j][_qp];
+    return -_test[_i][_qp] * _stoichiometric_coeff * power * _reaction_coeff[_qp] * gas_mult *
+           _phi[_j][_qp];
   }
 }
 
@@ -103,23 +105,24 @@ ProductSecondOrderLog::computeQpOffDiagJacobian(unsigned int jvar)
   // Real rate_constant;
   power = 0;
   gas_mult = 1;
-  if (_v_coupled)
-    mult1 = std::exp(_v[_qp]);
-  else
-    mult1 = _n_gas[_qp];
+  // if (_v_coupled)
+  mult1 = std::exp(_v[_qp]);
+  // else
+  //  mult1 = _n_gas[_qp];
 
-  if (_w_coupled)
-    mult2 = std::exp(_w[_qp]);
-  else
-    mult2 = _n_gas[_qp];
+  // if (_w_coupled)
+  mult2 = std::exp(_w[_qp]);
+  // else
+  //  mult2 = _n_gas[_qp];
 
-  if (_v_coupled && !_v_eq_u && jvar==_v_id)
+  if (_v_coupled && !_v_eq_u && jvar == _v_id)
     power += 1;
 
-  if (_w_coupled && !_w_eq_u && jvar==_w_id)
+  if (_w_coupled && !_w_eq_u && jvar == _w_id)
     power += 1;
 
   gas_mult = mult1 * mult2;
 
-  return -_test[_i][_qp] * _stoichiometric_coeff * _reaction_coeff[_qp] * gas_mult * power * _phi[_j][_qp];
+  return -_test[_i][_qp] * _stoichiometric_coeff * _reaction_coeff[_qp] * gas_mult * power *
+         _phi[_j][_qp];
 }

--- a/src/kernels/ProductSecondOrderLog.C
+++ b/src/kernels/ProductSecondOrderLog.C
@@ -33,6 +33,10 @@ ProductSecondOrderLog::ProductSecondOrderLog(const InputParameters & parameters)
     _v_coupled(isCoupled("v") ? true : false),
     _w_coupled(isCoupled("w") ? true : false)
 {
+  if (!isCoupled("v") || !isCoupled("w"))
+  {
+    mooseError("Missing coupled variable(s) in reaction {"+getParam<std::string>("reaction")+"}! \nMake sure all reactants are either nonlinear or auxiliary variables.");
+  }
 }
 
 Real
@@ -118,57 +122,4 @@ ProductSecondOrderLog::computeQpOffDiagJacobian(unsigned int jvar)
   gas_mult = mult1 * mult2;
 
   return -_test[_i][_qp] * _stoichiometric_coeff * _reaction_coeff[_qp] * gas_mult * power * _phi[_j][_qp];
-
-
-  // if (_v_coupled && _w_coupled)
-  // {
-  //   if (_v_id != _w_id)
-  //   {
-  //     if (jvar == _v_id)
-  //     {
-  //       return -_test[_i][_qp] * _stoichiometric_coeff * _reaction_coeff[_qp] *
-  //               std::exp(_w[_qp]) * std::exp(_v[_qp]) * _phi[_j][_qp];
-  //     }
-  //     else if (jvar == _w_id)
-  //     {
-  //       return -_test[_i][_qp] * _stoichiometric_coeff * _reaction_coeff[_qp] *
-  //               std::exp(_v[_qp]) * std::exp(_w[_qp]) * _phi[_j][_qp];
-  //     }
-  //     else
-  //       return 0.0;
-  //   }
-  //   else
-  //   {
-  //     if (jvar == _v_id)
-  //     {
-  //       return -_test[_i][_qp] * 2.0 * _stoichiometric_coeff * _reaction_coeff[_qp] *
-  //               std::exp(_v[_qp]) * std::exp(_w[_qp]) * _phi[_j][_qp];
-  //       // return -_test[_i][_qp] * _stoichiometric_coeff * _reaction_coeff[_qp] * 2.0 * _phi[_j][_qp] * (std::exp(_v[_qp]) + std::exp(_w[_qp]));
-  //     }
-  //     else
-  //     {
-  //       return 0.0;
-  //     }
-  //   }
-  // }
-  // else if (isCoupled("v") && !isCoupled("w"))
-  // {
-  //   if (jvar == _v_id)
-  //     return -_test[_i][_qp] * _stoichiometric_coeff * _reaction_coeff[_qp] *
-  //             _n_gas[_qp] * std::exp(_v[_qp]) * _phi[_j][_qp];
-  //   else
-  //     return 0.0;
-  // }
-  // else if (!isCoupled("v") && isCoupled("w"))
-  // {
-  //   if (jvar == _w_id)
-  //     return -_test[_i][_qp] * _stoichiometric_coeff * _reaction_coeff[_qp] *
-  //           _n_gas[_qp] * std::exp(_w[_qp]) * _phi[_j][_qp];
-  //   else
-  //     return 0.0;
-  // }
-  // else
-  // {
-  //   return 0.0;
-  // }
 }

--- a/src/kernels/ProductThirdOrder.C
+++ b/src/kernels/ProductThirdOrder.C
@@ -10,9 +10,9 @@ InputParameters
 validParams<ProductThirdOrder>()
 {
   InputParameters params = validParams<Kernel>();
-  params.addCoupledVar("v", "The first variable that is reacting.");
-  params.addCoupledVar("w", "The second variable that is reacting.");
-  params.addCoupledVar("x", "The third variable that is reacting.");
+  params.addRequiredCoupledVar("v", "The first variable that is reacting.");
+  params.addRequiredCoupledVar("w", "The second variable that is reacting.");
+  params.addRequiredCoupledVar("x", "The third variable that is reacting.");
   params.addRequiredParam<std::string>("reaction", "The full reaction equation.");
   params.addRequiredParam<Real>("coefficient", "The stoichiometric coeffient.");
   params.addParam<bool>("_v_eq_u", false, "Whether or not v and u are the same variable.");
@@ -23,13 +23,12 @@ validParams<ProductThirdOrder>()
 
 ProductThirdOrder::ProductThirdOrder(const InputParameters & parameters)
   : Kernel(parameters),
-    _v(isCoupled("v") ? coupledValue("v") : _zero),
-    _w(isCoupled("w") ? coupledValue("w") : _zero),
-    _x(isCoupled("x") ? coupledValue("x") : _zero),
-    _v_id(coupled("v") ? coupled("w") : 0),
-    _w_id(isCoupled("w") ? coupled("w") : 0),
-    _x_id(isCoupled("x") ? coupled("x") : 0),
-    _n_gas(getMaterialProperty<Real>("n_gas")),
+    _v(coupledValue("v")),
+    _w(coupledValue("w")),
+    _x(coupledValue("x")),
+    _v_id(coupled("v")),
+    _w_id(coupled("w")),
+    _x_id(coupled("x")),
     _reaction_coeff(getMaterialProperty<Real>("k_" + getParam<std::string>("reaction"))),
     _stoichiometric_coeff(getParam<Real>("coefficient")),
     _v_eq_u(getParam<bool>("_v_eq_u")),
@@ -41,71 +40,37 @@ ProductThirdOrder::ProductThirdOrder(const InputParameters & parameters)
 Real
 ProductThirdOrder::computeQpResidual()
 {
-  // Here we see if the variables are coupled or not
-  // If not, the values default to _n_gas.
-  // (This will need to be changed eventually.)
-  Real mult_1, mult_2, mult_3;
-
-  if (isCoupled("v"))
-    mult_1 = _v[_qp];
-  else
-    mult_1 = _n_gas[_qp];
-
-  if (isCoupled("w"))
-    mult_2 = _w[_qp];
-  else
-    mult_2 = _n_gas[_qp];
-
-  if (isCoupled("x"))
-    mult_3 = _x[_qp];
-  else
-    mult_3 = _n_gas[_qp];
-
-  return -_test[_i][_qp] * _stoichiometric_coeff * _reaction_coeff[_qp] * mult_1 * mult_2 * mult_3;
-  // if (isCoupled("v") && isCoupled("w") && isCoupled("x"))
-  // {
-  //   return -_test[_i][_qp] * _stoichiometric_coeff * _reaction_coeff[_qp] * _v[_qp] * _w[_qp] * _x[_qp];
-  // }
-  // else if (isCoupled("v") && !isCoupled("w") && isCoupled("x"))
-  // {
-  //   return -_test[_i][_qp] * _stoichiometric_coeff * _reaction_coeff[_qp] * _v[_qp] * _n_gas[_qp] * _x[_qp];
-  // }
-  // else if (!isCoupled("v") && isCoupled("w") && isCoupled("x"))
-  // {
-  //   return -_test[_i][_qp] * _stoichiometric_coeff * _reaction_coeff[_qp] * _w[_qp] * _n_gas[_qp] * _x[_qp];
-  // }
-  // else if (isCoupled("v") && !isCoupled("w") && !isCoupled("x"))
-  // {
-  //
-  // }
-  // else
-  // {
-  //   return -_test[_i][_qp] * _stoichiometric_coeff * _reaction_coeff[_qp] * _n_gas[_qp] * _n_gas[_qp] * _x[_qp];
-  // }
+  return -_test[_i][_qp] * _stoichiometric_coeff * _reaction_coeff[_qp] * _v[_qp] * _w[_qp] *
+         _x[_qp];
 }
 
 Real
 ProductThirdOrder::computeQpJacobian()
 {
+  Real aval;
+  aval = -_test[_i][_qp] * _stoichiometric_coeff * _reaction_coeff[_qp] * _phi[_j][_qp];
+
+  if (_v_eq_u && _w_eq_u && _x_eq_u)
+    return aval * 3.0 * _u[_qp] * _u[_qp];
+  else if (_v_eq_u && !_w_eq_u && !_x_eq_u)
+    return aval * _w[_qp] * _x[_qp];
+  else if (_v_eq_u && _w_eq_u && !_x_eq_u)
+    return aval * 2.0 * _u[_qp] * _x[_qp];
+  else if (_v_eq_u && !_w_eq_u && _x_eq_u)
+    return aval * 2.0 * _u[_qp] * _w[_qp];
+  else if (!_v_eq_u && _w_eq_u && _x_eq_u)
+    return aval * 2.0 * _u[_qp] * _v[_qp];
+  else if (!_v_eq_u && _w_eq_u && !_x_eq_u)
+    return aval * _u[_qp] * _v[_qp] * _x[_qp];
+  else if (!_v_eq_u && !_w_eq_u && _x_eq_u)
+    return aval * _u[_qp] * _v[_qp] * _w[_qp];
+  else
+    return 0.0;
+  /*
   Real mult_1, mult_2, mult_3, power, eq_u_mult, gas_mult;
   power = 0.0;
   eq_u_mult = 1.0;
   gas_mult = 1.0;
-
-  if (isCoupled("v"))
-    mult_1 = _v[_qp];
-  else
-    mult_1 = _n_gas[_qp];
-
-  if (isCoupled("w"))
-    mult_2 = _w[_qp];
-  else
-    mult_2 = _n_gas[_qp];
-
-  if (isCoupled("x"))
-    mult_3 = _x[_qp];
-  else
-    mult_3 = _n_gas[_qp];
 
   if (_v_eq_u)
   {
@@ -135,16 +100,95 @@ ProductThirdOrder::computeQpJacobian()
     return 0.0;
   else
   {
-    return -_test[_i][_qp] * _stoichiometric_coeff * power * std::pow(eq_u_mult, power-1) * gas_mult * _phi[_j][_qp];
+    return -_test[_i][_qp] * _stoichiometric_coeff * power * std::pow(eq_u_mult, power-1) * gas_mult
+  * _phi[_j][_qp];
   }
-  // return 0.0;
-  // if (_v_eq_u && _w_eq_u && _x_eq_u)
-    // return -_test[_i][_qp] * _stoichiometric_coeff * _reaction_coeff[_qp] *
+  */
 }
 
 Real
 ProductThirdOrder::computeQpOffDiagJacobian(unsigned int jvar)
 {
+  Real aval;
+  aval = -_test[_i][_qp] * _stoichiometric_coeff * _reaction_coeff[_qp] * _phi[_j][_qp];
+
+  if (!_v_eq_u && !_w_eq_u && !_x_eq_u)
+  {
+    if (jvar == _v_id && jvar == _w_id && jvar == _x_id)
+      return aval * 3.0 * _v[_qp] * _v[_qp]; // This means that v, w, and x are the same variable.
+    else if (jvar == _v_id && jvar != _w_id && jvar != _x_id)
+      return aval * _w[_qp] * _x[_qp];
+    else if (jvar == _v_id && jvar != _w_id && jvar == _x_id) // v and x are the same
+      return aval * 2.0 * _v[_qp] * _w[_qp];
+    else if (jvar == _v_id && jvar == _w_id && jvar != _x_id)
+      return aval * 2.0 * _v[_qp] * _x[_qp];
+    else if (jvar != _v_id && jvar == _w_id && jvar == _x_id)
+      return aval * _v[_qp] * 2.0 * _w[_qp];
+    else if (jvar != _v_id && jvar != _w_id && jvar == _x_id)
+      return aval * _v[_qp] * _w[_qp];
+    else if (jvar != _v_id && jvar == _w_id && jvar != _x_id)
+      return aval * _v[_qp] * _x[_qp];
+    else
+      return 0.0;
+  }
+  else if (!_v_eq_u && _w_eq_u && _x_eq_u)
+  {
+    if (jvar == _v_id)
+      return aval * _w[_qp] * _x[_qp];
+    else
+      return 0.0;
+  }
+  else if (!_v_eq_u && _w_eq_u && !_x_eq_u)
+  {
+    if (jvar == _v_id && jvar == _x_id)
+      return aval * 2.0 * _v[_qp] * _w[_qp];
+    else if (jvar == _v_id && jvar != _x_id)
+      return aval * _x[_qp] * _w[_qp];
+    else if (jvar != _v_id && jvar == _x_id)
+      return aval * _v[_qp] * _w[_qp];
+    else
+      return 0.0;
+  }
+  else if (!_v_eq_u && !_w_eq_u && _x_eq_u)
+  {
+    if (jvar == _v_id && jvar == _w_id)
+      return aval * 2.0 * _v[_qp] * _x[_qp];
+    else if (jvar == _v_id && jvar != _w_id)
+      return aval * _w[_qp] * _x[_qp];
+    else if (jvar != _v_id && jvar == _w_id)
+      return aval * _v[_qp] * _x[_qp];
+    else
+      return 0.0;
+  }
+  else if (_v_eq_u && !_w_eq_u && !_x_eq_u)
+  {
+    if (jvar == _w_id && jvar == _x_id)
+      return aval * _v[_qp] * 2.0 * _w[_qp];
+    else if (jvar == _w_id && jvar != _x_id)
+      return aval * _v[_qp] * _x[_qp];
+    else if (jvar != _w_id && jvar == _x_id)
+      return aval * _v[_qp] * _w[_qp];
+    else
+      return 0.0;
+  }
+  else if (_v_eq_u && _w_eq_u && !_x_eq_u)
+  {
+    if (jvar == _x_id)
+      return aval * _v[_qp] * _w[_qp];
+    else
+      return 0.0;
+  }
+  else if (_v_eq_u && !_w_eq_u && _x_eq_u)
+  {
+    if (jvar == _w_id)
+      return aval * _v[_qp] * _x[_qp];
+    else
+      return 0.0;
+  }
+  else
+    return 0.0;
+
+  /*
   // This jacobian is incorrect, I think. How to fix? - S. Keniley, 4/19/2018
   if (isCoupled("w") && isCoupled("v"))
   {
@@ -152,13 +196,13 @@ ProductThirdOrder::computeQpOffDiagJacobian(unsigned int jvar)
     {
       if (jvar == _v_id)
       {
-        return -_test[_i][_qp] * _stoichiometric_coeff * _reaction_coeff[_qp] *
-                _w[_qp] * _phi[_j][_qp];
+        return -_test[_i][_qp] * _stoichiometric_coeff * _reaction_coeff[_qp] * _w[_qp] *
+               _phi[_j][_qp];
       }
       else if (jvar == _w_id)
       {
-        return -_test[_i][_qp] * _stoichiometric_coeff * _reaction_coeff[_qp] *
-                _v[_qp] * _phi[_j][_qp];
+        return -_test[_i][_qp] * _stoichiometric_coeff * _reaction_coeff[_qp] * _v[_qp] *
+               _phi[_j][_qp];
       }
       else
         return 0.0;
@@ -167,8 +211,8 @@ ProductThirdOrder::computeQpOffDiagJacobian(unsigned int jvar)
     {
       if (jvar == _v_id)
       {
-        return -_test[_i][_qp] * 2.0 * _stoichiometric_coeff * _reaction_coeff[_qp] *
-                _v[_qp] * _w[_qp] * _phi[_j][_qp];
+        return -_test[_i][_qp] * 2.0 * _stoichiometric_coeff * _reaction_coeff[_qp] * _v[_qp] *
+               _w[_qp] * _phi[_j][_qp];
       }
       else
       {
@@ -179,16 +223,16 @@ ProductThirdOrder::computeQpOffDiagJacobian(unsigned int jvar)
   else if (!isCoupled("w") && isCoupled("v"))
   {
     if (jvar == _v_id)
-      return -_test[_i][_qp] * _stoichiometric_coeff * _reaction_coeff[_qp] *
-              _n_gas[_qp] * _phi[_j][_qp];
+      return -_test[_i][_qp] * _stoichiometric_coeff * _reaction_coeff[_qp] * _n_gas[_qp] *
+             _phi[_j][_qp];
     else
       return 0.0;
   }
   else if (isCoupled("w") && !isCoupled("v"))
   {
     if (jvar == _w_id)
-      return -_test[_i][_qp] * _stoichiometric_coeff * _reaction_coeff[_qp] *
-            _n_gas[_qp] * _phi[_j][_qp];
+      return -_test[_i][_qp] * _stoichiometric_coeff * _reaction_coeff[_qp] * _n_gas[_qp] *
+             _phi[_j][_qp];
     else
       return 0.0;
   }
@@ -196,4 +240,5 @@ ProductThirdOrder::computeQpOffDiagJacobian(unsigned int jvar)
   {
     return 0.0;
   }
+  */
 }

--- a/src/kernels/ProductThirdOrderLog.C
+++ b/src/kernels/ProductThirdOrderLog.C
@@ -10,9 +10,9 @@ InputParameters
 validParams<ProductThirdOrderLog>()
 {
   InputParameters params = validParams<Kernel>();
-  params.addCoupledVar("v", "The first variable that is reacting.");
-  params.addCoupledVar("w", "The second variable that is reacting.");
-  params.addCoupledVar("x", "The third variable that is reacting.");
+  params.addRequiredCoupledVar("v", "The first variable that is reacting.");
+  params.addRequiredCoupledVar("w", "The second variable that is reacting.");
+  params.addRequiredCoupledVar("x", "The third variable that is reacting.");
   params.addRequiredParam<std::string>("reaction", "The full reaction equation.");
   params.addRequiredParam<Real>("coefficient", "The stoichiometric coeffient.");
   params.addParam<bool>("_v_eq_u", false, "If coupled v == u.");
@@ -23,19 +23,15 @@ validParams<ProductThirdOrderLog>()
 
 ProductThirdOrderLog::ProductThirdOrderLog(const InputParameters & parameters)
   : Kernel(parameters),
-    _v(isCoupled("v") ? coupledValue("v") : _zero),
-    _w(isCoupled("w") ? coupledValue("w") : _zero),
-    _x(isCoupled("x") ? coupledValue("x") : _zero),
-    _v_id(isCoupled("v") ? coupled("v") : 0),
-    _w_id(isCoupled("w") ? coupled("w") : 0),
-    _x_id(isCoupled("x") ? coupled("x") : 0),
+    _v(coupledValue("v")),
+    _w(coupledValue("w")),
+    _x(coupledValue("x")),
+    _v_id(coupled("v")),
+    _w_id(coupled("w")),
+    _x_id(coupled("x")),
     _v_eq_u(getParam<bool>("_v_eq_u")),
     _w_eq_u(getParam<bool>("_w_eq_u")),
     _x_eq_u(getParam<bool>("_x_eq_u")),
-    _v_coupled(isCoupled("v") ? true : false),
-    _w_coupled(isCoupled("w") ? true : false),
-    _x_coupled(isCoupled("x") ? true : false),
-    // _n_gas(getMaterialProperty<Real>("n_gas")),
     _reaction_coeff(getMaterialProperty<Real>("k_" + getParam<std::string>("reaction"))),
     _stoichiometric_coeff(getParam<Real>("coefficient"))
 {
@@ -44,76 +40,21 @@ ProductThirdOrderLog::ProductThirdOrderLog(const InputParameters & parameters)
 Real
 ProductThirdOrderLog::computeQpResidual()
 {
-  // Real mult1, mult2, mult3;
-  // if (_v_coupled)
-  //  mult1 = std::exp(_v[_qp]);
-  // else
-  //  mult1 = _n_gas[_qp];
-
-  // if (_w_coupled)
-  //  mult2 = std::exp(_w[_qp]);
-  // else
-  //  mult2 = _n_gas[_qp];
-
-  // if (_x_coupled)
-  //  mult3 = std::exp(_x[_qp]);
-  // else
-  //  mult3 = _n_gas[_qp];
-
   return -_test[_i][_qp] * _stoichiometric_coeff * _reaction_coeff[_qp] * std::exp(_v[_qp]) *
          std::exp(_w[_qp]) * std::exp(_x[_qp]);
-  // return -_test[_i][_qp] * _stoichiometric_coeff * _reaction_coeff[_qp] * mult1 * mult2 * mult3;
-  // if (isCoupled("w") && isCoupled("v") && isCoupled("x"))
-  // {
-  //   return -_test[_i][_qp] * (_stoichiometric_coeff) * _reaction_coeff[_qp] * std::exp(_v[_qp]) *
-  //   std::exp(_w[_qp]) * std::exp(_x[_qp]);
-  // }
-  // else if (isCoupled("v") && !isCoupled("w") && isCoupled("x"))
-  // {
-  //   return -_test[_i][_qp] * (_stoichiometric_coeff) * _reaction_coeff[_qp] * std::exp(_v[_qp]) *
-  //   _n_gas[_qp] * std::exp(_x[_qp]);
-  // }
-  // else if (!isCoupled("v") && !isCoupled("w") && isCoupled("x"))
-  // {
-  //   return -_test[_i][_qp] * (_stoichiometric_coeff) * _reaction_coeff[_qp] * std::exp(_w[_qp]) *
-  //   _n_gas[_qp];
-  // }
-  // else
-  // {
-  //   return -_test[_i][_qp] * (_stoichiometric_coeff) * _reaction_coeff[_qp] * _n_gas[_qp] *
-  //   _n_gas[_qp];
-  // }
-  // Need to add more possibilities
 }
 
 Real
 ProductThirdOrderLog::computeQpJacobian()
 {
-  //  Real mult1, mult2, mult3, power, u_mult;
   Real power;
-  // if (_v_coupled)
-  //  mult1 = std::exp(_v[_qp]);
-  // else
-  //  mult1 = _n_gas[_qp];
-
-  // if (_w_coupled)
-  //  mult2 = std::exp(_w[_qp]);
-  // else
-  //  mult2 = _n_gas[_qp];
-
-  // if (_x_coupled)
-  //  mult3 = std::exp(_x[_qp]);
-  // else
-  //  mult3 = _n_gas[_qp];
-
-  // u_mult = mult1 * mult2 * mult3; // This is true regardless of derivatives!
 
   power = 0;
-  if (_v_coupled && _v_eq_u)
+  if (_v_eq_u)
     power += 1;
-  if (_w_coupled && _w_eq_u)
+  if (_w_eq_u)
     power += 1;
-  if (_x_coupled && _x_eq_u)
+  if (_x_eq_u)
     power += 1;
 
   return -_test[_i][_qp] * _stoichiometric_coeff * _reaction_coeff[_qp] * power *
@@ -123,90 +64,18 @@ ProductThirdOrderLog::computeQpJacobian()
 Real
 ProductThirdOrderLog::computeQpOffDiagJacobian(unsigned int jvar)
 {
-  // Real mult1, mult2, mult3, power, u_mult;
   Real power;
-  // if (_v_coupled)
-  //  mult1 = std::exp(_v[_qp]);
-  // else
-  //  mult1 = _n_gas[_qp];
-
-  // if (_w_coupled)
-  //  mult2 = std::exp(_w[_qp]);
-  // else
-  //  mult2 = _n_gas[_qp];
-
-  // if (_x_coupled)
-  //  mult3 = std::exp(_x[_qp]);
-  // else
-  //  mult3 = _n_gas[_qp];
-  // u_mult = mult1 * mult2 * mult3;
   power = 0;
 
-  if (_v_coupled && !_v_eq_u && jvar == _v_id)
+  if (!_v_eq_u && jvar == _v_id)
     power += 1;
 
-  if (_w_coupled && !_w_eq_u && jvar == _w_id)
+  if (!_w_eq_u && jvar == _w_id)
     power += 1;
 
-  if (_x_coupled && !_x_eq_u && jvar == _x_id)
+  if (!_x_eq_u && jvar == _x_id)
     power += 1;
 
   return -_test[_i][_qp] * _stoichiometric_coeff * _reaction_coeff[_qp] * std::exp(_v[_qp]) *
          std::exp(_w[_qp]) * std::exp(_x[_qp]) * power * _phi[_j][_qp];
-  // This jacobian is incorrect, I think. How to fix? - S. Keniley, 4/19/2018
-  // if (isCoupled("v") && isCoupled("w") && isCoupled("x"))
-  // {
-  //   if (_v_id != _w_id && _v_id != _x_id && _w_id != _x_id)
-  //   {
-  //     if (jvar == _v_id)
-  //     {
-  //       return -_test[_i][_qp] * (_stoichiometric_coeff) * _reaction_coeff[_qp] *
-  //               std::exp(_w[_qp]) * _phi[_j][_qp];
-  //     }
-  //     else if (jvar == _w_id)
-  //     {
-  //       return -_test[_i][_qp] * (_stoichiometric_coeff) * _reaction_coeff[_qp] *
-  //               std::exp(_v[_qp]) * _phi[_j][_qp];
-  //     }
-  //     else
-  //       return 0.0;
-  //   }
-  //   else if (_v_id != _w_id && _v_id != _x_id && _w_id == _x_id)
-  //   {
-  //     return -_test[_i][_qp] * _stoichiometric_coeff * _reaction_coeff[_qp] *
-  //       std::exp(_v[_qp]) * 2.0 * std::exp(_w[_qp]) * std::exp(_x[_qp]) * _phi[_j][_qp];
-  //   }
-  //   else
-  //   {
-  //     if (jvar == _v_id)
-  //     {
-  //       return -_test[_i][_qp] * 2.0 * (_stoichiometric_coeff) * _reaction_coeff[_qp] *
-  //               std::exp(_v[_qp]) * std::exp(_w[_qp]) * _phi[_j][_qp];
-  //     }
-  //     else
-  //     {
-  //       return 0.0;
-  //     }
-  //   }
-  // }
-  // else if (!isCoupled("w") && isCoupled("v") && isCoupled("x"))
-  // {
-  //   if (jvar == _v_id)
-  //     return -_test[_i][_qp] * (_stoichiometric_coeff) * _reaction_coeff[_qp] *
-  //             _n_gas[_qp] * _phi[_j][_qp];
-  //   else
-  //     return 0.0;
-  // }
-  // else if (isCoupled("w") && !isCoupled("v") && isCoupled("x"))
-  // {
-  //   if (jvar == _w_id)
-  //     return -_test[_i][_qp] * (_stoichiometric_coeff) * _reaction_coeff[_qp] *
-  //           _n_gas[_qp] * _phi[_j][_qp];
-  //   else
-  //     return 0.0;
-  // }
-  // else
-  // {
-  //   return 0.0;
-  // }
 }

--- a/src/kernels/ProductThirdOrderLog.C
+++ b/src/kernels/ProductThirdOrderLog.C
@@ -35,7 +35,7 @@ ProductThirdOrderLog::ProductThirdOrderLog(const InputParameters & parameters)
     _v_coupled(isCoupled("v") ? true : false),
     _w_coupled(isCoupled("w") ? true : false),
     _x_coupled(isCoupled("x") ? true : false),
-    _n_gas(getMaterialProperty<Real>("n_gas")),
+    // _n_gas(getMaterialProperty<Real>("n_gas")),
     _reaction_coeff(getMaterialProperty<Real>("k_" + getParam<std::string>("reaction"))),
     _stoichiometric_coeff(getParam<Real>("coefficient"))
 {
@@ -44,38 +44,44 @@ ProductThirdOrderLog::ProductThirdOrderLog(const InputParameters & parameters)
 Real
 ProductThirdOrderLog::computeQpResidual()
 {
-  Real mult1,mult2,mult3;
-  if (_v_coupled)
-    mult1 = std::exp(_v[_qp]);
-  else
-    mult1 = _n_gas[_qp];
+  // Real mult1, mult2, mult3;
+  // if (_v_coupled)
+  //  mult1 = std::exp(_v[_qp]);
+  // else
+  //  mult1 = _n_gas[_qp];
 
-  if (_w_coupled)
-    mult2 = std::exp(_w[_qp]);
-  else
-    mult2 = _n_gas[_qp];
+  // if (_w_coupled)
+  //  mult2 = std::exp(_w[_qp]);
+  // else
+  //  mult2 = _n_gas[_qp];
 
-  if (_x_coupled)
-    mult3 = std::exp(_x[_qp]);
-  else
-    mult3 = _n_gas[_qp];
+  // if (_x_coupled)
+  //  mult3 = std::exp(_x[_qp]);
+  // else
+  //  mult3 = _n_gas[_qp];
 
-  return -_test[_i][_qp] * _stoichiometric_coeff * _reaction_coeff[_qp] * mult1 * mult2 * mult3;
+  return -_test[_i][_qp] * _stoichiometric_coeff * _reaction_coeff[_qp] * std::exp(_v[_qp]) *
+         std::exp(_w[_qp]) * std::exp(_x[_qp]);
+  // return -_test[_i][_qp] * _stoichiometric_coeff * _reaction_coeff[_qp] * mult1 * mult2 * mult3;
   // if (isCoupled("w") && isCoupled("v") && isCoupled("x"))
   // {
-  //   return -_test[_i][_qp] * (_stoichiometric_coeff) * _reaction_coeff[_qp] * std::exp(_v[_qp]) * std::exp(_w[_qp]) * std::exp(_x[_qp]);
+  //   return -_test[_i][_qp] * (_stoichiometric_coeff) * _reaction_coeff[_qp] * std::exp(_v[_qp]) *
+  //   std::exp(_w[_qp]) * std::exp(_x[_qp]);
   // }
   // else if (isCoupled("v") && !isCoupled("w") && isCoupled("x"))
   // {
-  //   return -_test[_i][_qp] * (_stoichiometric_coeff) * _reaction_coeff[_qp] * std::exp(_v[_qp]) * _n_gas[_qp] * std::exp(_x[_qp]);
+  //   return -_test[_i][_qp] * (_stoichiometric_coeff) * _reaction_coeff[_qp] * std::exp(_v[_qp]) *
+  //   _n_gas[_qp] * std::exp(_x[_qp]);
   // }
   // else if (!isCoupled("v") && !isCoupled("w") && isCoupled("x"))
   // {
-  //   return -_test[_i][_qp] * (_stoichiometric_coeff) * _reaction_coeff[_qp] * std::exp(_w[_qp]) * _n_gas[_qp];
+  //   return -_test[_i][_qp] * (_stoichiometric_coeff) * _reaction_coeff[_qp] * std::exp(_w[_qp]) *
+  //   _n_gas[_qp];
   // }
   // else
   // {
-  //   return -_test[_i][_qp] * (_stoichiometric_coeff) * _reaction_coeff[_qp] * _n_gas[_qp] * _n_gas[_qp];
+  //   return -_test[_i][_qp] * (_stoichiometric_coeff) * _reaction_coeff[_qp] * _n_gas[_qp] *
+  //   _n_gas[_qp];
   // }
   // Need to add more possibilities
 }
@@ -83,24 +89,24 @@ ProductThirdOrderLog::computeQpResidual()
 Real
 ProductThirdOrderLog::computeQpJacobian()
 {
-  Real mult1,mult2,mult3,power,u_mult;
+  //  Real mult1, mult2, mult3, power, u_mult;
+  Real power;
+  // if (_v_coupled)
+  //  mult1 = std::exp(_v[_qp]);
+  // else
+  //  mult1 = _n_gas[_qp];
 
-  if (_v_coupled)
-    mult1 = std::exp(_v[_qp]);
-  else
-    mult1 = _n_gas[_qp];
+  // if (_w_coupled)
+  //  mult2 = std::exp(_w[_qp]);
+  // else
+  //  mult2 = _n_gas[_qp];
 
-  if (_w_coupled)
-    mult2 = std::exp(_w[_qp]);
-  else
-    mult2 = _n_gas[_qp];
+  // if (_x_coupled)
+  //  mult3 = std::exp(_x[_qp]);
+  // else
+  //  mult3 = _n_gas[_qp];
 
-  if (_x_coupled)
-    mult3 = std::exp(_x[_qp]);
-  else
-    mult3 = _n_gas[_qp];
-
-  u_mult = mult1 * mult2 * mult3; // This is true regardless of derivatives!
+  // u_mult = mult1 * mult2 * mult3; // This is true regardless of derivatives!
 
   power = 0;
   if (_v_coupled && _v_eq_u)
@@ -110,41 +116,43 @@ ProductThirdOrderLog::computeQpJacobian()
   if (_x_coupled && _x_eq_u)
     power += 1;
 
-  return -_test[_i][_qp] * _stoichiometric_coeff * _reaction_coeff[_qp] * power * u_mult * _phi[_j][_qp];
+  return -_test[_i][_qp] * _stoichiometric_coeff * _reaction_coeff[_qp] * power *
+         std::exp(_v[_qp]) * std::exp(_w[_qp]) * std::exp(_x[_qp]) * _phi[_j][_qp];
 }
 
 Real
 ProductThirdOrderLog::computeQpOffDiagJacobian(unsigned int jvar)
 {
-  Real mult1,mult2,mult3,power,u_mult;
+  // Real mult1, mult2, mult3, power, u_mult;
+  Real power;
+  // if (_v_coupled)
+  //  mult1 = std::exp(_v[_qp]);
+  // else
+  //  mult1 = _n_gas[_qp];
 
-  if (_v_coupled)
-    mult1 = std::exp(_v[_qp]);
-  else
-    mult1 = _n_gas[_qp];
+  // if (_w_coupled)
+  //  mult2 = std::exp(_w[_qp]);
+  // else
+  //  mult2 = _n_gas[_qp];
 
-  if (_w_coupled)
-    mult2 = std::exp(_w[_qp]);
-  else
-    mult2 = _n_gas[_qp];
-
-  if (_x_coupled)
-    mult3 = std::exp(_x[_qp]);
-  else
-    mult3 = _n_gas[_qp];
-  u_mult = mult1 * mult2 * mult3;
+  // if (_x_coupled)
+  //  mult3 = std::exp(_x[_qp]);
+  // else
+  //  mult3 = _n_gas[_qp];
+  // u_mult = mult1 * mult2 * mult3;
   power = 0;
 
-  if (_v_coupled && !_v_eq_u && jvar==_v_id)
+  if (_v_coupled && !_v_eq_u && jvar == _v_id)
     power += 1;
 
-  if (_w_coupled && !_w_eq_u && jvar==_w_id)
+  if (_w_coupled && !_w_eq_u && jvar == _w_id)
     power += 1;
 
-  if (_x_coupled && !_x_eq_u && jvar==_x_id)
+  if (_x_coupled && !_x_eq_u && jvar == _x_id)
     power += 1;
 
-  return -_test[_i][_qp] * _stoichiometric_coeff * _reaction_coeff[_qp] * u_mult * power * _phi[_j][_qp];
+  return -_test[_i][_qp] * _stoichiometric_coeff * _reaction_coeff[_qp] * std::exp(_v[_qp]) *
+         std::exp(_w[_qp]) * std::exp(_x[_qp]) * power * _phi[_j][_qp];
   // This jacobian is incorrect, I think. How to fix? - S. Keniley, 4/19/2018
   // if (isCoupled("v") && isCoupled("w") && isCoupled("x"))
   // {

--- a/src/kernels/ReactantFirstOrderLog.C
+++ b/src/kernels/ReactantFirstOrderLog.C
@@ -19,8 +19,6 @@ validParams<ReactantFirstOrderLog>()
 ReactantFirstOrderLog::ReactantFirstOrderLog(const InputParameters & parameters)
   : Kernel(parameters),
     _reaction_coeff(getMaterialProperty<Real>("k_" + getParam<std::string>("reaction"))),
-    // _diff_rate(getMaterialProperty<Real>("diffusion_rate")),
-    // _n_gas(getMaterialProperty<Real>("n_gas")),
     _stoichiometric_coeff(getParam<Real>("coefficient"))
 {
 }
@@ -28,22 +26,12 @@ ReactantFirstOrderLog::ReactantFirstOrderLog(const InputParameters & parameters)
 Real
 ReactantFirstOrderLog::computeQpResidual()
 {
-  // if (getParam<bool>("diffusion_term"))
-  // return -_test[_i][_qp] * _stoichiometric_coeff * _diff_rate[_qp] * 6.022e23 *
-  // std::exp(_u[_qp]);
-  // return -_test[_i][_qp] * _stoichiometric_coeff * _diff_rate[_qp] * std::exp(_u[_qp]);
-  // else
-  // return -_test[_i][_qp] * _stoichiometric_coeff * _reaction_coeff[_qp] * 6.022e23 *
-  // std::exp(_u[_qp]);
   return -_test[_i][_qp] * _stoichiometric_coeff * _reaction_coeff[_qp] * std::exp(_u[_qp]);
 }
 
 Real
 ReactantFirstOrderLog::computeQpJacobian()
 {
-  // return -_test[_i][_qp] * _stoichiometric_coeff * _diff_rate[_qp] * 6.022e23 * std::exp(_u[_qp])
-  // * _phi[_j][_qp]; return -_test[_i][_qp] * _stoichiometric_coeff * _diff_rate[_qp] *
-  // std::exp(_u[_qp]) * _phi[_j][_qp]; return 0.0;
   return -_test[_i][_qp] * _stoichiometric_coeff * _reaction_coeff[_qp] * std::exp(_u[_qp]) *
          _phi[_j][_qp];
 }

--- a/src/kernels/ReactantSecondOrder.C
+++ b/src/kernels/ReactantSecondOrder.C
@@ -10,7 +10,7 @@ InputParameters
 validParams<ReactantSecondOrder>()
 {
   InputParameters params = validParams<Kernel>();
-  params.addCoupledVar("v", "The first variable that is reacting to create u.");
+  params.addRequiredCoupledVar("v", "The first variable that is reacting to create u.");
   params.addRequiredParam<std::string>("reaction", "The full reaction equation.");
   params.addRequiredParam<Real>("coefficient", "The stoichiometric coeffient.");
   params.addParam<bool>("_v_eq_u", false, "Whether or not v and u are the same variable.");
@@ -19,10 +19,9 @@ validParams<ReactantSecondOrder>()
 
 ReactantSecondOrder::ReactantSecondOrder(const InputParameters & parameters)
   : Kernel(parameters),
-    _reaction_coeff(getMaterialProperty<Real>("k_"+getParam<std::string>("reaction"))),
-    _v(isCoupled("v") ? coupledValue("v") : _zero),
-    _v_id(isCoupled("v") ? coupled("v") : 0),
-    _n_gas(getMaterialProperty<Real>("n_gas")),
+    _reaction_coeff(getMaterialProperty<Real>("k_" + getParam<std::string>("reaction"))),
+    _v(coupledValue("v")),
+    _v_id(coupled("v")),
     _stoichiometric_coeff(getParam<Real>("coefficient")),
     _v_eq_u(getParam<bool>("_v_eq_u"))
 {
@@ -31,25 +30,18 @@ ReactantSecondOrder::ReactantSecondOrder(const InputParameters & parameters)
 Real
 ReactantSecondOrder::computeQpResidual()
 {
-  Real mult_1;
-
-  if (isCoupled("v"))
-    mult_1 = _v[_qp];
-  else
-    mult_1 = _n_gas[_qp];
-
-  return -_test[_i][_qp] * _stoichiometric_coeff * _reaction_coeff[_qp] * mult_1 * _u[_qp];
-  // if (isCoupled("v"))
-  // {
-  //   return -_test[_i][_qp] * _stoichiometric_coeff * _reaction_coeff[_qp] * _v[_qp] * _u[_qp];
-  // }
-  // else
-  //   return -_test[_i][_qp] * _stoichiometric_coeff * _reaction_coeff[_qp] * _n_gas[_qp] * _u[_qp];
+  return -_test[_i][_qp] * _stoichiometric_coeff * _reaction_coeff[_qp] * _v[_qp] * _u[_qp];
 }
 
 Real
 ReactantSecondOrder::computeQpJacobian()
 {
+  if (_v_eq_u)
+    return -_test[_i][_qp] * _stoichiometric_coeff * _reaction_coeff[_qp] * 2.0 * _u[_qp] *
+           _phi[_j][_qp];
+  else
+    return -_test[_i][_qp] * _stoichiometric_coeff * _reaction_coeff[_qp] * _v[_qp] * _phi[_j][_qp];
+  /*
   Real mult_1, power, eq_u_mult, gas_mult;
   power = 1.0;
   eq_u_mult = _u[_qp];
@@ -68,22 +60,17 @@ ReactantSecondOrder::computeQpJacobian()
   else
     gas_mult *= mult_1;
 
-  return -_test[_i][_qp] * _stoichiometric_coeff * _reaction_coeff[_qp] * power * std::pow(eq_u_mult, power-1) * gas_mult * _phi[_j][_qp];
+  return -_test[_i][_qp] * _stoichiometric_coeff * _reaction_coeff[_qp] * power *
+  std::pow(eq_u_mult, power-1) * gas_mult * _phi[_j][_qp];
   // return -_test[_i][_qp] * _stoichiometric_coeff * _reaction_coeff[_qp] * power * eq_u_mult * gas_mult * _phi[_j][_qp];
+  */
 }
 
 Real
 ReactantSecondOrder::computeQpOffDiagJacobian(unsigned int jvar)
 {
-  if (isCoupled("v"))
-  {
-    if (jvar == _v_id)
-      return -_test[_i][_qp] * _stoichiometric_coeff * _reaction_coeff[_qp] * 1.0 * _u[_qp] * _phi[_j][_qp];
-    else
-      return 0.0;
-  }
+  if (!_v_eq_u && jvar == _v_id)
+    return -_test[_i][_qp] * _stoichiometric_coeff * _reaction_coeff[_qp] * _u[_qp] * _phi[_j][_qp];
   else
-  {
     return 0.0;
-  }
 }

--- a/src/kernels/ReactantSecondOrderLog.C
+++ b/src/kernels/ReactantSecondOrderLog.C
@@ -19,10 +19,10 @@ validParams<ReactantSecondOrderLog>()
 
 ReactantSecondOrderLog::ReactantSecondOrderLog(const InputParameters & parameters)
   : Kernel(parameters),
-    _reaction_coeff(getMaterialProperty<Real>("k_"+getParam<std::string>("reaction"))),
+    _reaction_coeff(getMaterialProperty<Real>("k_" + getParam<std::string>("reaction"))),
     _v(isCoupled("v") ? coupledValue("v") : _zero),
     _v_id(isCoupled("v") ? coupled("v") : 0),
-    _n_gas(getMaterialProperty<Real>("n_gas")),
+    //_n_gas(getMaterialProperty<Real>("n_gas")),
     _stoichiometric_coeff(getParam<Real>("coefficient")),
     _v_eq_u(getParam<bool>("_v_eq_u"))
 {
@@ -33,21 +33,29 @@ ReactantSecondOrderLog::computeQpResidual()
 {
   if (isCoupled("v"))
   {
-    return -_test[_i][_qp] * _stoichiometric_coeff * _reaction_coeff[_qp] * std::exp(_v[_qp]) * std::exp(_u[_qp]);
+    return -_test[_i][_qp] * _stoichiometric_coeff * _reaction_coeff[_qp] * std::exp(_v[_qp]) *
+           std::exp(_u[_qp]);
   }
   else
-    return -_test[_i][_qp] * _stoichiometric_coeff * _reaction_coeff[_qp] * _n_gas[_qp] * std::exp(_u[_qp]);
+    return 0.0;
+  //  return -_test[_i][_qp] * _stoichiometric_coeff * _reaction_coeff[_qp] * _n_gas[_qp] *
+  //  std::exp(_u[_qp]);
 }
 
 Real
 ReactantSecondOrderLog::computeQpJacobian()
 {
   if (isCoupled("v"))
-    return -_test[_i][_qp] * _stoichiometric_coeff * _reaction_coeff[_qp] * 1.0 * std::exp(_v[_qp]) *
-           std::exp(_u[_qp]) * _phi[_j][_qp];
+    if (_v_eq_u)
+      return -_test[_i][_qp] * _stoichiometric_coeff * _reaction_coeff[_qp] * 2.0 *
+             std::exp(_v[_qp]) * std::exp(_u[_qp]) * _phi[_j][_qp];
+    else
+      return -_test[_i][_qp] * _stoichiometric_coeff * _reaction_coeff[_qp] * 1.0 *
+             std::exp(_v[_qp]) * std::exp(_u[_qp]) * _phi[_j][_qp];
   else
-    return -_test[_i][_qp] * _stoichiometric_coeff * _reaction_coeff[_qp] * 1.0 * _n_gas[_qp] *
-           std::exp(_u[_qp]) * _phi[_j][_qp];
+    return 0.0;
+  //   return -_test[_i][_qp] * _stoichiometric_coeff * _reaction_coeff[_qp] * 1.0 * _n_gas[_qp] *
+  //          std::exp(_u[_qp]) * _phi[_j][_qp];
 }
 
 Real
@@ -56,7 +64,8 @@ ReactantSecondOrderLog::computeQpOffDiagJacobian(unsigned int jvar)
   if (isCoupled("v"))
   {
     if (jvar == _v_id)
-      return -_test[_i][_qp] * _stoichiometric_coeff * _reaction_coeff[_qp] * 1.0 * std::exp(_u[_qp]) * std::exp(_v[_qp]) * _phi[_j][_qp];
+      return -_test[_i][_qp] * _stoichiometric_coeff * _reaction_coeff[_qp] * 1.0 *
+             std::exp(_u[_qp]) * std::exp(_v[_qp]) * _phi[_j][_qp];
     else
       return 0.0;
   }

--- a/src/kernels/ReactantThirdOrder.C
+++ b/src/kernels/ReactantThirdOrder.C
@@ -10,151 +10,91 @@ InputParameters
 validParams<ReactantThirdOrder>()
 {
   InputParameters params = validParams<Kernel>();
-  params.addCoupledVar("v", "The first variable that is reacting to create u.");
-  params.addCoupledVar("w", "The second variable that is reacting to create u.");
+  params.addRequiredCoupledVar("v", "The first variable that is reacting to create u.");
+  params.addRequiredCoupledVar("w", "The second variable that is reacting to create u.");
   params.addRequiredParam<std::string>("reaction", "The full reaction equation.");
   params.addRequiredParam<Real>("coefficient", "The stoichiometric coeffient.");
-  params.addParam<bool>("v_eq_u", false, "If v == u.");
-  params.addParam<bool>("w_eq_u", false, "If w == u.");
+  params.addParam<bool>("_v_eq_u", false, "If v == u.");
+  params.addParam<bool>("_w_eq_u", false, "If w == u.");
   return params;
 }
 
 ReactantThirdOrder::ReactantThirdOrder(const InputParameters & parameters)
   : Kernel(parameters),
-    _reaction_coeff(getMaterialProperty<Real>("k_"+getParam<std::string>("reaction"))),
-    _v(isCoupled("v") ? coupledValue("v") : _zero),
-    _w(isCoupled("w") ? coupledValue("w") : _zero),
-    _v_id(isCoupled("v") ? coupled("v") : 0),
-    _w_id(isCoupled("w") ? coupled("w") : 0),
-    _n_gas(getMaterialProperty<Real>("n_gas")),
+    _reaction_coeff(getMaterialProperty<Real>("k_" + getParam<std::string>("reaction"))),
+    _v(coupledValue("v")),
+    _w(coupledValue("w")),
+    _v_id(coupled("v")),
+    _w_id(coupled("w")),
     _stoichiometric_coeff(getParam<Real>("coefficient")),
-    _v_eq_u(getParam<bool>("v_eq_u")),
-    _w_eq_u(getParam<bool>("w_eq_u"))
+    _v_eq_u(getParam<bool>("_v_eq_u")),
+    _w_eq_u(getParam<bool>("_w_eq_u"))
 {
 }
 
 Real
 ReactantThirdOrder::computeQpResidual()
 {
-  if (isCoupled("v") && isCoupled("w"))
-  {
-    return -_test[_i][_qp] * _stoichiometric_coeff * _reaction_coeff[_qp] * _v[_qp] * _w[_qp] * _u[_qp];
-  }
-  else if (isCoupled("v") && !isCoupled("w"))
-  {
-    return -_test[_i][_qp] * _stoichiometric_coeff * _reaction_coeff[_qp] * _v[_qp] * _n_gas[_qp] * _u[_qp];
-  }
-  else if (!isCoupled("v") && isCoupled("w"))
-  {
-    return -_test[_i][_qp] * _stoichiometric_coeff * _reaction_coeff[_qp] * _w[_qp] * _n_gas[_qp] * _u[_qp];
-  }
-  else
-    return -_test[_i][_qp] * _stoichiometric_coeff * _reaction_coeff[_qp] * _n_gas[_qp] * _n_gas[_qp] * _u[_qp];
+  return -_test[_i][_qp] * _stoichiometric_coeff * _reaction_coeff[_qp] * _v[_qp] * _w[_qp] *
+         _u[_qp];
 }
 
 Real
 ReactantThirdOrder::computeQpJacobian()
 {
-  Real mult1, mult2, power, gas_mult;
-  if (isCoupled("v"))
-    mult1 = _v[_qp];
-  else
-    mult1 = _n_gas[_qp];
-
-  if (isCoupled("w"))
-    mult2 = _w[_qp];
-  else
-    mult2 = _n_gas[_qp];
+  Real power, gas_mult;
 
   power = 1.0;
-  // eq_u_mult = _u[_qp];  // multiplies variables that are equal to _u
   gas_mult = 1.0; // multiplies the rest of the variables (!= _u)
   if (_v_eq_u)
   {
     power += 1.0;
-    // eq_u_mult *= mult1;
   }
   else
-    gas_mult *= mult1;
+    gas_mult *= _v[_qp];
 
   if (_w_eq_u)
   {
     power += 1.0;
-    // eq_u_mult *= mult2;
   }
   else
-    gas_mult *= mult2;
+    gas_mult *= _w[_qp];
 
-  return -_test[_i][_qp] * _stoichiometric_coeff * _reaction_coeff[_qp] * power * std::pow(_u[_qp], power-1) * gas_mult * _phi[_j][_qp];
-
-  // if (isCoupled("v") && isCoupled("w"))
-  //   return -_test[_i][_qp] * _stoichiometric_coeff * _reaction_coeff[_qp] * 1.0 * _v[_qp] *
-  //          _w[_qp] * _phi[_j][_qp];
-  // else if (isCoupled("v") && !isCoupled("w"))
-  // {
-  //   return -_test[_i][_qp] * _stoichiometric_coeff * _reaction_coeff[_qp] * 1.0 * _v[_qp] *
-  //          _n_gas[_qp] * _phi[_j][_qp];
-  // }
-  // else if (!isCoupled("v") && isCoupled("w"))
-  // {
-  //   return -_test[_i][_qp] * _stoichiometric_coeff * _reaction_coeff[_qp] * 1.0 * _w[_qp] *
-  //          _n_gas[_qp] * _phi[_j][_qp];
-  // }
-  // else
-  //   return -_test[_i][_qp] * _stoichiometric_coeff * _reaction_coeff[_qp] * 1.0 * _n_gas[_qp] *
-  //          _n_gas[_qp] * _phi[_j][_qp];
+  return -_test[_i][_qp] * _stoichiometric_coeff * _reaction_coeff[_qp] * power *
+         std::pow(_u[_qp], power - 1) * gas_mult * _phi[_j][_qp];
 }
 
 Real
 ReactantThirdOrder::computeQpOffDiagJacobian(unsigned int jvar)
 {
-  Real mult1, mult2;
-  if (isCoupled("v"))
-    mult1 = _v[_qp];
-  else
-    mult1 = _n_gas[_qp];
+  Real aval;
+  aval = -_test[_i][_qp] * _stoichiometric_coeff * _reaction_coeff[_qp] * _phi[_j][_qp];
 
-  if (isCoupled("w"))
-    mult2 = _w[_qp];
-  else
-    mult2 = _n_gas[_qp];
-
-
-  if (isCoupled("v") && isCoupled("w"))
+  if (!_v_eq_u && !_w_eq_u)
   {
-    if (_v_id != _w_id)
-    {
-      if ((jvar == _v_id) && (!_v_eq_u))
-        return -_test[_i][_qp] * _stoichiometric_coeff * _reaction_coeff[_qp] * _u[_qp] * mult2 * _phi[_j][_qp];
-      else if ((jvar == _w_id) && (!_w_eq_u))
-        return -_test[_i][_qp] * _stoichiometric_coeff * _reaction_coeff[_qp] * _u[_qp] * mult1 * _phi[_j][_qp];
-      else
-        return 0.0;
-    }
-    else
-    {
-      if (jvar == _v_id)
-        return -_test[_i][_qp] * _stoichiometric_coeff * _reaction_coeff[_qp] * 2.0 * _u[_qp] * mult1 * _phi[_j][_qp];
-      else
-        return 0.0;
-    }
-  }
-  else if (isCoupled("v") && !isCoupled("w"))
-  {
-    if (jvar == _v_id)
-      return -_test[_i][_qp] * _stoichiometric_coeff * _reaction_coeff[_qp] * _u[_qp] * mult2 * _phi[_j][_qp];
+    if (jvar == _v_id && jvar == _w_id)
+      return aval * _u[_qp] * 2.0 * _v[_qp];
+    else if (jvar == _v_id && jvar != _w_id)
+      return aval * _u[_qp] * _w[_qp];
+    else if (jvar != _v_id && jvar == _w_id)
+      return aval * _u[_qp] * _v[_qp];
     else
       return 0.0;
   }
-  else if (!isCoupled("v") && isCoupled("w"))
+  else if (_v_eq_u && !_w_eq_u)
   {
     if (jvar == _w_id)
-      return -_test[_i][_qp] * _stoichiometric_coeff * _reaction_coeff[_qp] * _u[_qp] * mult1 * _phi[_j][_qp];
+      return aval * _u[_qp] * _v[_qp];
+    else
+      return 0.0;
+  }
+  else if (!_v_eq_u && _w_eq_u)
+  {
+    if (jvar == _v_id)
+      return aval * _u[_qp] * _w[_qp];
     else
       return 0.0;
   }
   else
-  {
     return 0.0;
-  }
 }

--- a/src/kernels/ReactantThirdOrderLog.C
+++ b/src/kernels/ReactantThirdOrderLog.C
@@ -30,7 +30,7 @@ ReactantThirdOrderLog::ReactantThirdOrderLog(const InputParameters & parameters)
     _w_eq_u(getParam<bool>("_w_eq_u")),
     _v_coupled(isCoupled("v") ? true : false),
     _w_coupled(isCoupled("w") ? true : false),
-    _n_gas(getMaterialProperty<Real>("n_gas")),
+    // _n_gas(getMaterialProperty<Real>("n_gas")),
     _stoichiometric_coeff(getParam<Real>("coefficient"))
 {
 }
@@ -38,20 +38,22 @@ ReactantThirdOrderLog::ReactantThirdOrderLog(const InputParameters & parameters)
 Real
 ReactantThirdOrderLog::computeQpResidual()
 {
-  Real mult1, mult2;
+  // Real mult1, mult2;
 
-  if (_v_coupled)
-    mult1 = std::exp(_v[_qp]);
-  else
-    mult1 = _n_gas[_qp];
+  // if (_v_coupled)
+  //  mult1 = std::exp(_v[_qp]);
+  // else
+  //  mult1 = _n_gas[_qp];
 
-  if (_w_coupled)
-    mult2 = std::exp(_w[_qp]);
-  else
-    mult2 = _n_gas[_qp];
+  // if (_w_coupled)
+  //  mult2 = std::exp(_w[_qp]);
+  // else
+  //  mult2 = _n_gas[_qp];
 
   return -_test[_i][_qp] * _stoichiometric_coeff * _reaction_coeff[_qp] * std::exp(_u[_qp]) *
-         mult1 * mult2;
+         std::exp(_v[_qp]) * std::exp(_w[_qp]);
+  // return -_test[_i][_qp] * _stoichiometric_coeff * _reaction_coeff[_qp] * std::exp(_u[_qp]) *
+  //       mult1 * mult2;
 
   // if (isCoupled("v") && isCoupled("w"))
   // {
@@ -76,24 +78,24 @@ ReactantThirdOrderLog::computeQpResidual()
 Real
 ReactantThirdOrderLog::computeQpJacobian()
 {
-
-  Real mult1, mult2;
-  Real power, u_mult;
+  Real power;
+  //  Real mult1, mult2;
+  //  Real power, u_mult;
   // power = 0.0;
   // eq_u_mult = 1.0;
   // gas_mult = 1.0;
 
-  if (_v_coupled)
-    mult1 = std::exp(_v[_qp]);
-  else
-    mult1 = _n_gas[_qp];
+  // if (_v_coupled)
+  //  mult1 = std::exp(_v[_qp]);
+  // else
+  //  mult1 = _n_gas[_qp];
 
-  if (_w_coupled)
-    mult2 = std::exp(_w[_qp]);
-  else
-    mult2 = _n_gas[_qp];
+  // if (_w_coupled)
+  //  mult2 = std::exp(_w[_qp]);
+  // else
+  //  mult2 = _n_gas[_qp];
 
-  u_mult = mult1 * mult2 * std::exp(_u[_qp]);
+  // u_mult = mult1 * mult2 * std::exp(_u[_qp]);
 
   power = 1;
   if (_v_coupled && _v_eq_u)
@@ -102,8 +104,10 @@ ReactantThirdOrderLog::computeQpJacobian()
   if (_w_coupled && _w_eq_u)
     power += 1;
 
-  return -_test[_i][_qp] * _stoichiometric_coeff * _reaction_coeff[_qp] * power * u_mult *
-         _phi[_j][_qp];
+  return -_test[_i][_qp] * _stoichiometric_coeff * _reaction_coeff[_qp] * power *
+         std::exp(_u[_qp]) * std::exp(_v[_qp]) * std::exp(_w[_qp]) * _phi[_j][_qp];
+  // return -_test[_i][_qp] * _stoichiometric_coeff * _reaction_coeff[_qp] * power * u_mult *
+  //       _phi[_j][_qp];
 
   // if (isCoupled("v") && isCoupled("w"))
   //   return -_test[_i][_qp] * _stoichiometric_coeff * _reaction_coeff[_qp] * 1.0 *
@@ -129,18 +133,19 @@ ReactantThirdOrderLog::computeQpJacobian()
 Real
 ReactantThirdOrderLog::computeQpOffDiagJacobian(unsigned int)
 {
-  Real mult1, mult2, u_mult, power;
-  if (_v_coupled)
-    mult1 = std::exp(_v[_qp]);
-  else
-    mult1 = _n_gas[_qp];
+  Real power;
+  // Real mult1, mult2, u_mult, power;
+  // if (_v_coupled)
+  //  mult1 = std::exp(_v[_qp]);
+  // else
+  //  mult1 = _n_gas[_qp];
 
-  if (_w_coupled)
-    mult2 = std::exp(_w[_qp]);
-  else
-    mult2 = _n_gas[_qp];
+  // if (_w_coupled)
+  //  mult2 = std::exp(_w[_qp]);
+  // else
+  //  mult2 = _n_gas[_qp];
 
-  u_mult = mult1 * mult2 * std::exp(_u[_qp]);
+  // u_mult = mult1 * mult2 * std::exp(_u[_qp]);
 
   power = 0;
 
@@ -150,8 +155,10 @@ ReactantThirdOrderLog::computeQpOffDiagJacobian(unsigned int)
   if (_w_coupled && !_w_eq_u)
     power += 1;
 
-  return -_test[_i][_qp] * _stoichiometric_coeff * _reaction_coeff[_qp] * power * u_mult *
-         _phi[_j][_qp];
+  return -_test[_i][_qp] * _stoichiometric_coeff * _reaction_coeff[_qp] * power *
+         std::exp(_u[_qp]) * std::exp(_v[_qp]) * std::exp(_w[_qp]) * _phi[_j][_qp];
+  //  return -_test[_i][_qp] * _stoichiometric_coeff * _reaction_coeff[_qp] * power * u_mult *
+  //         _phi[_j][_qp];
   // if (isCoupled("v") && isCoupled("w"))
   // {
   //   if (_v_id != _w_id)

--- a/src/kernels/ReactantThirdOrderLog.C
+++ b/src/kernels/ReactantThirdOrderLog.C
@@ -10,8 +10,8 @@ InputParameters
 validParams<ReactantThirdOrderLog>()
 {
   InputParameters params = validParams<Kernel>();
-  params.addCoupledVar("v", "The first variable that is reacting to create u.");
-  params.addCoupledVar("w", "The second variable that is reacting to create u.");
+  params.addRequiredCoupledVar("v", "The first variable that is reacting to create u.");
+  params.addRequiredCoupledVar("w", "The second variable that is reacting to create u.");
   params.addRequiredParam<std::string>("reaction", "The full reaction equation.");
   params.addRequiredParam<Real>("coefficient", "The stoichiometric coeffient.");
   params.addParam<bool>("_v_eq_u", false, "If coupled v == u.");
@@ -22,15 +22,12 @@ validParams<ReactantThirdOrderLog>()
 ReactantThirdOrderLog::ReactantThirdOrderLog(const InputParameters & parameters)
   : Kernel(parameters),
     _reaction_coeff(getMaterialProperty<Real>("k_" + getParam<std::string>("reaction"))),
-    _v(isCoupled("v") ? coupledValue("v") : _zero),
-    _w(isCoupled("w") ? coupledValue("w") : _zero),
-    _v_id(coupled("v") ? coupled("v") : 0),
-    _w_id(coupled("w") ? coupled("w") : 0),
+    _v(coupledValue("v")),
+    _w(coupledValue("w")),
+    _v_id(coupled("v")),
+    _w_id(coupled("w")),
     _v_eq_u(getParam<bool>("_v_eq_u")),
     _w_eq_u(getParam<bool>("_w_eq_u")),
-    _v_coupled(isCoupled("v") ? true : false),
-    _w_coupled(isCoupled("w") ? true : false),
-    // _n_gas(getMaterialProperty<Real>("n_gas")),
     _stoichiometric_coeff(getParam<Real>("coefficient"))
 {
 }
@@ -38,167 +35,39 @@ ReactantThirdOrderLog::ReactantThirdOrderLog(const InputParameters & parameters)
 Real
 ReactantThirdOrderLog::computeQpResidual()
 {
-  // Real mult1, mult2;
-
-  // if (_v_coupled)
-  //  mult1 = std::exp(_v[_qp]);
-  // else
-  //  mult1 = _n_gas[_qp];
-
-  // if (_w_coupled)
-  //  mult2 = std::exp(_w[_qp]);
-  // else
-  //  mult2 = _n_gas[_qp];
-
   return -_test[_i][_qp] * _stoichiometric_coeff * _reaction_coeff[_qp] * std::exp(_u[_qp]) *
          std::exp(_v[_qp]) * std::exp(_w[_qp]);
-  // return -_test[_i][_qp] * _stoichiometric_coeff * _reaction_coeff[_qp] * std::exp(_u[_qp]) *
-  //       mult1 * mult2;
-
-  // if (isCoupled("v") && isCoupled("w"))
-  // {
-  //   return -_test[_i][_qp] * _stoichiometric_coeff * _reaction_coeff[_qp] * std::exp(_v[_qp]) *
-  //   std::exp(_w[_qp]) * std::exp(_u[_qp]);
-  // }
-  // else if (isCoupled("v") && !isCoupled("w"))
-  // {
-  //   return -_test[_i][_qp] * _stoichiometric_coeff * _reaction_coeff[_qp] * std::exp(_v[_qp]) *
-  //   _n_gas[_qp] * std::exp(_u[_qp]);
-  // }
-  // else if (!isCoupled("v") && isCoupled("w"))
-  // {
-  //   return -_test[_i][_qp] * _stoichiometric_coeff * _reaction_coeff[_qp] * std::exp(_w[_qp]) *
-  //   _n_gas[_qp] * std::exp(_u[_qp]);
-  // }
-  // else
-  //   return -_test[_i][_qp] * _stoichiometric_coeff * _reaction_coeff[_qp] * _n_gas[_qp] *
-  //   _n_gas[_qp] * std::exp(_u[_qp]);
 }
 
 Real
 ReactantThirdOrderLog::computeQpJacobian()
 {
   Real power;
-  //  Real mult1, mult2;
-  //  Real power, u_mult;
-  // power = 0.0;
-  // eq_u_mult = 1.0;
-  // gas_mult = 1.0;
-
-  // if (_v_coupled)
-  //  mult1 = std::exp(_v[_qp]);
-  // else
-  //  mult1 = _n_gas[_qp];
-
-  // if (_w_coupled)
-  //  mult2 = std::exp(_w[_qp]);
-  // else
-  //  mult2 = _n_gas[_qp];
-
-  // u_mult = mult1 * mult2 * std::exp(_u[_qp]);
 
   power = 1;
-  if (_v_coupled && _v_eq_u)
+  if (_v_eq_u)
     power += 1;
 
-  if (_w_coupled && _w_eq_u)
+  if (_w_eq_u)
     power += 1;
 
   return -_test[_i][_qp] * _stoichiometric_coeff * _reaction_coeff[_qp] * power *
          std::exp(_u[_qp]) * std::exp(_v[_qp]) * std::exp(_w[_qp]) * _phi[_j][_qp];
-  // return -_test[_i][_qp] * _stoichiometric_coeff * _reaction_coeff[_qp] * power * u_mult *
-  //       _phi[_j][_qp];
-
-  // if (isCoupled("v") && isCoupled("w"))
-  //   return -_test[_i][_qp] * _stoichiometric_coeff * _reaction_coeff[_qp] * 1.0 *
-  //   std::exp(_v[_qp]) *
-  //          std::exp(_w[_qp]) * _phi[_j][_qp];
-  // else if (isCoupled("v") && !isCoupled("w"))
-  // {
-  //   return -_test[_i][_qp] * _stoichiometric_coeff * _reaction_coeff[_qp] * 1.0 *
-  //   std::exp(_v[_qp]) *
-  //          _n_gas[_qp] * _phi[_j][_qp];
-  // }
-  // else if (!isCoupled("v") && isCoupled("w"))
-  // {
-  //   return -_test[_i][_qp] * _stoichiometric_coeff * _reaction_coeff[_qp] * 1.0 *
-  //   std::exp(_w[_qp]) *
-  //          _n_gas[_qp] * _phi[_j][_qp];
-  // }
-  // else
-  //   return -_test[_i][_qp] * _stoichiometric_coeff * _reaction_coeff[_qp] * 1.0 * _n_gas[_qp] *
-  //          _n_gas[_qp] * _phi[_j][_qp];
 }
 
 Real
 ReactantThirdOrderLog::computeQpOffDiagJacobian(unsigned int)
 {
   Real power;
-  // Real mult1, mult2, u_mult, power;
-  // if (_v_coupled)
-  //  mult1 = std::exp(_v[_qp]);
-  // else
-  //  mult1 = _n_gas[_qp];
-
-  // if (_w_coupled)
-  //  mult2 = std::exp(_w[_qp]);
-  // else
-  //  mult2 = _n_gas[_qp];
-
-  // u_mult = mult1 * mult2 * std::exp(_u[_qp]);
 
   power = 0;
 
-  if (_v_coupled && !_v_eq_u)
+  if (!_v_eq_u)
     power += 1;
 
-  if (_w_coupled && !_w_eq_u)
+  if (!_w_eq_u)
     power += 1;
 
   return -_test[_i][_qp] * _stoichiometric_coeff * _reaction_coeff[_qp] * power *
          std::exp(_u[_qp]) * std::exp(_v[_qp]) * std::exp(_w[_qp]) * _phi[_j][_qp];
-  //  return -_test[_i][_qp] * _stoichiometric_coeff * _reaction_coeff[_qp] * power * u_mult *
-  //         _phi[_j][_qp];
-  // if (isCoupled("v") && isCoupled("w"))
-  // {
-  //   if (_v_id != _w_id)
-  //   {
-  //     if (jvar == _v_id)
-  //       return -_test[_i][_qp] * _stoichiometric_coeff * _reaction_coeff[_qp] * 1.0 *
-  //       std::exp(_u[_qp]) * std::exp(_w[_qp]) * _phi[_j][_qp];
-  //     else if (jvar == _w_id)
-  //       return -_test[_i][_qp] * _stoichiometric_coeff * _reaction_coeff[_qp] * 1.0 *
-  //       std::exp(_u[_qp]) * std::exp(_v[_qp]) * _phi[_j][_qp];
-  //     else
-  //       return 0.0;
-  //   }
-  //   else
-  //   {
-  //     if (jvar == _v_id)
-  //       return -_test[_i][_qp] * _stoichiometric_coeff * _reaction_coeff[_qp] * 1.0 *
-  //       std::exp(_u[_qp]) * std::exp(_w[_qp]) * _phi[_j][_qp];
-  //     else
-  //       return 0.0;
-  //   }
-  // }
-  // else if (isCoupled("v") && !isCoupled("w"))
-  // {
-  //   if (jvar == _v_id)
-  //     return -_test[_i][_qp] * _stoichiometric_coeff * _reaction_coeff[_qp] * 1.0 *
-  //     std::exp(_u[_qp]) * _n_gas[_qp] * _phi[_j][_qp];
-  //   else
-  //     return 0.0;
-  // }
-  // else if (!isCoupled("v") && isCoupled("w"))
-  // {
-  //   if (jvar == _v_id)
-  //     return -_test[_i][_qp] * _stoichiometric_coeff * _reaction_coeff[_qp] * 1.0 *
-  //     std::exp(_u[_qp]) * _n_gas[_qp] * _phi[_j][_qp];
-  //   else
-  //     return 0.0;
-  // }
-  // else
-  // {
-  //   return 0.0;
-  // }
 }


### PR DESCRIPTION
This PR has a few substantial updates. The largest one is a new Action syntax that allows multiple action blocks to be added like so: 

[Reactions]
  [./block0]
    species = ...
    reactions = ...
    block = 0
  [../]

  [./block1]
    ...
    block = 1
  [../]
[]

**Note: right now this is exclusively for Zapdos actions (e.g. it uses the AddZapdosReaction class). I'd like to make this syntax applicable to the other classes, but Zapdos is the most important use case at the moment.**

Other important changes: 

1. **References to the material property _n_gas were removed.** All reactants **must** be either nonlinear or auxiliary variables now. It didn't make sense to refer to "n_gas" for reactions in water, for example.

2. **Kernel off-diagonal Jacobian bug fixes.** Found a few small errors in some of the Kernels. They were only producing small errors according to the Python jacobian checking script (on the order of ~2%), but it was still having a noticeable effect on the number of nonlinear iterations. They should be correct now. 