### PR TITLE
Adding kernels for electron-impact reactions under the Townsend formulation

### DIFF
--- a/include/kernels/ElectronEnergyTermElasticTownsend.h
+++ b/include/kernels/ElectronEnergyTermElasticTownsend.h
@@ -30,14 +30,14 @@ protected:
   virtual Real computeQpOffDiagJacobian(unsigned int jvar);
 
   Real _r_units;
-  std::string _reaction_coeff_name; 
+  std::string _reaction_coeff_name;
   const MaterialProperty<Real> & _diffem;
   const MaterialProperty<Real> & _muem;
   const MaterialProperty<Real> & _alpha;
   const MaterialProperty<Real> & _d_iz_d_actual_mean_en;
   const MaterialProperty<Real> & _d_muem_d_actual_mean_en;
   const MaterialProperty<Real> & _d_diffem_d_actual_mean_en;
-  //const MaterialProperty<Real> & _massem;
+  // const MaterialProperty<Real> & _massem;
   const MaterialProperty<Real> & _massGas;
   const MaterialProperty<Real> & _d_el_d_actual_mean_en;
 

--- a/include/kernels/ElectronEnergyTermElasticTownsend.h
+++ b/include/kernels/ElectronEnergyTermElasticTownsend.h
@@ -1,0 +1,52 @@
+//* This file is part of Zapdos, an open-source
+//* application for the simulation of plasmas
+//* https://github.com/shannon-lab/zapdos
+//*
+//* Zapdos is powered by the MOOSE Framework
+//* https://www.mooseframework.org
+//*
+//* Licensed under LGPL 2.1, please see LICENSE for details
+//* https://www.gnu.org/licenses/lgpl-2.1.html
+
+#ifndef ELECTRONENERGYTERMELASTICTOWNSEND_H
+#define ELECTRONENERGYTERMELASTICTOWNSEND_H
+
+#include "Kernel.h"
+
+class ElectronEnergyTermElasticTownsend;
+
+template <>
+InputParameters validParams<ElectronEnergyTermElasticTownsend>();
+
+class ElectronEnergyTermElasticTownsend : public Kernel
+{
+public:
+  ElectronEnergyTermElasticTownsend(const InputParameters & parameters);
+  virtual ~ElectronEnergyTermElasticTownsend();
+
+protected:
+  virtual Real computeQpResidual();
+  virtual Real computeQpJacobian();
+  virtual Real computeQpOffDiagJacobian(unsigned int jvar);
+
+  Real _r_units;
+  std::string _reaction_coeff_name; 
+  const MaterialProperty<Real> & _diffem;
+  const MaterialProperty<Real> & _muem;
+  const MaterialProperty<Real> & _alpha;
+  const MaterialProperty<Real> & _d_iz_d_actual_mean_en;
+  const MaterialProperty<Real> & _d_muem_d_actual_mean_en;
+  const MaterialProperty<Real> & _d_diffem_d_actual_mean_en;
+  //const MaterialProperty<Real> & _massem;
+  const MaterialProperty<Real> & _massGas;
+  const MaterialProperty<Real> & _d_el_d_actual_mean_en;
+
+  const VariableGradient & _grad_potential;
+  const VariableValue & _em;
+  const VariableGradient & _grad_em;
+  unsigned int _potential_id;
+  unsigned int _em_id;
+  Real _massem;
+};
+
+#endif /* ELECTRONENERGYLOSSFROMELASTIC_H */

--- a/include/kernels/ElectronEnergyTermTownsend.h
+++ b/include/kernels/ElectronEnergyTermTownsend.h
@@ -1,0 +1,57 @@
+/****************************************************************/
+/*               DO NOT MODIFY THIS HEADER                      */
+/* MOOSE - Multiphysics Object Oriented Simulation Environment  */
+/*                                                              */
+/*           (c) 2010 Battelle Energy Alliance, LLC             */
+/*                   ALL RIGHTS RESERVED                        */
+/*                                                              */
+/*          Prepared by Battelle Energy Alliance, LLC           */
+/*            Under Contract No. DE-AC07-05ID14517              */
+/*            With the U. S. Department of Energy               */
+/*                                                              */
+/*            See COPYRIGHT for full restrictions               */
+/****************************************************************/
+
+#ifndef ELECTRONENERGYTERMTOWNSEND_H
+#define ELECTRONENERGYTERMTOWNSEND_H
+
+#include "Kernel.h"
+
+class ElectronEnergyTermTownsend;
+
+template <>
+InputParameters validParams<ElectronEnergyTermTownsend>();
+
+class ElectronEnergyTermTownsend : public Kernel
+{
+public:
+  ElectronEnergyTermTownsend(const InputParameters & parameters);
+  virtual ~ElectronEnergyTermTownsend();
+
+protected:
+  virtual Real computeQpResidual();
+  virtual Real computeQpJacobian();
+  virtual Real computeQpOffDiagJacobian(unsigned int jvar);
+
+  Real _r_units;
+
+  bool _elastic;
+  Real _threshold_energy;
+  const MaterialProperty<Real> & _elastic_energy;
+  const MaterialProperty<Real> & _diffem;
+  const MaterialProperty<Real> & _muem;
+  const MaterialProperty<Real> & _alpha;
+  const MaterialProperty<Real> & _d_iz_d_actual_mean_en;
+  const MaterialProperty<Real> & _d_muem_d_actual_mean_en;
+  const MaterialProperty<Real> & _d_diffem_d_actual_mean_en;
+
+  const VariableGradient & _grad_potential;
+  const VariableValue & _em;
+  const VariableGradient & _grad_em;
+  unsigned int _potential_id;
+  unsigned int _em_id;
+
+  Real _energy_change;
+};
+
+#endif /* ELECTRONENERGYTERMTOWNSEND_H */

--- a/include/kernels/ElectronImpactReactionProduct.h
+++ b/include/kernels/ElectronImpactReactionProduct.h
@@ -1,0 +1,56 @@
+/****************************************************************/
+/*               DO NOT MODIFY THIS HEADER                      */
+/* MOOSE - Multiphysics Object Oriented Simulation Environment  */
+/*                                                              */
+/*           (c) 2010 Battelle Energy Alliance, LLC             */
+/*                   ALL RIGHTS RESERVED                        */
+/*                                                              */
+/*          Prepared by Battelle Energy Alliance, LLC           */
+/*            Under Contract No. DE-AC07-05ID14517              */
+/*            With the U. S. Department of Energy               */
+/*                                                              */
+/*            See COPYRIGHT for full restrictions               */
+/****************************************************************/
+
+#ifndef ELECTRONIMPACTREACTIONPRODUCT_H
+#define ELECTRONIMPACTREACTIONPRODUCT_H
+
+#include "Kernel.h"
+
+class ElectronImpactReactionProduct;
+
+template <>
+InputParameters validParams<ElectronImpactReactionProduct>();
+
+class ElectronImpactReactionProduct : public Kernel
+{
+public:
+  ElectronImpactReactionProduct(const InputParameters & parameters);
+  virtual ~ElectronImpactReactionProduct();
+
+protected:
+  virtual Real computeQpResidual();
+  virtual Real computeQpJacobian();
+  virtual Real computeQpOffDiagJacobian(unsigned int jvar);
+
+  Real _r_units;
+  std::string _reaction_coeff_name;
+  std::string _reaction_name;
+
+  const MaterialProperty<Real> & _diffem;
+  const MaterialProperty<Real> & _muem;
+  const MaterialProperty<Real> & _alpha;
+  const MaterialProperty<Real> & _d_iz_d_actual_mean_en;
+  const MaterialProperty<Real> & _d_muem_d_actual_mean_en;
+  const MaterialProperty<Real> & _d_diffem_d_actual_mean_en;
+
+  const VariableValue & _mean_en;
+  const VariableGradient & _grad_potential;
+  const VariableValue & _em;
+  const VariableGradient & _grad_em;
+  unsigned int _mean_en_id;
+  unsigned int _potential_id;
+  unsigned int _em_id;
+};
+
+#endif /* ELECTRONIMPACTREACTIONPRODUCT_H */

--- a/include/kernels/ElectronImpactReactionReactant.h
+++ b/include/kernels/ElectronImpactReactionReactant.h
@@ -51,7 +51,6 @@ protected:
   unsigned int _mean_en_id;
   unsigned int _potential_id;
   unsigned int _em_id;
-
 };
 
 #endif /* ELECTRONIMPACTREACTIONREACTANT_H */

--- a/include/kernels/ElectronImpactReactionReactant.h
+++ b/include/kernels/ElectronImpactReactionReactant.h
@@ -1,0 +1,57 @@
+/****************************************************************/
+/*               DO NOT MODIFY THIS HEADER                      */
+/* MOOSE - Multiphysics Object Oriented Simulation Environment  */
+/*                                                              */
+/*           (c) 2010 Battelle Energy Alliance, LLC             */
+/*                   ALL RIGHTS RESERVED                        */
+/*                                                              */
+/*          Prepared by Battelle Energy Alliance, LLC           */
+/*            Under Contract No. DE-AC07-05ID14517              */
+/*            With the U. S. Department of Energy               */
+/*                                                              */
+/*            See COPYRIGHT for full restrictions               */
+/****************************************************************/
+
+#ifndef ELECTRONIMPACTREACTIONREACTANT_H
+#define ELECTRONIMPACTREACTIONREACTANT_H
+
+#include "Kernel.h"
+
+class ElectronImpactReactionReactant;
+
+template <>
+InputParameters validParams<ElectronImpactReactionReactant>();
+
+class ElectronImpactReactionReactant : public Kernel
+{
+public:
+  ElectronImpactReactionReactant(const InputParameters & parameters);
+  virtual ~ElectronImpactReactionReactant();
+
+protected:
+  virtual Real computeQpResidual();
+  virtual Real computeQpJacobian();
+  virtual Real computeQpOffDiagJacobian(unsigned int jvar);
+
+  Real _r_units;
+  std::string _reaction_coeff_name;
+  std::string _reaction_name;
+
+  const MaterialProperty<Real> & _diffem;
+  const MaterialProperty<Real> & _muem;
+  const MaterialProperty<Real> & _alpha;
+  const MaterialProperty<Real> & _d_iz_d_actual_mean_en;
+  const MaterialProperty<Real> & _d_muem_d_actual_mean_en;
+  const MaterialProperty<Real> & _d_diffem_d_actual_mean_en;
+
+  const VariableValue & _mean_en;
+  const VariableGradient & _grad_potential;
+  const VariableValue & _em;
+  const VariableGradient & _grad_em;
+  unsigned int _mean_en_id;
+  unsigned int _potential_id;
+  unsigned int _em_id;
+
+};
+
+#endif /* ELECTRONIMPACTREACTIONREACTANT_H */

--- a/include/kernels/ElectronReactantSecondOrderLog.h
+++ b/include/kernels/ElectronReactantSecondOrderLog.h
@@ -44,6 +44,5 @@ protected:
   const MaterialProperty<Real> & _n_gas;
   Real _stoichiometric_coeff;
   bool _v_eq_electron;
-
 };
 #endif // ELECTRONREACTANTSECONDORDERLOG_H

--- a/include/materials/EEDFRateConstantTownsend.h
+++ b/include/materials/EEDFRateConstantTownsend.h
@@ -43,7 +43,7 @@ protected:
   MaterialProperty<unsigned int> & _d_alpha_d_var_id;
   MaterialProperty<bool> & _target_coupled;
   bool _is_target_aux;
-//  const MaterialProperty<Real> & _n_gas;
+  //  const MaterialProperty<Real> & _n_gas;
   const MaterialProperty<Real> & _massIncident;
   const MaterialProperty<Real> & _massTarget;
 

--- a/include/materials/EEDFRateConstantTownsend.h
+++ b/include/materials/EEDFRateConstantTownsend.h
@@ -43,7 +43,7 @@ protected:
   MaterialProperty<unsigned int> & _d_alpha_d_var_id;
   MaterialProperty<bool> & _target_coupled;
   bool _is_target_aux;
-  const MaterialProperty<Real> & _n_gas;
+//  const MaterialProperty<Real> & _n_gas;
   const MaterialProperty<Real> & _massIncident;
   const MaterialProperty<Real> & _massTarget;
 

--- a/src/actions/AddZapdosReactions.C
+++ b/src/actions/AddZapdosReactions.C
@@ -552,8 +552,8 @@ AddZapdosReactions::act()
               InputParameters params = _factory.getValidParams(reactant_kernel_name);
               params.set<NonlinearVariableName>("variable") = _species[j];
               params.set<Real>("coefficient") = _species_count[i][j];
-              // std::cout << getParam<std::vector<SubdomainName>>("block")[0] << ", " <<  _species_count[i][j] << std::endl;
-              // mooseError("TESTING");
+              // std::cout << getParam<std::vector<SubdomainName>>("block")[0] << ", " <<
+              // _species_count[i][j] << std::endl; mooseError("TESTING");
               params.set<std::string>("reaction") = _reaction[i];
               if (find_other || find_aux)
               {

--- a/src/kernels/ElectronEnergyTermElasticTownsend.C
+++ b/src/kernels/ElectronEnergyTermElasticTownsend.C
@@ -27,17 +27,18 @@ validParams<ElectronEnergyTermElasticTownsend>()
   return params;
 }
 
-ElectronEnergyTermElasticTownsend::ElectronEnergyTermElasticTownsend(const InputParameters & parameters)
+ElectronEnergyTermElasticTownsend::ElectronEnergyTermElasticTownsend(
+    const InputParameters & parameters)
   : Kernel(parameters),
     _r_units(1. / getParam<Real>("position_units")),
     _diffem(getMaterialProperty<Real>("diffem")),
     _muem(getMaterialProperty<Real>("muem")),
-    _alpha(getMaterialProperty<Real>("alpha_"+getParam<std::string>("reaction"))),
+    _alpha(getMaterialProperty<Real>("alpha_" + getParam<std::string>("reaction"))),
     _d_iz_d_actual_mean_en(getMaterialProperty<Real>("d_iz_d_actual_mean_en")),
     _d_muem_d_actual_mean_en(getMaterialProperty<Real>("d_muem_d_actual_mean_en")),
     _d_diffem_d_actual_mean_en(getMaterialProperty<Real>("d_diffem_d_actual_mean_en")),
-//    _massem(getMaterialProperty<Real>("mass" + (*getVar("electron_species",0)).name())),
-    _massGas(getMaterialProperty<Real>("mass" + (*getVar("target_species",0)).name())),
+    //    _massem(getMaterialProperty<Real>("mass" + (*getVar("electron_species",0)).name())),
+    _massGas(getMaterialProperty<Real>("mass" + (*getVar("target_species", 0)).name())),
     _d_el_d_actual_mean_en(getMaterialProperty<Real>("d_el_d_actual_mean_en")),
     _grad_potential(coupledGradient("potential")),
     _em(coupledValue("electron_species")),
@@ -58,7 +59,7 @@ ElectronEnergyTermElasticTownsend::computeQpResidual()
                                .norm();
   Real Eel = -3.0 * _massem / _massGas[_qp] * 2.0 / 3 * std::exp(_u[_qp] - _em[_qp]);
   Real el_term = _alpha[_qp] * electron_flux_mag * Eel;
-  
+
   return -_test[_i][_qp] * el_term;
 }
 

--- a/src/kernels/ElectronEnergyTermElasticTownsend.C
+++ b/src/kernels/ElectronEnergyTermElasticTownsend.C
@@ -1,0 +1,137 @@
+//* This file is part of CRANE, an open-source
+//* application for the simulation of plasmas
+//* https://github.com/lcpp-org/crane
+//*
+//* CRANE is powered by the MOOSE Framework
+//* https://www.mooseframework.org
+//*
+//* Licensed under LGPL 2.1, please see LICENSE for details
+//* https://www.gnu.org/licenses/lgpl-2.1.html
+
+#include "ElectronEnergyTermElasticTownsend.h"
+
+registerMooseObject("CraneApp", ElectronEnergyTermElasticTownsend);
+
+template <>
+InputParameters
+validParams<ElectronEnergyTermElasticTownsend>()
+{
+  InputParameters params = validParams<Kernel>();
+  params.addRequiredCoupledVar("potential", "The potential.");
+  params.addRequiredCoupledVar("electron_species", "The electron density.");
+  params.addRequiredCoupledVar("target_species", "The target species variable.");
+  params.addRequiredParam<std::string>("reaction",
+                                       "Stores the name of the reaction (townsend) coefficient, "
+                                       "unique to each individual reaction.");
+  params.addRequiredParam<Real>("position_units", "Units of position.");
+  return params;
+}
+
+ElectronEnergyTermElasticTownsend::ElectronEnergyTermElasticTownsend(const InputParameters & parameters)
+  : Kernel(parameters),
+    _r_units(1. / getParam<Real>("position_units")),
+    _diffem(getMaterialProperty<Real>("diffem")),
+    _muem(getMaterialProperty<Real>("muem")),
+    _alpha(getMaterialProperty<Real>("alpha_"+getParam<std::string>("reaction"))),
+    _d_iz_d_actual_mean_en(getMaterialProperty<Real>("d_iz_d_actual_mean_en")),
+    _d_muem_d_actual_mean_en(getMaterialProperty<Real>("d_muem_d_actual_mean_en")),
+    _d_diffem_d_actual_mean_en(getMaterialProperty<Real>("d_diffem_d_actual_mean_en")),
+//    _massem(getMaterialProperty<Real>("mass" + (*getVar("electron_species",0)).name())),
+    _massGas(getMaterialProperty<Real>("mass" + (*getVar("target_species",0)).name())),
+    _d_el_d_actual_mean_en(getMaterialProperty<Real>("d_el_d_actual_mean_en")),
+    _grad_potential(coupledGradient("potential")),
+    _em(coupledValue("electron_species")),
+    _grad_em(coupledGradient("electron_species")),
+    _potential_id(coupled("potential")),
+    _em_id(coupled("electron_species"))
+{
+  _massem = 9.11e-31;
+}
+
+ElectronEnergyTermElasticTownsend::~ElectronEnergyTermElasticTownsend() {}
+
+Real
+ElectronEnergyTermElasticTownsend::computeQpResidual()
+{
+  Real electron_flux_mag = (-_muem[_qp] * -_grad_potential[_qp] * _r_units * std::exp(_em[_qp]) -
+                            _diffem[_qp] * std::exp(_em[_qp]) * _grad_em[_qp] * _r_units)
+                               .norm();
+  Real Eel = -3.0 * _massem / _massGas[_qp] * 2.0 / 3 * std::exp(_u[_qp] - _em[_qp]);
+  Real el_term = _alpha[_qp] * electron_flux_mag * Eel;
+  
+  return -_test[_i][_qp] * el_term;
+}
+
+Real
+ElectronEnergyTermElasticTownsend::computeQpJacobian()
+{
+  Real d_actual_mean_en_d_mean_en = std::exp(_u[_qp] - _em[_qp]) * _phi[_j][_qp];
+  Real d_el_d_mean_en = _d_el_d_actual_mean_en[_qp] * d_actual_mean_en_d_mean_en;
+  Real d_muem_d_mean_en = _d_muem_d_actual_mean_en[_qp] * d_actual_mean_en_d_mean_en;
+  Real d_diffem_d_mean_en = _d_diffem_d_actual_mean_en[_qp] * d_actual_mean_en_d_mean_en;
+
+  RealVectorValue electron_flux =
+      -_muem[_qp] * -_grad_potential[_qp] * _r_units * std::exp(_em[_qp]) -
+      _diffem[_qp] * std::exp(_em[_qp]) * _grad_em[_qp] * _r_units;
+  RealVectorValue d_electron_flux_d_mean_en =
+      -d_muem_d_mean_en * -_grad_potential[_qp] * _r_units * std::exp(_em[_qp]) -
+      d_diffem_d_mean_en * std::exp(_em[_qp]) * _grad_em[_qp] * _r_units;
+  Real electron_flux_mag = electron_flux.norm();
+  Real d_electron_flux_mag_d_mean_en = electron_flux * d_electron_flux_d_mean_en /
+                                       (electron_flux_mag + std::numeric_limits<double>::epsilon());
+
+  Real Eel = -3.0 * _massem / _massGas[_qp] * 2.0 / 3 * std::exp(_u[_qp] - _em[_qp]);
+  Real d_Eel_d_mean_en =
+      -3.0 * _massem / _massGas[_qp] * 2.0 / 3 * std::exp(_u[_qp] - _em[_qp]) * _phi[_j][_qp];
+  Real d_el_term_d_mean_en =
+      (electron_flux_mag * d_el_d_mean_en + _alpha[_qp] * d_electron_flux_mag_d_mean_en) * Eel +
+      electron_flux_mag * _alpha[_qp] * d_Eel_d_mean_en;
+
+  return -_test[_i][_qp] * d_el_term_d_mean_en;
+}
+
+Real
+ElectronEnergyTermElasticTownsend::computeQpOffDiagJacobian(unsigned int jvar)
+{
+  Real d_actual_mean_en_d_em = -std::exp(_u[_qp] - _em[_qp]) * _phi[_j][_qp];
+  Real d_el_d_em = _d_el_d_actual_mean_en[_qp] * d_actual_mean_en_d_em;
+  Real d_muem_d_em = _d_muem_d_actual_mean_en[_qp] * d_actual_mean_en_d_em;
+  Real d_diffem_d_em = _d_diffem_d_actual_mean_en[_qp] * d_actual_mean_en_d_em;
+
+  RealVectorValue electron_flux =
+      -_muem[_qp] * -_grad_potential[_qp] * _r_units * std::exp(_em[_qp]) -
+      _diffem[_qp] * std::exp(_em[_qp]) * _grad_em[_qp] * _r_units;
+  RealVectorValue d_electron_flux_d_potential =
+      -_muem[_qp] * -_grad_phi[_j][_qp] * _r_units * std::exp(_em[_qp]);
+  RealVectorValue d_electron_flux_d_em =
+      -d_muem_d_em * -_grad_potential[_qp] * _r_units * std::exp(_em[_qp]) -
+      _muem[_qp] * -_grad_potential[_qp] * _r_units * std::exp(_em[_qp]) * _phi[_j][_qp] -
+      d_diffem_d_em * std::exp(_em[_qp]) * _grad_em[_qp] * _r_units -
+      _diffem[_qp] * std::exp(_em[_qp]) * _phi[_j][_qp] * _grad_em[_qp] * _r_units -
+      _diffem[_qp] * std::exp(_em[_qp]) * _grad_phi[_j][_qp] * _r_units;
+  Real electron_flux_mag = electron_flux.norm();
+  Real d_electron_flux_mag_d_potential =
+      electron_flux * d_electron_flux_d_potential /
+      (electron_flux_mag + std::numeric_limits<double>::epsilon());
+  Real d_electron_flux_mag_d_em = electron_flux * d_electron_flux_d_em /
+                                  (electron_flux_mag + std::numeric_limits<double>::epsilon());
+
+  Real Eel = -3.0 * _massem / _massGas[_qp] * 2.0 / 3 * std::exp(_u[_qp] - _em[_qp]);
+  Real d_Eel_d_em =
+      -3.0 * _massem / _massGas[_qp] * 2.0 / 3 * std::exp(_u[_qp] - _em[_qp]) * -_phi[_j][_qp];
+  Real d_Eel_d_potential = 0.0;
+  Real d_el_term_d_em =
+      (electron_flux_mag * d_el_d_em + _alpha[_qp] * d_electron_flux_mag_d_em) * Eel +
+      electron_flux_mag * _alpha[_qp] * d_Eel_d_em;
+  Real d_el_term_d_potential = (_alpha[_qp] * d_electron_flux_mag_d_potential) * Eel +
+                               electron_flux_mag * _alpha[_qp] * d_Eel_d_potential;
+
+  if (jvar == _potential_id)
+    return -_test[_i][_qp] * d_el_term_d_potential;
+
+  else if (jvar == _em_id)
+    return -_test[_i][_qp] * d_el_term_d_em;
+
+  else
+    return 0.0;
+}

--- a/src/kernels/ElectronEnergyTermTownsend.C
+++ b/src/kernels/ElectronEnergyTermTownsend.C
@@ -1,0 +1,124 @@
+#include "ElectronEnergyTermTownsend.h"
+
+registerMooseObject("CraneApp", ElectronEnergyTermTownsend);
+
+template <>
+InputParameters
+validParams<ElectronEnergyTermTownsend>()
+{
+  InputParameters params = validParams<Kernel>();
+  params.addCoupledVar("potential", "The potential.");
+  params.addRequiredCoupledVar("em", "The electron density.");
+  params.addParam<bool>("elastic_collision", false, "If the collision is elastic.");
+  params.addRequiredParam<std::string>("reaction", "The reaction that is adding/removing energy.");
+  params.addParam<Real>("threshold_energy", 0.0, "Energy required for reaction to take place.");
+  params.addRequiredParam<Real>("position_units", "Units of position.");
+  return params;
+}
+
+ElectronEnergyTermTownsend::ElectronEnergyTermTownsend(
+    const InputParameters & parameters)
+  : Kernel(parameters),
+    _r_units(1. / getParam<Real>("position_units")),
+    _elastic(getParam<bool>("elastic_collision")),
+    _threshold_energy(getParam<Real>("threshold_energy")),
+    _elastic_energy(getMaterialProperty<Real>("energy_elastic_"+getParam<std::string>("reaction"))),
+    _diffem(getMaterialProperty<Real>("diffem")),
+    _muem(getMaterialProperty<Real>("muem")),
+    _alpha(getMaterialProperty<Real>("alpha_"+getParam<std::string>("reaction"))),
+    // _d_iz_d_actual_mean_en(getMaterialProperty<Real>("d_alpha_d_en_em + Ar = em + em + Arp")),
+    _d_iz_d_actual_mean_en(getMaterialProperty<Real>("d_alpha_d_en_"+getParam<std::string>("reaction"))),
+    _d_muem_d_actual_mean_en(getMaterialProperty<Real>("d_muem_d_actual_mean_en")),
+    _d_diffem_d_actual_mean_en(getMaterialProperty<Real>("d_diffem_d_actual_mean_en")),
+    _grad_potential(isCoupled("potential") ? coupledGradient("potential") : _grad_zero),
+    _em(coupledValue("em")),
+    _grad_em(coupledGradient("em")),
+    _potential_id(coupled("potential")),
+    _em_id(coupled("em"))
+{
+  if (!_elastic && !isParamValid("threshold_energy"))
+    mooseError("ElectronEnergyTermTownsend: Elastic collision set to false, but no threshold energy for this reaction is provided!");
+  // else if (_elastic)
+    // _energy_change = _elastic_energy[_qp];
+  // else
+    _energy_change = _threshold_energy;
+}
+
+ElectronEnergyTermTownsend::~ElectronEnergyTermTownsend() {}
+
+Real
+ElectronEnergyTermTownsend::computeQpResidual()
+{
+  Real electron_flux_mag = (-_muem[_qp] * -_grad_potential[_qp] * _r_units * std::exp(_em[_qp]) -
+                            _diffem[_qp] * std::exp(_em[_qp]) * _grad_em[_qp] * _r_units)
+                               .norm();
+  Real iz_term = _alpha[_qp] * electron_flux_mag;
+
+  return -_test[_i][_qp] * iz_term * _threshold_energy;
+}
+
+Real
+ElectronEnergyTermTownsend::computeQpJacobian()
+{
+  Real actual_mean_en = std::exp(_u[_qp] - _em[_qp]);
+  Real d_actual_mean_en_d_mean_en = std::exp(_u[_qp] - _em[_qp]) * _phi[_j][_qp];
+  Real d_iz_d_mean_en = _d_iz_d_actual_mean_en[_qp] * d_actual_mean_en_d_mean_en;
+  Real d_muem_d_mean_en = _d_muem_d_actual_mean_en[_qp] * d_actual_mean_en_d_mean_en;
+  Real d_diffem_d_mean_en = _d_diffem_d_actual_mean_en[_qp] * d_actual_mean_en_d_mean_en;
+
+  RealVectorValue electron_flux =
+      -_muem[_qp] * -_grad_potential[_qp] * _r_units * std::exp(_em[_qp]) -
+      _diffem[_qp] * std::exp(_em[_qp]) * _grad_em[_qp] * _r_units;
+  RealVectorValue d_electron_flux_d_mean_en =
+      -d_muem_d_mean_en * -_grad_potential[_qp] * _r_units * std::exp(_em[_qp]) -
+      d_diffem_d_mean_en * std::exp(_em[_qp]) * _grad_em[_qp] * _r_units;
+  Real electron_flux_mag = electron_flux.norm();
+  Real d_electron_flux_mag_d_mean_en = electron_flux * d_electron_flux_d_mean_en /
+                                       (electron_flux_mag + std::numeric_limits<double>::epsilon());
+  Real d_iz_term_d_mean_en =
+      (electron_flux_mag * d_iz_d_mean_en + _alpha[_qp] * d_electron_flux_mag_d_mean_en);
+
+  return -_test[_i][_qp] * d_iz_term_d_mean_en * _threshold_energy;
+}
+
+Real
+ElectronEnergyTermTownsend::computeQpOffDiagJacobian(unsigned int jvar)
+{
+  Real actual_mean_en = std::exp(_u[_qp] - _em[_qp]);
+  Real d_actual_mean_en_d_em = -std::exp(_u[_qp] - _em[_qp]) * _phi[_j][_qp];
+  Real d_iz_d_em = _d_iz_d_actual_mean_en[_qp] * d_actual_mean_en_d_em;
+  Real d_muem_d_em = _d_muem_d_actual_mean_en[_qp] * d_actual_mean_en_d_em;
+  Real d_diffem_d_em = _d_diffem_d_actual_mean_en[_qp] * d_actual_mean_en_d_em;
+
+  RealVectorValue electron_flux =
+      -_muem[_qp] * -_grad_potential[_qp] * _r_units * std::exp(_em[_qp]) -
+      _diffem[_qp] * std::exp(_em[_qp]) * _grad_em[_qp] * _r_units;
+  RealVectorValue d_electron_flux_d_potential =
+      -_muem[_qp] * -_grad_phi[_j][_qp] * _r_units * std::exp(_em[_qp]);
+  RealVectorValue d_electron_flux_d_em =
+      -d_muem_d_em * -_grad_potential[_qp] * _r_units * std::exp(_em[_qp]) -
+      _muem[_qp] * -_grad_potential[_qp] * _r_units * std::exp(_em[_qp]) * _phi[_j][_qp] -
+      d_diffem_d_em * std::exp(_em[_qp]) * _grad_em[_qp] * _r_units -
+      _diffem[_qp] * std::exp(_em[_qp]) * _phi[_j][_qp] * _grad_em[_qp] * _r_units -
+      _diffem[_qp] * std::exp(_em[_qp]) * _grad_phi[_j][_qp] * _r_units;
+  Real electron_flux_mag = electron_flux.norm();
+  Real d_electron_flux_mag_d_potential =
+      electron_flux * d_electron_flux_d_potential /
+      (electron_flux_mag + std::numeric_limits<double>::epsilon());
+  Real d_electron_flux_mag_d_em = electron_flux * d_electron_flux_d_em /
+                                  (electron_flux_mag + std::numeric_limits<double>::epsilon());
+
+  Real d_iz_term_d_potential = (_alpha[_qp] * d_electron_flux_mag_d_potential);
+  Real d_iz_term_d_em = (electron_flux_mag * d_iz_d_em + _alpha[_qp] * d_electron_flux_mag_d_em);
+
+  if (jvar == _potential_id)
+    return -_test[_i][_qp] * d_iz_term_d_potential * _threshold_energy;
+
+  else if (jvar == _em_id)
+  {
+    return -_test[_i][_qp] * d_iz_term_d_em * _threshold_energy;
+  }
+
+  else
+    return 0.0;
+}

--- a/src/kernels/ElectronEnergyTermTownsend.C
+++ b/src/kernels/ElectronEnergyTermTownsend.C
@@ -16,18 +16,19 @@ validParams<ElectronEnergyTermTownsend>()
   return params;
 }
 
-ElectronEnergyTermTownsend::ElectronEnergyTermTownsend(
-    const InputParameters & parameters)
+ElectronEnergyTermTownsend::ElectronEnergyTermTownsend(const InputParameters & parameters)
   : Kernel(parameters),
     _r_units(1. / getParam<Real>("position_units")),
     _elastic(getParam<bool>("elastic_collision")),
     _threshold_energy(getParam<Real>("threshold_energy")),
-    _elastic_energy(getMaterialProperty<Real>("energy_elastic_"+getParam<std::string>("reaction"))),
+    _elastic_energy(
+        getMaterialProperty<Real>("energy_elastic_" + getParam<std::string>("reaction"))),
     _diffem(getMaterialProperty<Real>("diffem")),
     _muem(getMaterialProperty<Real>("muem")),
-    _alpha(getMaterialProperty<Real>("alpha_"+getParam<std::string>("reaction"))),
+    _alpha(getMaterialProperty<Real>("alpha_" + getParam<std::string>("reaction"))),
     // _d_iz_d_actual_mean_en(getMaterialProperty<Real>("d_alpha_d_en_em + Ar = em + em + Arp")),
-    _d_iz_d_actual_mean_en(getMaterialProperty<Real>("d_alpha_d_en_"+getParam<std::string>("reaction"))),
+    _d_iz_d_actual_mean_en(
+        getMaterialProperty<Real>("d_alpha_d_en_" + getParam<std::string>("reaction"))),
     _d_muem_d_actual_mean_en(getMaterialProperty<Real>("d_muem_d_actual_mean_en")),
     _d_diffem_d_actual_mean_en(getMaterialProperty<Real>("d_diffem_d_actual_mean_en")),
     _grad_potential(isCoupled("potential") ? coupledGradient("potential") : _grad_zero),
@@ -37,11 +38,12 @@ ElectronEnergyTermTownsend::ElectronEnergyTermTownsend(
     _em_id(coupled("em"))
 {
   if (!_elastic && !isParamValid("threshold_energy"))
-    mooseError("ElectronEnergyTermTownsend: Elastic collision set to false, but no threshold energy for this reaction is provided!");
+    mooseError("ElectronEnergyTermTownsend: Elastic collision set to false, but no threshold "
+               "energy for this reaction is provided!");
   // else if (_elastic)
-    // _energy_change = _elastic_energy[_qp];
+  // _energy_change = _elastic_energy[_qp];
   // else
-    _energy_change = _threshold_energy;
+  _energy_change = _threshold_energy;
 }
 
 ElectronEnergyTermTownsend::~ElectronEnergyTermTownsend() {}

--- a/src/kernels/ElectronImpactReactionProduct.C
+++ b/src/kernels/ElectronImpactReactionProduct.C
@@ -16,7 +16,8 @@ validParams<ElectronImpactReactionProduct>()
   params.addRequiredParam<Real>("position_units", "Units of position.");
   params.addRequiredParam<std::string>("reaction", "Stores the full reaction equation.");
   params.addRequiredParam<std::string>("reaction_coefficient_name",
-    "Stores the name of the reaction rate/townsend coefficient, unique to each individual reaction.");
+                                       "Stores the name of the reaction rate/townsend coefficient, "
+                                       "unique to each individual reaction.");
   return params;
 }
 
@@ -31,7 +32,7 @@ ElectronImpactReactionProduct::ElectronImpactReactionProduct(const InputParamete
     // _alpha(getMaterialProperty<Real>("alpha_iz")),
     _alpha(getMaterialProperty<Real>(_reaction_coeff_name)),
     // _d_iz_d_actual_mean_en(getMaterialProperty<Real>("d_iz_d_actual_mean_en")),
-    _d_iz_d_actual_mean_en(getMaterialProperty<Real>("d_alpha_d_en_"+_reaction_name)),
+    _d_iz_d_actual_mean_en(getMaterialProperty<Real>("d_alpha_d_en_" + _reaction_name)),
     _d_muem_d_actual_mean_en(getMaterialProperty<Real>("d_muem_d_actual_mean_en")),
     _d_diffem_d_actual_mean_en(getMaterialProperty<Real>("d_diffem_d_actual_mean_en")),
     _mean_en(coupledValue("mean_en")),
@@ -64,8 +65,8 @@ ElectronImpactReactionProduct::computeQpResidual()
   // Real iz_term = _alpha_iz[_qp] * electron_flux_mag;
   // Real iz_term = alpha * electron_flux_mag;
 
-    // return -_test[_i][_qp] * iz_term;
-    return -_test[_i][_qp] * _alpha[_qp] * electron_flux_mag;
+  // return -_test[_i][_qp] * iz_term;
+  return -_test[_i][_qp] * _alpha[_qp] * electron_flux_mag;
 }
 
 Real
@@ -93,8 +94,7 @@ ElectronImpactReactionProduct::computeQpJacobian()
     Real d_electron_flux_mag_d_em = electron_flux * d_electron_flux_d_em /
                                     (electron_flux_mag + std::numeric_limits<double>::epsilon());
 
-    Real d_iz_term_d_em =
-        (electron_flux_mag * d_iz_d_em + _alpha[_qp] * d_electron_flux_mag_d_em);
+    Real d_iz_term_d_em = (electron_flux_mag * d_iz_d_em + _alpha[_qp] * d_electron_flux_mag_d_em);
 
     return -_test[_i][_qp] * d_iz_term_d_em;
   }
@@ -144,13 +144,13 @@ ElectronImpactReactionProduct::computeQpOffDiagJacobian(unsigned int jvar)
   // Real d_iz_term_d_potential = (_alpha_iz[_qp] * d_electron_flux_mag_d_potential);
   // Real d_iz_term_d_mean_en =
   //     (electron_flux_mag * d_iz_d_mean_en + _alpha_iz[_qp] * d_electron_flux_mag_d_mean_en);
-  // Real d_iz_term_d_em = (electron_flux_mag * d_iz_d_em + _alpha_iz[_qp] * d_electron_flux_mag_d_em);
+  // Real d_iz_term_d_em = (electron_flux_mag * d_iz_d_em + _alpha_iz[_qp] *
+  // d_electron_flux_mag_d_em);
 
   Real d_iz_term_d_potential = (_alpha[_qp] * d_electron_flux_mag_d_potential);
   Real d_iz_term_d_mean_en =
       (electron_flux_mag * d_iz_d_mean_en + _alpha[_qp] * d_electron_flux_mag_d_mean_en);
   Real d_iz_term_d_em = (electron_flux_mag * d_iz_d_em + _alpha[_qp] * d_electron_flux_mag_d_em);
-
 
   if (jvar == _potential_id)
     return -_test[_i][_qp] * d_iz_term_d_potential;
@@ -175,5 +175,4 @@ ElectronImpactReactionProduct::computeQpOffDiagJacobian(unsigned int jvar)
   //
   // else
   //   return 0.0;
-
 }

--- a/src/kernels/ElectronImpactReactionProduct.C
+++ b/src/kernels/ElectronImpactReactionProduct.C
@@ -1,0 +1,179 @@
+#include "ElectronImpactReactionProduct.h"
+
+// MOOSE includes
+#include "MooseVariable.h"
+
+registerMooseObject("CraneApp", ElectronImpactReactionProduct);
+
+template <>
+InputParameters
+validParams<ElectronImpactReactionProduct>()
+{
+  InputParameters params = validParams<Kernel>();
+  params.addRequiredCoupledVar("mean_en", "The electron mean energy.");
+  params.addRequiredCoupledVar("potential", "The potential.");
+  params.addRequiredCoupledVar("em", "The electron density.");
+  params.addRequiredParam<Real>("position_units", "Units of position.");
+  params.addRequiredParam<std::string>("reaction", "Stores the full reaction equation.");
+  params.addRequiredParam<std::string>("reaction_coefficient_name",
+    "Stores the name of the reaction rate/townsend coefficient, unique to each individual reaction.");
+  return params;
+}
+
+ElectronImpactReactionProduct::ElectronImpactReactionProduct(const InputParameters & parameters)
+  : Kernel(parameters),
+
+    _r_units(1. / getParam<Real>("position_units")),
+    _reaction_coeff_name(getParam<std::string>("reaction_coefficient_name")),
+    _reaction_name(getParam<std::string>("reaction")),
+    _diffem(getMaterialProperty<Real>("diffem")),
+    _muem(getMaterialProperty<Real>("muem")),
+    // _alpha(getMaterialProperty<Real>("alpha_iz")),
+    _alpha(getMaterialProperty<Real>(_reaction_coeff_name)),
+    // _d_iz_d_actual_mean_en(getMaterialProperty<Real>("d_iz_d_actual_mean_en")),
+    _d_iz_d_actual_mean_en(getMaterialProperty<Real>("d_alpha_d_en_"+_reaction_name)),
+    _d_muem_d_actual_mean_en(getMaterialProperty<Real>("d_muem_d_actual_mean_en")),
+    _d_diffem_d_actual_mean_en(getMaterialProperty<Real>("d_diffem_d_actual_mean_en")),
+    _mean_en(coupledValue("mean_en")),
+    _grad_potential(coupledGradient("potential")),
+    _em(coupledValue("em")),
+    _grad_em(coupledGradient("em")),
+    _mean_en_id(coupled("mean_en")),
+    _potential_id(coupled("potential")),
+    _em_id(coupled("em"))
+{
+}
+
+ElectronImpactReactionProduct::~ElectronImpactReactionProduct() {}
+
+Real
+ElectronImpactReactionProduct::computeQpResidual()
+{
+  Real electron_flux_mag = (-_muem[_qp] * -_grad_potential[_qp] * _r_units * std::exp(_em[_qp]) -
+                            _diffem[_qp] * std::exp(_em[_qp]) * _grad_em[_qp] * _r_units)
+                               .norm();
+
+  // std::cout << _alpha_sink[_qp] << std::endl;
+  // std::cout << _alpha_source[_qp] << "\n" << std::endl;
+
+  // if (_reactant)
+  //   Real alpha = _alpha_sink[_qp];
+  // else
+  //   Real alpha = _alpha_source[_qp];
+
+  // Real iz_term = _alpha_iz[_qp] * electron_flux_mag;
+  // Real iz_term = alpha * electron_flux_mag;
+
+    // return -_test[_i][_qp] * iz_term;
+    return -_test[_i][_qp] * _alpha[_qp] * electron_flux_mag;
+}
+
+Real
+ElectronImpactReactionProduct::computeQpJacobian()
+{
+  if (_var.number() == _em_id)
+  {
+    Real actual_mean_en = std::exp(_mean_en[_qp] - _em[_qp]);
+    Real d_actual_mean_en_d_em = -std::exp(_mean_en[_qp] - _em[_qp]) * _phi[_j][_qp];
+
+    Real d_iz_d_em = _d_iz_d_actual_mean_en[_qp] * actual_mean_en * -_phi[_j][_qp];
+    Real d_muem_d_em = _d_muem_d_actual_mean_en[_qp] * actual_mean_en * -_phi[_j][_qp];
+    Real d_diffem_d_em = _d_diffem_d_actual_mean_en[_qp] * actual_mean_en * -_phi[_j][_qp];
+
+    RealVectorValue electron_flux =
+        -_muem[_qp] * -_grad_potential[_qp] * _r_units * std::exp(_em[_qp]) -
+        _diffem[_qp] * std::exp(_em[_qp]) * _grad_em[_qp] * _r_units;
+    RealVectorValue d_electron_flux_d_em =
+        -d_muem_d_em * -_grad_potential[_qp] * _r_units * std::exp(_em[_qp]) -
+        _muem[_qp] * -_grad_potential[_qp] * _r_units * std::exp(_em[_qp]) * _phi[_j][_qp] -
+        d_diffem_d_em * std::exp(_em[_qp]) * _grad_em[_qp] * _r_units -
+        _diffem[_qp] * std::exp(_em[_qp]) * _phi[_j][_qp] * _grad_em[_qp] * _r_units -
+        _diffem[_qp] * std::exp(_em[_qp]) * _grad_phi[_j][_qp] * _r_units;
+    Real electron_flux_mag = electron_flux.norm();
+    Real d_electron_flux_mag_d_em = electron_flux * d_electron_flux_d_em /
+                                    (electron_flux_mag + std::numeric_limits<double>::epsilon());
+
+    Real d_iz_term_d_em =
+        (electron_flux_mag * d_iz_d_em + _alpha[_qp] * d_electron_flux_mag_d_em);
+
+    return -_test[_i][_qp] * d_iz_term_d_em;
+  }
+  else
+    return 0;
+}
+
+Real
+ElectronImpactReactionProduct::computeQpOffDiagJacobian(unsigned int jvar)
+{
+  // Define multiplication factor (determining if product or reactant)
+
+  Real actual_mean_en = std::exp(_mean_en[_qp] - _em[_qp]);
+  Real d_actual_mean_en_d_mean_en = std::exp(_mean_en[_qp] - _em[_qp]) * _phi[_j][_qp];
+  Real d_actual_mean_en_d_em = -std::exp(_mean_en[_qp] - _em[_qp]) * _phi[_j][_qp];
+
+  Real d_iz_d_mean_en = _d_iz_d_actual_mean_en[_qp] * actual_mean_en * _phi[_j][_qp];
+  Real d_iz_d_em = _d_iz_d_actual_mean_en[_qp] * actual_mean_en * -_phi[_j][_qp];
+  Real d_muem_d_mean_en = _d_muem_d_actual_mean_en[_qp] * actual_mean_en * _phi[_j][_qp];
+  Real d_muem_d_em = _d_muem_d_actual_mean_en[_qp] * actual_mean_en * -_phi[_j][_qp];
+  Real d_diffem_d_mean_en = _d_diffem_d_actual_mean_en[_qp] * actual_mean_en * _phi[_j][_qp];
+  Real d_diffem_d_em = _d_diffem_d_actual_mean_en[_qp] * actual_mean_en * -_phi[_j][_qp];
+
+  RealVectorValue electron_flux =
+      -_muem[_qp] * -_grad_potential[_qp] * _r_units * std::exp(_em[_qp]) -
+      _diffem[_qp] * std::exp(_em[_qp]) * _grad_em[_qp] * _r_units;
+  RealVectorValue d_electron_flux_d_potential =
+      -_muem[_qp] * -_grad_phi[_j][_qp] * _r_units * std::exp(_em[_qp]);
+  RealVectorValue d_electron_flux_d_mean_en =
+      -d_muem_d_mean_en * -_grad_potential[_qp] * _r_units * std::exp(_em[_qp]) -
+      d_diffem_d_mean_en * std::exp(_em[_qp]) * _grad_em[_qp] * _r_units;
+  RealVectorValue d_electron_flux_d_em =
+      -d_muem_d_em * -_grad_potential[_qp] * _r_units * std::exp(_em[_qp]) -
+      _muem[_qp] * -_grad_potential[_qp] * _r_units * std::exp(_em[_qp]) * _phi[_j][_qp] -
+      d_diffem_d_em * std::exp(_em[_qp]) * _grad_em[_qp] * _r_units -
+      _diffem[_qp] * std::exp(_em[_qp]) * _phi[_j][_qp] * _grad_em[_qp] * _r_units -
+      _diffem[_qp] * std::exp(_em[_qp]) * _grad_phi[_j][_qp] * _r_units;
+  Real electron_flux_mag = electron_flux.norm();
+  Real d_electron_flux_mag_d_potential =
+      electron_flux * d_electron_flux_d_potential /
+      (electron_flux_mag + std::numeric_limits<double>::epsilon());
+  Real d_electron_flux_mag_d_mean_en = electron_flux * d_electron_flux_d_mean_en /
+                                       (electron_flux_mag + std::numeric_limits<double>::epsilon());
+  Real d_electron_flux_mag_d_em = electron_flux * d_electron_flux_d_em /
+                                  (electron_flux_mag + std::numeric_limits<double>::epsilon());
+
+  // Real d_iz_term_d_potential = (_alpha_iz[_qp] * d_electron_flux_mag_d_potential);
+  // Real d_iz_term_d_mean_en =
+  //     (electron_flux_mag * d_iz_d_mean_en + _alpha_iz[_qp] * d_electron_flux_mag_d_mean_en);
+  // Real d_iz_term_d_em = (electron_flux_mag * d_iz_d_em + _alpha_iz[_qp] * d_electron_flux_mag_d_em);
+
+  Real d_iz_term_d_potential = (_alpha[_qp] * d_electron_flux_mag_d_potential);
+  Real d_iz_term_d_mean_en =
+      (electron_flux_mag * d_iz_d_mean_en + _alpha[_qp] * d_electron_flux_mag_d_mean_en);
+  Real d_iz_term_d_em = (electron_flux_mag * d_iz_d_em + _alpha[_qp] * d_electron_flux_mag_d_em);
+
+
+  if (jvar == _potential_id)
+    return -_test[_i][_qp] * d_iz_term_d_potential;
+
+  else if (jvar == _mean_en_id)
+    return -_test[_i][_qp] * d_iz_term_d_mean_en;
+
+  else if (jvar == _em_id)
+    return -_test[_i][_qp] * d_iz_term_d_em;
+
+  else
+    return 0.0;
+
+  // if (jvar == _potential_id)
+  //   return -_test[_i][_qp] * d_iz_term_d_potential;
+  //
+  // else if (jvar == _mean_en_id)
+  //   return -_test[_i][_qp] * d_iz_term_d_mean_en;
+  //
+  // else if (jvar == _em_id)
+  //   return -_test[_i][_qp] * d_iz_term_d_em;
+  //
+  // else
+  //   return 0.0;
+
+}

--- a/src/kernels/ElectronImpactReactionReactant.C
+++ b/src/kernels/ElectronImpactReactionReactant.C
@@ -15,8 +15,9 @@ validParams<ElectronImpactReactionReactant>()
   params.addRequiredCoupledVar("em", "The electron density.");
   params.addRequiredParam<Real>("position_units", "Units of position.");
   params.addRequiredParam<std::string>("reaction", "Stores the full reaction equation.");
-  params.addRequiredParam<std::string>("reaction_coefficient_name",
-    "Stores the name of the reaction rate, unique to each individual reaction.");
+  params.addRequiredParam<std::string>(
+      "reaction_coefficient_name",
+      "Stores the name of the reaction rate, unique to each individual reaction.");
   return params;
 }
 
@@ -33,7 +34,7 @@ ElectronImpactReactionReactant::ElectronImpactReactionReactant(const InputParame
     // _alpha(getMaterialProperty<Real>("alpha_dex")),
     _alpha(getMaterialProperty<Real>(_reaction_coeff_name)),
     // _d_iz_d_actual_mean_en(getMaterialProperty<Real>("d_iz_d_actual_mean_en")),
-    _d_iz_d_actual_mean_en(getMaterialProperty<Real>("d_alpha_d_en_"+_reaction_name)),
+    _d_iz_d_actual_mean_en(getMaterialProperty<Real>("d_alpha_d_en_" + _reaction_name)),
     _d_muem_d_actual_mean_en(getMaterialProperty<Real>("d_muem_d_actual_mean_en")),
     _d_diffem_d_actual_mean_en(getMaterialProperty<Real>("d_diffem_d_actual_mean_en")),
     _mean_en(coupledValue("mean_en")),
@@ -57,7 +58,6 @@ ElectronImpactReactionReactant::computeQpResidual()
 
   // return -_test[_i][_qp] * iz_term;
   return -_test[_i][_qp] * (-1.0) * _alpha[_qp] * electron_flux_mag;
-
 }
 
 Real
@@ -108,7 +108,8 @@ ElectronImpactReactionReactant::computeQpOffDiagJacobian(unsigned int jvar)
   // Real d_iz_term_d_potential = (_alpha_iz[_qp] * d_electron_flux_mag_d_potential);
   // Real d_iz_term_d_mean_en =
   //     (electron_flux_mag * d_iz_d_mean_en + _alpha_iz[_qp] * d_electron_flux_mag_d_mean_en);
-  // Real d_iz_term_d_em = (electron_flux_mag * d_iz_d_em + _alpha_iz[_qp] * d_electron_flux_mag_d_em);
+  // Real d_iz_term_d_em = (electron_flux_mag * d_iz_d_em + _alpha_iz[_qp] *
+  // d_electron_flux_mag_d_em);
 
   Real d_iz_term_d_potential = (_alpha[_qp] * d_electron_flux_mag_d_potential);
   Real d_iz_term_d_mean_en =
@@ -138,5 +139,4 @@ ElectronImpactReactionReactant::computeQpOffDiagJacobian(unsigned int jvar)
   //
   // else
   //   return 0.0;
-
 }

--- a/src/kernels/ElectronImpactReactionReactant.C
+++ b/src/kernels/ElectronImpactReactionReactant.C
@@ -1,0 +1,142 @@
+#include "ElectronImpactReactionReactant.h"
+
+// MOOSE includes
+#include "MooseVariable.h"
+
+registerMooseObject("CraneApp", ElectronImpactReactionReactant);
+
+template <>
+InputParameters
+validParams<ElectronImpactReactionReactant>()
+{
+  InputParameters params = validParams<Kernel>();
+  params.addRequiredCoupledVar("mean_en", "The electron mean energy.");
+  params.addRequiredCoupledVar("potential", "The potential.");
+  params.addRequiredCoupledVar("em", "The electron density.");
+  params.addRequiredParam<Real>("position_units", "Units of position.");
+  params.addRequiredParam<std::string>("reaction", "Stores the full reaction equation.");
+  params.addRequiredParam<std::string>("reaction_coefficient_name",
+    "Stores the name of the reaction rate, unique to each individual reaction.");
+  return params;
+}
+
+ElectronImpactReactionReactant::ElectronImpactReactionReactant(const InputParameters & parameters)
+  : Kernel(parameters),
+
+    _r_units(1. / getParam<Real>("position_units")),
+    _reaction_coeff_name(getParam<std::string>("reaction_coefficient_name")),
+    _reaction_name(getParam<std::string>("reaction")),
+    _diffem(getMaterialProperty<Real>("diffem")),
+    _muem(getMaterialProperty<Real>("muem")),
+    // _alpha_iz(getMaterialProperty<Real>("alpha_iz")),
+    // _alpha_iz(getMaterialProperty<Real>("alpha_Ar_Arp")),
+    // _alpha(getMaterialProperty<Real>("alpha_dex")),
+    _alpha(getMaterialProperty<Real>(_reaction_coeff_name)),
+    // _d_iz_d_actual_mean_en(getMaterialProperty<Real>("d_iz_d_actual_mean_en")),
+    _d_iz_d_actual_mean_en(getMaterialProperty<Real>("d_alpha_d_en_"+_reaction_name)),
+    _d_muem_d_actual_mean_en(getMaterialProperty<Real>("d_muem_d_actual_mean_en")),
+    _d_diffem_d_actual_mean_en(getMaterialProperty<Real>("d_diffem_d_actual_mean_en")),
+    _mean_en(coupledValue("mean_en")),
+    _grad_potential(coupledGradient("potential")),
+    _em(coupledValue("em")),
+    _grad_em(coupledGradient("em")),
+    _mean_en_id(coupled("mean_en")),
+    _potential_id(coupled("potential")),
+    _em_id(coupled("em"))
+{
+}
+
+ElectronImpactReactionReactant::~ElectronImpactReactionReactant() {}
+
+Real
+ElectronImpactReactionReactant::computeQpResidual()
+{
+  Real electron_flux_mag = (-_muem[_qp] * -_grad_potential[_qp] * _r_units * std::exp(_em[_qp]) -
+                            _diffem[_qp] * std::exp(_em[_qp]) * _grad_em[_qp] * _r_units)
+                               .norm();
+
+  // return -_test[_i][_qp] * iz_term;
+  return -_test[_i][_qp] * (-1.0) * _alpha[_qp] * electron_flux_mag;
+
+}
+
+Real
+ElectronImpactReactionReactant::computeQpJacobian()
+{
+  return 0.0;
+}
+
+Real
+ElectronImpactReactionReactant::computeQpOffDiagJacobian(unsigned int jvar)
+{
+  // Define multiplication factor (determining if product or reactant)
+
+  Real actual_mean_en = std::exp(_mean_en[_qp] - _em[_qp]);
+  Real d_actual_mean_en_d_mean_en = std::exp(_mean_en[_qp] - _em[_qp]) * _phi[_j][_qp];
+  Real d_actual_mean_en_d_em = -std::exp(_mean_en[_qp] - _em[_qp]) * _phi[_j][_qp];
+
+  Real d_iz_d_mean_en = _d_iz_d_actual_mean_en[_qp] * actual_mean_en * _phi[_j][_qp];
+  Real d_iz_d_em = _d_iz_d_actual_mean_en[_qp] * actual_mean_en * -_phi[_j][_qp];
+  Real d_muem_d_mean_en = _d_muem_d_actual_mean_en[_qp] * actual_mean_en * _phi[_j][_qp];
+  Real d_muem_d_em = _d_muem_d_actual_mean_en[_qp] * actual_mean_en * -_phi[_j][_qp];
+  Real d_diffem_d_mean_en = _d_diffem_d_actual_mean_en[_qp] * actual_mean_en * _phi[_j][_qp];
+  Real d_diffem_d_em = _d_diffem_d_actual_mean_en[_qp] * actual_mean_en * -_phi[_j][_qp];
+
+  RealVectorValue electron_flux =
+      -_muem[_qp] * -_grad_potential[_qp] * _r_units * std::exp(_em[_qp]) -
+      _diffem[_qp] * std::exp(_em[_qp]) * _grad_em[_qp] * _r_units;
+  RealVectorValue d_electron_flux_d_potential =
+      -_muem[_qp] * -_grad_phi[_j][_qp] * _r_units * std::exp(_em[_qp]);
+  RealVectorValue d_electron_flux_d_mean_en =
+      -d_muem_d_mean_en * -_grad_potential[_qp] * _r_units * std::exp(_em[_qp]) -
+      d_diffem_d_mean_en * std::exp(_em[_qp]) * _grad_em[_qp] * _r_units;
+  RealVectorValue d_electron_flux_d_em =
+      -d_muem_d_em * -_grad_potential[_qp] * _r_units * std::exp(_em[_qp]) -
+      _muem[_qp] * -_grad_potential[_qp] * _r_units * std::exp(_em[_qp]) * _phi[_j][_qp] -
+      d_diffem_d_em * std::exp(_em[_qp]) * _grad_em[_qp] * _r_units -
+      _diffem[_qp] * std::exp(_em[_qp]) * _phi[_j][_qp] * _grad_em[_qp] * _r_units -
+      _diffem[_qp] * std::exp(_em[_qp]) * _grad_phi[_j][_qp] * _r_units;
+  Real electron_flux_mag = electron_flux.norm();
+  Real d_electron_flux_mag_d_potential =
+      electron_flux * d_electron_flux_d_potential /
+      (electron_flux_mag + std::numeric_limits<double>::epsilon());
+  Real d_electron_flux_mag_d_mean_en = electron_flux * d_electron_flux_d_mean_en /
+                                       (electron_flux_mag + std::numeric_limits<double>::epsilon());
+  Real d_electron_flux_mag_d_em = electron_flux * d_electron_flux_d_em /
+                                  (electron_flux_mag + std::numeric_limits<double>::epsilon());
+
+  // Real d_iz_term_d_potential = (_alpha_iz[_qp] * d_electron_flux_mag_d_potential);
+  // Real d_iz_term_d_mean_en =
+  //     (electron_flux_mag * d_iz_d_mean_en + _alpha_iz[_qp] * d_electron_flux_mag_d_mean_en);
+  // Real d_iz_term_d_em = (electron_flux_mag * d_iz_d_em + _alpha_iz[_qp] * d_electron_flux_mag_d_em);
+
+  Real d_iz_term_d_potential = (_alpha[_qp] * d_electron_flux_mag_d_potential);
+  Real d_iz_term_d_mean_en =
+      (electron_flux_mag * d_iz_d_mean_en + _alpha[_qp] * d_electron_flux_mag_d_mean_en);
+  Real d_iz_term_d_em = (electron_flux_mag * d_iz_d_em + _alpha[_qp] * d_electron_flux_mag_d_em);
+
+  if (jvar == _potential_id)
+    return _test[_i][_qp] * d_iz_term_d_potential;
+
+  else if (jvar == _mean_en_id)
+    return _test[_i][_qp] * d_iz_term_d_mean_en;
+
+  else if (jvar == _em_id)
+    return _test[_i][_qp] * d_iz_term_d_em;
+
+  else
+    return 0.0;
+
+  // if (jvar == _potential_id)
+  //   return -_test[_i][_qp] * d_iz_term_d_potential;
+  //
+  // else if (jvar == _mean_en_id)
+  //   return -_test[_i][_qp] * d_iz_term_d_mean_en;
+  //
+  // else if (jvar == _em_id)
+  //   return -_test[_i][_qp] * d_iz_term_d_em;
+  //
+  // else
+  //   return 0.0;
+
+}

--- a/src/kernels/ElectronProductSecondOrderLog.C
+++ b/src/kernels/ElectronProductSecondOrderLog.C
@@ -13,7 +13,8 @@ validParams<ElectronProductSecondOrderLog>()
   params.addCoupledVar("electron", "The electron species variable.");
   params.addCoupledVar("target", "The target species variable.");
   params.addRequiredCoupledVar("energy",
-    "The energy variable. (Required for jacobian term. Ignore if reaction rate is a constant value.)");
+                               "The energy variable. (Required for jacobian term. Ignore if "
+                               "reaction rate is a constant value.)");
   params.addRequiredParam<std::string>("reaction", "The full reaction equation.");
   params.addRequiredParam<Real>("coefficient", "The stoichiometric coeffient.");
   params.addParam<bool>("_electron_eq_u", false, "If v == u.");
@@ -53,7 +54,8 @@ ElectronProductSecondOrderLog::computeQpResidual()
     mult2 = _n_gas[_qp];
   }
 
-  return -_test[_i][_qp] * _stoichiometric_coeff * _reaction_coeff[_qp] * std::exp(_electron[_qp]) * mult2;
+  return -_test[_i][_qp] * _stoichiometric_coeff * _reaction_coeff[_qp] * std::exp(_electron[_qp]) *
+         mult2;
 }
 
 Real
@@ -81,41 +83,44 @@ ElectronProductSecondOrderLog::computeQpJacobian()
     else
       d_ame_d_electron = 0.0;
 
-    return -_test[_i][_qp] * _stoichiometric_coeff * (_reaction_coeff[_qp] + (_d_k_d_en[_qp]*d_ame_d_electron)) * std::exp(_electron[_qp]) * mult2 * _phi[_j][_qp];
+    return -_test[_i][_qp] * _stoichiometric_coeff *
+           (_reaction_coeff[_qp] + (_d_k_d_en[_qp] * d_ame_d_electron)) * std::exp(_electron[_qp]) *
+           mult2 * _phi[_j][_qp];
   }
   // else
   // {
-    // power = 0.0;
-    // gas_mult = 1.0;
-    // k_deriv_mult = 0;
-    //
-    // if (_target_coupled)
-    //   mult2 = std::exp(_target[_qp]);
-    // else
-    //   mult2 = _n_gas[_qp];
-    //
-    // if (_electron_eq_u)
-    // {
-    //   power += 1.0;
-    //   actual_mean_en = std::exp(_energy[_qp] - _electron[_qp]);
-    //   d_ame_d_electron = -actual_mean_en;  // Multiplied by _phi[_j][_qp] at the end
-    // }
-    // else
-    //   d_ame_d_electron = 0.0;
-    //
-    // if (_target_coupled && _target_eq_u)
-    //   power += 1.0;
-    //
-    // gas_mult *= std::exp(_electron[_qp]) * mult2;
-    //
-    // return -_test[_i][_qp] * _stoichiometric_coeff * power * (_reaction_coeff[_qp] + (_d_k_d_en[_qp] * d_ame_d_electron)) * gas_mult * _phi[_j][_qp];
+  // power = 0.0;
+  // gas_mult = 1.0;
+  // k_deriv_mult = 0;
+  //
+  // if (_target_coupled)
+  //   mult2 = std::exp(_target[_qp]);
+  // else
+  //   mult2 = _n_gas[_qp];
+  //
+  // if (_electron_eq_u)
+  // {
+  //   power += 1.0;
+  //   actual_mean_en = std::exp(_energy[_qp] - _electron[_qp]);
+  //   d_ame_d_electron = -actual_mean_en;  // Multiplied by _phi[_j][_qp] at the end
+  // }
+  // else
+  //   d_ame_d_electron = 0.0;
+  //
+  // if (_target_coupled && _target_eq_u)
+  //   power += 1.0;
+  //
+  // gas_mult *= std::exp(_electron[_qp]) * mult2;
+  //
+  // return -_test[_i][_qp] * _stoichiometric_coeff * power * (_reaction_coeff[_qp] +
+  // (_d_k_d_en[_qp] * d_ame_d_electron)) * gas_mult * _phi[_j][_qp];
   // }
 }
 
 Real
 ElectronProductSecondOrderLog::computeQpOffDiagJacobian(unsigned int jvar)
 {
-  Real mult2,actual_mean_en,d_ame_d_electron,d_ame_d_energy;
+  Real mult2, actual_mean_en, d_ame_d_electron, d_ame_d_energy;
   // Real rate_constant;
 
   if (_target_coupled)
@@ -128,22 +133,25 @@ ElectronProductSecondOrderLog::computeQpOffDiagJacobian(unsigned int jvar)
     actual_mean_en = std::exp(_energy[_qp] - _electron[_qp]);
     d_ame_d_electron = -actual_mean_en;
 
-    return -_test[_i][_qp] * _stoichiometric_coeff * (_reaction_coeff[_qp] + (_d_k_d_en[_qp] * d_ame_d_electron)) * std::exp(_electron[_qp]) * mult2 * _phi[_j][_qp];
+    return -_test[_i][_qp] * _stoichiometric_coeff *
+           (_reaction_coeff[_qp] + (_d_k_d_en[_qp] * d_ame_d_electron)) * std::exp(_electron[_qp]) *
+           mult2 * _phi[_j][_qp];
   }
   else if (_target_coupled && !_target_eq_u && jvar == _target_id)
   {
-    return -_test[_i][_qp] * _stoichiometric_coeff * _reaction_coeff[_qp] * std::exp(_electron[_qp]) * mult2 * _phi[_j][_qp];
+    return -_test[_i][_qp] * _stoichiometric_coeff * _reaction_coeff[_qp] *
+           std::exp(_electron[_qp]) * mult2 * _phi[_j][_qp];
   }
   else if (jvar == _energy_id)
   {
     actual_mean_en = std::exp(_energy[_qp] - _electron[_qp]);
     d_ame_d_energy = actual_mean_en;
 
-    return -_test[_i][_qp] * _stoichiometric_coeff * (_d_k_d_en[_qp] * d_ame_d_energy) * std::exp(_electron[_qp]) * mult2 * _phi[_j][_qp];
+    return -_test[_i][_qp] * _stoichiometric_coeff * (_d_k_d_en[_qp] * d_ame_d_energy) *
+           std::exp(_electron[_qp]) * mult2 * _phi[_j][_qp];
   }
   else
     return 0.0;
-
 
   // if (!_electron_eq_u && jvar==_electron_id)
   // {
@@ -161,5 +169,6 @@ ElectronProductSecondOrderLog::computeQpOffDiagJacobian(unsigned int jvar)
   // // Since these are in exponential form, the exp(dens1 + dens2) term always exists regardless!
   // gas_mult = mult1 * mult2;
   //
-  // return -_test[_i][_qp] * _stoichiometric_coeff * (_reaction_coeff[_qp] + (_d_k_d_en[_qp] * d_ame_d_electron)) * gas_mult * power * _phi[_j][_qp];
+  // return -_test[_i][_qp] * _stoichiometric_coeff * (_reaction_coeff[_qp] + (_d_k_d_en[_qp] *
+  // d_ame_d_electron)) * gas_mult * power * _phi[_j][_qp];
 }

--- a/src/kernels/ElectronReactantSecondOrderLog.C
+++ b/src/kernels/ElectronReactantSecondOrderLog.C
@@ -20,8 +20,8 @@ validParams<ElectronReactantSecondOrderLog>()
 
 ElectronReactantSecondOrderLog::ElectronReactantSecondOrderLog(const InputParameters & parameters)
   : Kernel(parameters),
-    _reaction_coeff(getMaterialProperty<Real>("k_"+getParam<std::string>("reaction"))),
-    _d_k_d_en(getMaterialProperty<Real>("d_k_d_en_"+getParam<std::string>("reaction"))),
+    _reaction_coeff(getMaterialProperty<Real>("k_" + getParam<std::string>("reaction"))),
+    _d_k_d_en(getMaterialProperty<Real>("d_k_d_en_" + getParam<std::string>("reaction"))),
     _v(isCoupled("v") ? coupledValue("v") : _zero),
     _energy(coupledValue("energy")),
     _v_id(isCoupled("v") ? coupled("v") : 0),
@@ -37,17 +37,19 @@ ElectronReactantSecondOrderLog::computeQpResidual()
 {
   if (isCoupled("v"))
   {
-    return -_test[_i][_qp] * _stoichiometric_coeff * _reaction_coeff[_qp] * std::exp(_v[_qp]) * std::exp(_u[_qp]);
+    return -_test[_i][_qp] * _stoichiometric_coeff * _reaction_coeff[_qp] * std::exp(_v[_qp]) *
+           std::exp(_u[_qp]);
   }
   else
-    return -_test[_i][_qp] * _stoichiometric_coeff * _reaction_coeff[_qp] * _n_gas[_qp] * std::exp(_u[_qp]);
+    return -_test[_i][_qp] * _stoichiometric_coeff * _reaction_coeff[_qp] * _n_gas[_qp] *
+           std::exp(_u[_qp]);
 }
 
 Real
 ElectronReactantSecondOrderLog::computeQpJacobian()
 {
   // Note that if !_v_eq_electron, then by definition _var is the electron variable.
-  Real d_ame_d_en,actual_mean_en;
+  Real d_ame_d_en, actual_mean_en;
 
   if (!_v_eq_electron)
   {
@@ -58,17 +60,19 @@ ElectronReactantSecondOrderLog::computeQpJacobian()
     d_ame_d_en = 0.0;
 
   if (isCoupled("v"))
-    return -_test[_i][_qp] * _stoichiometric_coeff * (_reaction_coeff[_qp] + (_d_k_d_en[_qp] * d_ame_d_en)) * std::exp(_v[_qp]) *
+    return -_test[_i][_qp] * _stoichiometric_coeff *
+           (_reaction_coeff[_qp] + (_d_k_d_en[_qp] * d_ame_d_en)) * std::exp(_v[_qp]) *
            std::exp(_u[_qp]) * _phi[_j][_qp];
   else
-    return -_test[_i][_qp] * _stoichiometric_coeff * (_reaction_coeff[_qp] + (_d_k_d_en[_qp] * d_ame_d_en)) * _n_gas[_qp] *
+    return -_test[_i][_qp] * _stoichiometric_coeff *
+           (_reaction_coeff[_qp] + (_d_k_d_en[_qp] * d_ame_d_en)) * _n_gas[_qp] *
            std::exp(_u[_qp]) * _phi[_j][_qp];
 }
 
 Real
 ElectronReactantSecondOrderLog::computeQpOffDiagJacobian(unsigned int jvar)
 {
-  Real mult1,actual_mean_en,d_k_d_electron;
+  Real mult1, actual_mean_en, d_k_d_electron;
 
   if (isCoupled("v"))
     mult1 = std::exp(_v[_qp]);
@@ -84,11 +88,14 @@ ElectronReactantSecondOrderLog::computeQpOffDiagJacobian(unsigned int jvar)
       actual_mean_en = std::exp(_energy[_qp] - _v[_qp]);
       d_k_d_electron = -actual_mean_en;
 
-      return -_test[_i][_qp] * _stoichiometric_coeff * (_reaction_coeff[_qp] + (_d_k_d_en[_qp] * d_k_d_electron)) * std::exp(_u[_qp]) * mult1 * _phi[_j][_qp];
+      return -_test[_i][_qp] * _stoichiometric_coeff *
+             (_reaction_coeff[_qp] + (_d_k_d_en[_qp] * d_k_d_electron)) * std::exp(_u[_qp]) *
+             mult1 * _phi[_j][_qp];
     }
     else
     {
-      return -_test[_i][_qp] * _stoichiometric_coeff * _reaction_coeff[_qp] * std::exp(_u[_qp]) * mult1 * _phi[_j][_qp];
+      return -_test[_i][_qp] * _stoichiometric_coeff * _reaction_coeff[_qp] * std::exp(_u[_qp]) *
+             mult1 * _phi[_j][_qp];
     }
   }
   else if (jvar == _energy_id)
@@ -98,8 +105,8 @@ ElectronReactantSecondOrderLog::computeQpOffDiagJacobian(unsigned int jvar)
     else
       actual_mean_en = std::exp(_energy[_qp] - _u[_qp]);
 
-
-    return -_test[_i][_qp] * _stoichiometric_coeff * (_d_k_d_en[_qp] * actual_mean_en) * std::exp(_u[_qp]) * mult1 * _phi[_j][_qp];
+    return -_test[_i][_qp] * _stoichiometric_coeff * (_d_k_d_en[_qp] * actual_mean_en) *
+           std::exp(_u[_qp]) * mult1 * _phi[_j][_qp];
   }
   else
     return 0.0;
@@ -107,7 +114,8 @@ ElectronReactantSecondOrderLog::computeQpOffDiagJacobian(unsigned int jvar)
   // if (isCoupled("v"))
   // {
   //   if (jvar == _v_id)
-  //     return -_test[_i][_qp] * _stoichiometric_coeff * _reaction_coeff[_qp] * std::exp(_u[_qp]) * std::exp(_v[_qp]) * _phi[_j][_qp];
+  //     return -_test[_i][_qp] * _stoichiometric_coeff * _reaction_coeff[_qp] * std::exp(_u[_qp]) *
+  //     std::exp(_v[_qp]) * _phi[_j][_qp];
   //   else
   //     return 0.0;
   // }

--- a/src/materials/EEDFRateConstantTownsend.C
+++ b/src/materials/EEDFRateConstantTownsend.C
@@ -30,8 +30,8 @@ validParams<EEDFRateConstantTownsend>()
                         "Whether the coupled target species is an aux variable or not. (If it is, "
                         "it does not contribute to jacobian terms.)");
   params.addCoupledVar("target_species", "The heavy (target) species. Optional (default: _n_gas).");
-  params.addCoupledVar("mean_en", "The electron mean energy in log form.");
-  params.addCoupledVar("em", "The electron density.");
+  params.addRequiredCoupledVar("mean_en", "The electron mean energy in log form.");
+  params.addRequiredCoupledVar("em", "The electron density.");
 
   return params;
 }
@@ -49,7 +49,7 @@ EEDFRateConstantTownsend::EEDFRateConstantTownsend(const InputParameters & param
         declareProperty<unsigned int>("d_alpha_d_var_id_" + getParam<std::string>("reaction"))),
     _target_coupled(declareProperty<bool>("target_coupled_" + getParam<std::string>("reaction"))),
     _is_target_aux(getParam<bool>("is_target_aux")),
-    _n_gas(getMaterialProperty<Real>("n_gas")),
+//    _n_gas(getMaterialProperty<Real>("n_gas")),
     // _massIncident(getMaterialProperty<Real>("massHe+")),
     _massIncident(getMaterialProperty<Real>("mass" + (*getVar("em", 0)).name())),
     _massTarget(isCoupled("target_species")
@@ -143,8 +143,9 @@ EEDFRateConstantTownsend::computeQpProperties()
   // if (_coefficient_format == "townsend")
   // {
   _townsend_coefficient[_qp] = _coefficient_interpolation.sample(actual_mean_energy);
+//  std::cout << _townsend_coefficient[_qp] << ", " << getParam<std::string>("reaction")  << std::endl;
   _d_alpha_d_en[_qp] = _coefficient_interpolation.sampleDerivative(actual_mean_energy);
-  if (isCoupled("target_species"))
+/*  if (isCoupled("target_species"))
   {
     _townsend_coefficient[_qp] =
         _townsend_coefficient[_qp] * std::exp(_target_species[_qp]) / _n_gas[_qp];
@@ -154,6 +155,7 @@ EEDFRateConstantTownsend::computeQpProperties()
       _d_alpha_d_var_id[_qp] = _target_id;
     }
   }
+  */
 
   if (_elastic_collision == true)
   {

--- a/src/materials/EEDFRateConstantTownsend.C
+++ b/src/materials/EEDFRateConstantTownsend.C
@@ -49,7 +49,7 @@ EEDFRateConstantTownsend::EEDFRateConstantTownsend(const InputParameters & param
         declareProperty<unsigned int>("d_alpha_d_var_id_" + getParam<std::string>("reaction"))),
     _target_coupled(declareProperty<bool>("target_coupled_" + getParam<std::string>("reaction"))),
     _is_target_aux(getParam<bool>("is_target_aux")),
-//    _n_gas(getMaterialProperty<Real>("n_gas")),
+    //    _n_gas(getMaterialProperty<Real>("n_gas")),
     // _massIncident(getMaterialProperty<Real>("massHe+")),
     _massIncident(getMaterialProperty<Real>("mass" + (*getVar("em", 0)).name())),
     _massTarget(isCoupled("target_species")
@@ -143,19 +143,20 @@ EEDFRateConstantTownsend::computeQpProperties()
   // if (_coefficient_format == "townsend")
   // {
   _townsend_coefficient[_qp] = _coefficient_interpolation.sample(actual_mean_energy);
-//  std::cout << _townsend_coefficient[_qp] << ", " << getParam<std::string>("reaction")  << std::endl;
+  //  std::cout << _townsend_coefficient[_qp] << ", " << getParam<std::string>("reaction")  <<
+  //  std::endl;
   _d_alpha_d_en[_qp] = _coefficient_interpolation.sampleDerivative(actual_mean_energy);
-/*  if (isCoupled("target_species"))
-  {
-    _townsend_coefficient[_qp] =
-        _townsend_coefficient[_qp] * std::exp(_target_species[_qp]) / _n_gas[_qp];
-    if (!_is_target_aux)
+  /*  if (isCoupled("target_species"))
     {
-      _d_alpha_d_en[_qp] = _d_alpha_d_en[_qp] * std::exp(_target_species[_qp]) / _n_gas[_qp];
-      _d_alpha_d_var_id[_qp] = _target_id;
+      _townsend_coefficient[_qp] =
+          _townsend_coefficient[_qp] * std::exp(_target_species[_qp]) / _n_gas[_qp];
+      if (!_is_target_aux)
+      {
+        _d_alpha_d_en[_qp] = _d_alpha_d_en[_qp] * std::exp(_target_species[_qp]) / _n_gas[_qp];
+        _d_alpha_d_var_id[_qp] = _target_id;
+      }
     }
-  }
-  */
+    */
 
   if (_elastic_collision == true)
   {


### PR DESCRIPTION
This PR adds kernels for reactions using the Townsend formulation rather than standard rate coefficients. 