### PR TITLE
Added ability to track production rates of each species

### DIFF
--- a/include/actions/ChemicalReactionsBase.h
+++ b/include/actions/ChemicalReactionsBase.h
@@ -27,6 +27,7 @@ protected:
   bool _use_log;
   // bool _use_moles;
 
+  bool _track_rates;
   std::vector<bool> _energy_change;
   // std::vector<VariableName> _potential;
   std::vector<std::vector<Real>> _species_count;

--- a/include/auxkernels/ProcRateForRateCoeffThreeBody_Crane.h
+++ b/include/auxkernels/ProcRateForRateCoeffThreeBody_Crane.h
@@ -1,0 +1,38 @@
+//* This file is part of Zapdos, an open-source
+//* application for the simulation of plasmas
+//* https://github.com/shannon-lab/zapdos
+//*
+//* Zapdos is powered by the MOOSE Framework
+//* https://www.mooseframework.org
+//*
+//* Licensed under LGPL 2.1, please see LICENSE for details
+//* https://www.gnu.org/licenses/lgpl-2.1.html
+
+#ifndef PROCRATEFORRATECOEFFTHREEBODY_CRANE_H
+#define PROCRATEFORRATECOEFFTHREEBODY_CRANE_H
+
+#include "AuxKernel.h"
+
+class ProcRateForRateCoeffThreeBody_Crane;
+
+template <>
+InputParameters validParams<ProcRateForRateCoeffThreeBody_Crane>();
+
+class ProcRateForRateCoeffThreeBody_Crane : public AuxKernel
+{
+public:
+  ProcRateForRateCoeffThreeBody_Crane(const InputParameters & parameters);
+
+  virtual ~ProcRateForRateCoeffThreeBody_Crane() {}
+  virtual Real computeValue();
+
+protected:
+
+
+  const VariableValue & _v;
+  const VariableValue & _w;
+  const VariableValue & _vv;
+  const MaterialProperty<Real> & _reaction_coeff;
+};
+
+#endif // ProcRateForRateCoeffThreeBody_Crane_H

--- a/include/auxkernels/ProcRateForRateCoeffThreeBody_Crane.h
+++ b/include/auxkernels/ProcRateForRateCoeffThreeBody_Crane.h
@@ -1,12 +1,16 @@
-//* This file is part of Zapdos, an open-source
-//* application for the simulation of plasmas
-//* https://github.com/shannon-lab/zapdos
-//*
-//* Zapdos is powered by the MOOSE Framework
-//* https://www.mooseframework.org
-//*
-//* Licensed under LGPL 2.1, please see LICENSE for details
-//* https://www.gnu.org/licenses/lgpl-2.1.html
+/****************************************************************/
+/*               DO NOT MODIFY THIS HEADER                      */
+/* MOOSE - Multiphysics Object Oriented Simulation Environment  */
+/*                                                              */
+/*           (c) 2010 Battelle Energy Alliance, LLC             */
+/*                   ALL RIGHTS RESERVED                        */
+/*                                                              */
+/*          Prepared by Battelle Energy Alliance, LLC           */
+/*            Under Contract No. DE-AC07-05ID14517              */
+/*            With the U. S. Department of Energy               */
+/*                                                              */
+/*            See COPYRIGHT for full restrictions               */
+/****************************************************************/
 
 #ifndef PROCRATEFORRATECOEFFTHREEBODY_CRANE_H
 #define PROCRATEFORRATECOEFFTHREEBODY_CRANE_H

--- a/include/auxkernels/ProcRateForRateCoeff_Crane.h
+++ b/include/auxkernels/ProcRateForRateCoeff_Crane.h
@@ -1,12 +1,16 @@
-//* This file is part of Zapdos, an open-source
-//* application for the simulation of plasmas
-//* https://github.com/shannon-lab/zapdos
-//*
-//* Zapdos is powered by the MOOSE Framework
-//* https://www.mooseframework.org
-//*
-//* Licensed under LGPL 2.1, please see LICENSE for details
-//* https://www.gnu.org/licenses/lgpl-2.1.html
+/****************************************************************/
+/*               DO NOT MODIFY THIS HEADER                      */
+/* MOOSE - Multiphysics Object Oriented Simulation Environment  */
+/*                                                              */
+/*           (c) 2010 Battelle Energy Alliance, LLC             */
+/*                   ALL RIGHTS RESERVED                        */
+/*                                                              */
+/*          Prepared by Battelle Energy Alliance, LLC           */
+/*            Under Contract No. DE-AC07-05ID14517              */
+/*            With the U. S. Department of Energy               */
+/*                                                              */
+/*            See COPYRIGHT for full restrictions               */
+/****************************************************************/
 
 #ifndef PROCRATEFORRATECOEFF_CRANE_H
 #define PROCRATEFORRATECOEFF_CRANE_H

--- a/include/auxkernels/ProcRateForRateCoeff_Crane.h
+++ b/include/auxkernels/ProcRateForRateCoeff_Crane.h
@@ -1,0 +1,37 @@
+//* This file is part of Zapdos, an open-source
+//* application for the simulation of plasmas
+//* https://github.com/shannon-lab/zapdos
+//*
+//* Zapdos is powered by the MOOSE Framework
+//* https://www.mooseframework.org
+//*
+//* Licensed under LGPL 2.1, please see LICENSE for details
+//* https://www.gnu.org/licenses/lgpl-2.1.html
+
+#ifndef PROCRATEFORRATECOEFF_CRANE_H
+#define PROCRATEFORRATECOEFF_CRANE_H
+
+#include "AuxKernel.h"
+
+class ProcRateForRateCoeff_Crane;
+
+template <>
+InputParameters validParams<ProcRateForRateCoeff_Crane>();
+
+class ProcRateForRateCoeff_Crane : public AuxKernel
+{
+public:
+  ProcRateForRateCoeff_Crane(const InputParameters & parameters);
+
+  virtual ~ProcRateForRateCoeff_Crane() {}
+  virtual Real computeValue();
+
+protected:
+
+
+  const VariableValue & _v;
+  const VariableValue & _w;
+  const MaterialProperty<Real> & _reaction_coeff;
+};
+
+#endif // ProcRateForRateCoeff_Crane_H

--- a/include/auxkernels/ProcRateForRateCoeff_OneBody_Crane.h
+++ b/include/auxkernels/ProcRateForRateCoeff_OneBody_Crane.h
@@ -1,12 +1,16 @@
-//* This file is part of Zapdos, an open-source
-//* application for the simulation of plasmas
-//* https://github.com/shannon-lab/zapdos
-//*
-//* Zapdos is powered by the MOOSE Framework
-//* https://www.mooseframework.org
-//*
-//* Licensed under LGPL 2.1, please see LICENSE for details
-//* https://www.gnu.org/licenses/lgpl-2.1.html
+/****************************************************************/
+/*               DO NOT MODIFY THIS HEADER                      */
+/* MOOSE - Multiphysics Object Oriented Simulation Environment  */
+/*                                                              */
+/*           (c) 2010 Battelle Energy Alliance, LLC             */
+/*                   ALL RIGHTS RESERVED                        */
+/*                                                              */
+/*          Prepared by Battelle Energy Alliance, LLC           */
+/*            Under Contract No. DE-AC07-05ID14517              */
+/*            With the U. S. Department of Energy               */
+/*                                                              */
+/*            See COPYRIGHT for full restrictions               */
+/****************************************************************/
 
 #ifndef PROCRATEFORRATECOEFF_ONEBODY_CRANE_H
 #define PROCRATEFORRATECOEFF_ONEBODY_CRANE_H

--- a/include/auxkernels/ProcRateForRateCoeff_OneBody_Crane.h
+++ b/include/auxkernels/ProcRateForRateCoeff_OneBody_Crane.h
@@ -1,0 +1,36 @@
+//* This file is part of Zapdos, an open-source
+//* application for the simulation of plasmas
+//* https://github.com/shannon-lab/zapdos
+//*
+//* Zapdos is powered by the MOOSE Framework
+//* https://www.mooseframework.org
+//*
+//* Licensed under LGPL 2.1, please see LICENSE for details
+//* https://www.gnu.org/licenses/lgpl-2.1.html
+
+#ifndef PROCRATEFORRATECOEFF_ONEBODY_CRANE_H
+#define PROCRATEFORRATECOEFF_ONEBODY_CRANE_H
+
+#include "AuxKernel.h"
+
+class ProcRateForRateCoeff_OneBody_Crane;
+
+template <>
+InputParameters validParams<ProcRateForRateCoeff_OneBody_Crane>();
+
+class ProcRateForRateCoeff_OneBody_Crane : public AuxKernel
+{
+public:
+  ProcRateForRateCoeff_OneBody_Crane(const InputParameters & parameters);
+
+  virtual ~ProcRateForRateCoeff_OneBody_Crane() {}
+  virtual Real computeValue();
+
+protected:
+
+
+  const VariableValue & _v;
+  const MaterialProperty<Real> & _reaction_coeff;
+};
+
+#endif // ProcRateForRateCoeff_OneBody_Crane_H

--- a/include/auxkernels/ProcRateForRateCoeff_Townsend_Crane.h
+++ b/include/auxkernels/ProcRateForRateCoeff_Townsend_Crane.h
@@ -1,0 +1,55 @@
+/****************************************************************/
+/*               DO NOT MODIFY THIS HEADER                      */
+/* MOOSE - Multiphysics Object Oriented Simulation Environment  */
+/*                                                              */
+/*           (c) 2010 Battelle Energy Alliance, LLC             */
+/*                   ALL RIGHTS RESERVED                        */
+/*                                                              */
+/*          Prepared by Battelle Energy Alliance, LLC           */
+/*            Under Contract No. DE-AC07-05ID14517              */
+/*            With the U. S. Department of Energy               */
+/*                                                              */
+/*            See COPYRIGHT for full restrictions               */
+/****************************************************************/
+
+#ifndef PROCRATEFORRATECOEFF_TOWNSEND_CRANE_H
+#define PROCRATEFORRATECOEFF_TOWNSEND_CRANE_H
+
+#include "AuxKernel.h"
+
+class ProcRateForRateCoeff_Townsend_Crane;
+
+template <>
+InputParameters validParams<ProcRateForRateCoeff_Townsend_Crane>();
+
+class ProcRateForRateCoeff_Townsend_Crane : public AuxKernel
+{
+public:
+  ProcRateForRateCoeff_Townsend_Crane(const InputParameters & parameters);
+  virtual ~ProcRateForRateCoeff_Townsend_Crane() {}
+  virtual Real computeValue();
+protected:
+
+  Real _r_units;
+  std::string _reaction_coeff_name;
+  std::string _reaction_name;
+
+  const MaterialProperty<Real> & _diffem;
+  const MaterialProperty<Real> & _muem;
+  const MaterialProperty<Real> & _alpha;
+  const MaterialProperty<Real> & _d_iz_d_actual_mean_en;
+  const MaterialProperty<Real> & _d_muem_d_actual_mean_en;
+  const MaterialProperty<Real> & _d_diffem_d_actual_mean_en;
+
+  const VariableValue & _mean_en;
+  const VariableGradient & _grad_potential;
+  const VariableValue & _em;
+  const VariableGradient & _grad_em;
+  unsigned int _mean_en_id;
+  unsigned int _potential_id;
+  unsigned int _em_id;
+  const VariableValue & _target;
+  unsigned int _target_id;
+};
+
+#endif /* PROCRATEFORRATECOEFF_TOWNSEND_CRANE_H */

--- a/include/auxkernels/ProductionFirstOrder.h
+++ b/include/auxkernels/ProductionFirstOrder.h
@@ -1,0 +1,42 @@
+/****************************************************************/
+/*               DO NOT MODIFY THIS HEADER                      */
+/* MOOSE - Multiphysics Object Oriented Simulation Environment  */
+/*                                                              */
+/*           (c) 2010 Battelle Energy Alliance, LLC             */
+/*                   ALL RIGHTS RESERVED                        */
+/*                                                              */
+/*          Prepared by Battelle Energy Alliance, LLC           */
+/*            Under Contract No. DE-AC07-05ID14517              */
+/*            With the U. S. Department of Energy               */
+/*                                                              */
+/*            See COPYRIGHT for full restrictions               */
+/****************************************************************/
+
+#ifndef PRODUCTIONFIRSTORDER_H
+#define PRODUCTIONFIRSTORDER_H
+
+#include "Kernel.h"
+
+// Forward Declaration
+class ProductionFirstOrder;
+
+template <>
+InputParameters validParams<ProductionFirstOrder>();
+
+class ProductionFirstOrder : public AuxScalarKernel
+{
+public:
+  ProductionFirstOrder(const InputParameters & parameters);
+
+protected:
+  virtual Real computeValue();
+
+  // MooseVariable & _coupled_var_A;
+  // MooseVariable & _coupled_var_B;
+  const VariableValue & _v;
+
+  // The reaction coefficient
+  const VariableValue & _rate_coefficient;
+  Real _stoichiometric_coeff;
+};
+#endif // PRODUCTIONFIRSTORDER_H

--- a/include/auxkernels/ProductionSecondOrder.h
+++ b/include/auxkernels/ProductionSecondOrder.h
@@ -1,0 +1,43 @@
+/****************************************************************/
+/*               DO NOT MODIFY THIS HEADER                      */
+/* MOOSE - Multiphysics Object Oriented Simulation Environment  */
+/*                                                              */
+/*           (c) 2010 Battelle Energy Alliance, LLC             */
+/*                   ALL RIGHTS RESERVED                        */
+/*                                                              */
+/*          Prepared by Battelle Energy Alliance, LLC           */
+/*            Under Contract No. DE-AC07-05ID14517              */
+/*            With the U. S. Department of Energy               */
+/*                                                              */
+/*            See COPYRIGHT for full restrictions               */
+/****************************************************************/
+
+#ifndef PRODUCTIONSECONDORDER_H
+#define PRODUCTIONSECONDORDER_H
+
+#include "Kernel.h"
+
+// Forward Declaration
+class ProductionSecondOrder;
+
+template <>
+InputParameters validParams<ProductionSecondOrder>();
+
+class ProductionSecondOrder : public AuxScalarKernel
+{
+public:
+  ProductionSecondOrder(const InputParameters & parameters);
+
+protected:
+  virtual Real computeValue();
+
+  // MooseVariable & _coupled_var_A;
+  // MooseVariable & _coupled_var_B;
+  const VariableValue & _v;
+  const VariableValue & _w;
+
+  // The reaction coefficient
+  const VariableValue & _rate_coefficient;
+  Real _stoichiometric_coeff;
+};
+#endif // PRODUCTIONSECONDORDER_H

--- a/include/auxkernels/ProductionThirdOrder.h
+++ b/include/auxkernels/ProductionThirdOrder.h
@@ -1,0 +1,44 @@
+/****************************************************************/
+/*               DO NOT MODIFY THIS HEADER                      */
+/* MOOSE - Multiphysics Object Oriented Simulation Environment  */
+/*                                                              */
+/*           (c) 2010 Battelle Energy Alliance, LLC             */
+/*                   ALL RIGHTS RESERVED                        */
+/*                                                              */
+/*          Prepared by Battelle Energy Alliance, LLC           */
+/*            Under Contract No. DE-AC07-05ID14517              */
+/*            With the U. S. Department of Energy               */
+/*                                                              */
+/*            See COPYRIGHT for full restrictions               */
+/****************************************************************/
+
+#ifndef PRODUCTIONTHIRDORDER_H
+#define PRODUCTIONTHIRDORDER_H
+
+#include "Kernel.h"
+
+// Forward Declaration
+class ProductionThirdOrder;
+
+template <>
+InputParameters validParams<ProductionThirdOrder>();
+
+class ProductionThirdOrder : public AuxScalarKernel
+{
+public:
+  ProductionThirdOrder(const InputParameters & parameters);
+
+protected:
+  virtual Real computeValue();
+
+  // MooseVariable & _coupled_var_A;
+  // MooseVariable & _coupled_var_B;
+  const VariableValue & _v;
+  const VariableValue & _w;
+  const VariableValue & _z;
+
+  // The reaction coefficient
+  const VariableValue & _rate_coefficient;
+  Real _stoichiometric_coeff;
+};
+#endif // PRODUCTIONTHIRDORDER_H

--- a/problems/e4.i
+++ b/problems/e4.i
@@ -1,0 +1,291 @@
+[Mesh]
+  type = GeneratedMesh
+  dim = 1
+  nx = 1
+[]
+
+[Variables]
+  [./N]
+    family = SCALAR
+    order = FIRST
+    initial_condition = 0.0
+    scaling = 1e-5
+  [../]
+
+  [./N2]
+    family = SCALAR
+    order = FIRST
+    initial_condition = 2.4474637681159418e+19
+    scaling = 1e-10
+  [../]
+
+  [./N2A]
+    family = SCALAR
+    order = FIRST
+    initial_condition = 0.0
+    scaling = 1e-8
+  [../]
+
+  [./N2B]
+    family = SCALAR
+    order = FIRST
+    initial_condition = 0.0
+    scaling = 1e-5
+  [../]
+
+  [./N2a1]
+    family = SCALAR
+    order = FIRST
+    initial_condition = 0.0
+  [../]
+
+  [./N2C]
+    family = SCALAR
+    order = FIRST
+    initial_condition = 0.0
+    scaling = 1e-5
+  [../]
+
+  [./N+]
+    family = SCALAR
+    order = FIRST
+    initial_condition = 0.0
+    scaling = 1e-5
+  [../]
+
+  [./N2+]
+    family = SCALAR
+    order = FIRST
+    initial_condition = 0.0
+    scaling = 1e-5
+  [../]
+
+  [./N3+]
+    family = SCALAR
+    order = FIRST
+    initial_condition = 0.0
+    scaling = 1e-5
+  [../]
+
+  [./N4+]
+    family = SCALAR
+    order = FIRST
+    initial_condition = 0.0
+    scaling = 1e-5
+  [../]
+[]
+
+[ScalarKernels]
+  [./dN_dt]
+    type = ODETimeDerivative
+    variable = N
+  [../]
+
+  [./dN2_dt]
+    type = ODETimeDerivative
+    variable = N2
+  [../]
+
+  [./dN2A_dt]
+    type = ODETimeDerivative
+    variable = N2A
+  [../]
+
+  [./dN2B_dt]
+    type = ODETimeDerivative
+    variable = N2B
+  [../]
+
+  [./dN2a_dt]
+    type = ODETimeDerivative
+    variable = N2a1
+  [../]
+
+  [./dN2C_dt]
+    type = ODETimeDerivative
+    variable = N2C
+  [../]
+
+  [./dN+_dt]
+    type = ODETimeDerivative
+    variable = N+
+  [../]
+
+  [./dN2+_dt]
+    type = ODETimeDerivative
+    variable = N2+
+  [../]
+
+  [./dN3+_dt]
+    type = ODETimeDerivative
+    variable = N3+
+  [../]
+
+  [./dN4+_dt]
+    type = ODETimeDerivative
+    variable = N4+
+  [../]
+[]
+
+
+[ChemicalReactions]
+  [./ScalarNetwork]
+    species = 'e N N2 N2A N2B N2a1 N2C N+ N2+ N3+ N4+'
+    aux_species = 'e'
+    file_location = 'Example4'
+    track_rates = true
+
+    # These are parameters required equation-based rate coefficients
+    equation_variables = 'Te Teff'
+    rate_provider_var = 'reduced_field'
+
+
+    reactions = 'e + N2 -> e + N2A          : EEDF
+                 e + N2 -> e + N2B          : EEDF
+                 e + N2 -> e + N2a1         : EEDF
+                 e + N2 -> e + N2C          : EEDF
+                 e + N2 -> e + e + N2+      : EEDF
+                 N2A + N2a1 -> N4+ + e      : 4.0e-12
+                 N2a1 + N2a1 -> N4+ + e     : 4.0e-11
+                 N+ + e + N2 -> N + N2      : {6.0e-27*(300/(Te*11600))^1.5}
+                 N2+ + e -> N + N           : {1.8e-7*(300/(Te*11600))^0.39}
+                 N3+ + e -> N2 + N          : {2.0e-7*(300/(Te*11600))^0.5}
+                 N4+ + e -> N2 + N2         : {2.3e-6*(300/(Te*11600))^0.53}
+                 N+ + N + N2 -> N2+ + N2    : 1.0e-29
+                 N+ + N2 + N2 -> N3+ + N2   : {1.7e-29*(300.0/Teff)^2.1}
+                 N2+ + N -> N+ + N2         : {7.2e-13*(Teff/300.0)}
+                 N2+ + N2A -> N3+ + N       : 3.0e-10
+                 N2+ + N2 + N -> N3+ + N2   : {9.0e-30*exp(400.0/Teff)}
+                 N2+ + N2 + N2 -> N4+ + N2  : {5.2e-29*(300.0/Teff)^2.2}
+                 N3+ + N -> N2+ + N2        : 6.6e-11
+                 N4+ + N -> N+ + N2 + N2    : 1.0e-11
+                 N4+ + N2 -> N2+ + N2 + N2  : {2.1e-16*exp(Teff/121.0)}
+                 N2A -> N2                  : 5.0e-1
+                 N2B -> N2A                 : 1.3e5
+                 N2a1 -> N2                 : 1.0e2
+                 N2C -> N2B                 : 2.5e7
+                 N2A + N -> N2 + N          : 2.0e-12
+                 N2A + N2 -> N2 + N2        : 3.0e-16
+                 N2A + N2A -> N2 + N2B      : 3.0e-10
+                 N2A + N2A -> N2 + N2C      : 1.5e-10
+                 N2B + N2 -> N2 + N2        : 2.0e-12
+                 N2B + N2 -> N2A + N2       : 3.0e-11
+                 N2a1 + N2 -> N2 + N2B      : 1.9e-13
+                 N2C + N2 -> N2 + N2a1      : 1.0e-11
+                 N + N + N2 -> N2A + N2     : 1.7e-33
+                 N + N + N2 -> N2B + N2     : 2.4e-33'
+  [../]
+[]
+
+
+[AuxVariables]
+  [./reduced_field]
+    order = FIRST
+    family = SCALAR
+  [../]
+
+  [./e]
+    order = FIRST
+    family = SCALAR
+  [../]
+
+  [./Te]
+    order = FIRST
+    family = SCALAR
+  [../]
+
+  [./Teff]
+    order = FIRST
+    family = SCALAR
+  [../]
+[]
+
+[AuxScalarKernels]
+  [./field_calculation]
+    type = DataReadScalar
+    variable = reduced_field
+    # scale_factor = 1e-21
+    use_time = true
+    property_file = 'Example4/reduced_field.txt'
+    # execute_on = 'INITIAL TIMESTEP_END'
+    execute_on = 'TIMESTEP_BEGIN'
+  [../]
+
+  [./temperature_calculation]
+    type = DataReadScalar
+    variable = Te
+    scale_factor = 1.5e-1
+    sampler = reduced_field
+    property_file = 'Example4/electron_temperature.txt'
+    # execute_on = 'TIMESTEP_BEGIN'
+    execute_on = 'TIMESTEP_BEGIN'
+  [../]
+
+  [./density_calculation]
+    type = DataReadScalar
+    variable = e
+    use_time = true
+    property_file = 'Example4/electron_density.txt'
+    # execute_on = 'INITIAL TIMESTEP_END'
+    execute_on = 'TIMESTEP_BEGIN'
+  [../]
+
+  [./Teff_calculation]
+    type = ParsedAuxScalar
+    variable = Teff
+    constant_names = 'Tgas'
+    constant_expressions = '300'
+    args = 'reduced_field'
+    function = 'Tgas+(0.12*(reduced_field*1e21)^2)'
+    execute_on = 'INITIAL NONLINEAR'
+  [../]
+[]
+
+[Executioner]
+  type = Transient
+  end_time = 2.5e-3
+  solve_type = NEWTON
+  # scheme = crank-nicolson
+  # scheme = newmark-beta
+  # dtmin = 1e-20
+  # dtmax = 1e-5
+  # petsc_options_iname = '-snes_linesearch_type'
+  # petsc_options_value = 'l2'
+  # petsc_options_iname = '-pc_type -pc_factor_shift_type -pc_factor_shift_amount -ksp_type -snes_linesearch_minlambda'
+  # petsc_options_value = 'lu NONZERO 1.e-10 preonly 1e-3'
+  line_search = basic
+  nl_rel_tol = 1e-5
+  # nl_abs_tol = 7e-5
+  # dt = 1e-5
+  dtmax = 1e-5
+  # [./TimeStepper]
+  #   type = CSVTimeSequenceStepper
+  #   file_name = 'Example4/reduced_field.txt'
+  #   delimiter = ' '
+  #   column_index = 0
+  # [../]
+  [./TimeStepper]
+    type = IterationAdaptiveDT
+    cutback_factor = 0.4
+    dt = 1e-8
+    growth_factor = 1.2
+    optimal_iterations = 15
+  [../]
+[]
+
+[Preconditioning]
+  [./smp]
+    type = SMP
+    full = true
+    # ksp_norm = none
+  [../]
+[]
+
+[Outputs]
+  csv = true
+  [./console]
+    type = Console
+    execute_scalars_on = 'none'
+    # execute_on = 'initial'
+  [../]
+[]

--- a/problems/e5.i
+++ b/problems/e5.i
@@ -47,10 +47,11 @@
     species = 'e Ar Ar+'
     file_location = 'Example5'
     sampling_variable = 'reduced_field'
-
+    track_rates = true
     # Add reactions here
     reactions = 'e + Ar -> e + e + Ar+   : EEDF
-                 e + Ar+ + Ar -> Ar + Ar : 1e-25'
+                 e + Ar+ + Ar -> Ar + Ar : 1e-25
+                 Ar+ -> Ar+               : 1e-5'
 
    [../]
 []
@@ -61,8 +62,52 @@
     family = SCALAR
     initial_condition = 50e-21
   [../]
+ [./Production0]
+    order = FIRST
+    family = SCALAR
+  [../]   
+ 
+ [./Production1]
+    order = FIRST
+    family = SCALAR
+  [../]   
+ [./Production2]
+    order = FIRST
+    family = SCALAR
+  [../]    
 []
 
+[AuxScalarKernels]
+
+  [./Prod2_Calc]
+    type = ProductionFirstOrder
+    variable = Production2
+    v = 'Ar+'
+    rate_coefficient = 'rate_constant2' 
+    coefficient = 1
+    execute_on = 'TIMESTEP_BEGIN'
+  [../]
+  [./Prod0_Calc]
+    type = ProductionSecondOrder
+    variable = Production0
+    v = 'e'
+    w = 'Ar'
+    rate_coefficient = 'rate_constant0' 
+    coefficient = 1
+    execute_on = 'TIMESTEP_BEGIN'
+  [../]
+  
+  [./Prod1_Calc]
+    type = ProductionThirdOrder
+    variable = Production1
+    v = 'e'
+    w = 'Ar'
+    z = 'Ar+'
+    rate_coefficient = 'rate_constant1'
+    coefficient = 1 
+    execute_on = 'TIMESTEP_BEGIN'
+  [../]
+[]
 
 [Executioner]
   type = Transient

--- a/problems/e5_plot.py
+++ b/problems/e5_plot.py
@@ -1,0 +1,50 @@
+import numpy as np
+import matplotlib.pylab as plt
+
+# Output CSV file name
+# file = 'example5_scale_out.csv'
+file = 'e5_out.csv'
+file2 = 'e5_track_out.csv'
+file3 = 'e4_out.csv'
+
+data = np.genfromtxt(file, dtype=float, delimiter=',', skip_header=1)
+data2 = np.genfromtxt(file2, dtype=float, delimiter=',', skip_header=1)
+data3 = np.genfromtxt(file3, dtype=float, delimiter=',', skip_header=1)
+names =['Ar','Ar+','Production2','Production0','Production3','e'] 
+names2 =['Ar','Ar+','e','Ar+ and e Production rate','Ar+ + e Recombination rate','test 1-Body Production rate'] 
+names3 =['N','N+','N2','N2+','N2A','N2B','N2C','N2a1','N3+','N4+','Te','Teff','e','rate0','rate1','rate10','rate11','rate12','rate13','rate14','rate15','rate16','rate17','rate18','rate19','rate2','rate20','rate21','rate22','rate23','rate24','rate25','rate26','rate27','rate28','rate29','rate3','rate30','rate31','rate32','rate33','rate4','rate5','rate6','rate7','rate8','rate9']
+print(data3)
+
+for i in range(len(names)):
+    plt.semilogy(data[:,0], data[:,i+1],label='%s'%names[i])
+plt.gca().set_prop_cycle(None)
+
+plt.xlabel('Time [s]', fontsize=14)
+plt.ylabel('Number Density, [$cm^{-3}$]', fontsize=14)
+plt.legend()
+plt.figure(2)
+for i in range(len(names2)):
+    plt.semilogy(data2[:,0], data2[:,i+1],'--',label='%s'%names2[i])
+plt.legend()
+
+plt.xlabel('Time [s]', fontsize=14)
+plt.ylabel('Number Density, [$cm^{-3}$]', fontsize=14)
+j = names3.index('rate0')
+plt.figure(3)
+for i in range(j):
+    plt.semilogy(data3[:,0], data3[:,i+1],label='%s'%names3[i])
+
+plt.xlabel('Time [s]', fontsize=14)
+plt.ylabel('Number Density, [$cm^{-3}$]', fontsize=14)
+plt.legend()
+
+plt.figure(4)
+for i in range(j,len(names3)):
+    plt.semilogy(data3[:,0], data3[:,i+1],'--',label='%s'%names3[i])
+plt.title('Rates')
+plt.xlabel('Time [s]', fontsize=14)
+plt.ylabel('Number Density, [$cm^{-3}$]', fontsize=14)
+
+
+plt.legend()
+plt.show()

--- a/problems/e5_track.i
+++ b/problems/e5_track.i
@@ -47,11 +47,12 @@
     species = 'e Ar Ar+'
     file_location = 'Example5'
     sampling_variable = 'reduced_field'
-
+    track_rates = true
     # Add reactions here
-    reactions = 'e + Ar -> e + e + Ar+   : EEDF
-                 e + Ar+ + Ar -> Ar + Ar : 1e-25'
-
+    reactions = 'e + Ar -> e + e + Ar+   : EEDF 
+                 e + Ar+ + Ar -> Ar + Ar : 1e-25
+                 Ar+ -> Ar+ : 1e-14
+'
    [../]
 []
 

--- a/problems/example1.i
+++ b/problems/example1.i
@@ -39,7 +39,7 @@
   [./ScalarNetwork]
     species = 'x y'
     reaction_coefficient_format = 'rate'
-
+    track_rates = True
     reactions = 'x -> x + x             : 0.666667
                  x + y -> y             : 1.333333
                  y + x -> x + y + y     : 1

--- a/problems/example1_spatial.i
+++ b/problems/example1_spatial.i
@@ -44,9 +44,10 @@
     species = 'x y dummy'
     reaction_coefficient_format = 'rate'
     equation_variables = 'H2O'
-
-    reactions = 'x -> x + x  : 1.1
+    track_rates = True
+    reactions = '
                  x + y -> y  : 0.4
+                 x -> x + x  : 1.1
                  y + x -> x + y + y  : 0.1
                  y -> z  : 0.4
                  x + y -> dummy : {1e-5*H2O}'

--- a/src/actions/AddScalarReactions.C
+++ b/src/actions/AddScalarReactions.C
@@ -116,6 +116,10 @@ AddScalarReactions::act()
     for (unsigned int i = 0; i < _num_reactions; ++i)
     {
       _problem->addAuxScalarVariable(_aux_var_name[i], FIRST);
+      if (_track_rates == true)
+      {
+      	_problem->addAuxScalarVariable("rate" + std::to_string(i), FIRST);
+      }
     }
   }
 
@@ -266,6 +270,48 @@ AddScalarReactions::act()
         params.set<ExecFlagEnum>("execute_on") = "TIMESTEP_BEGIN";
         _problem->addAuxScalarKernel(
             "SuperelasticRateCoefficientScalar", "aux_rate" + std::to_string(i), params);
+      }
+      
+      if (_track_rates == true)
+      {
+
+        if (_reactants[i].size() == 1)
+	{
+		InputParameters params = _factory.getValidParams("ProductionFirstOrder");
+		params.set<std::vector<VariableName>>("v") = {(_reactants[i][0])};
+		params.set<AuxVariableName>("variable") = {"rate" + std::to_string(i)};
+            	params.set<std::vector<VariableName>>("rate_coefficient") = {_aux_var_name[i]};
+		params.set<Real>("coefficient") = 1;//_reaction_stoichiometric_coeff[i].back();
+        	params.set<ExecFlagEnum>("execute_on") = "TIMESTEP_BEGIN";
+		_problem->addAuxScalarKernel(
+            "ProductionFirstOrder", "Calc_Production_Rate" + std::to_string(i), params);
+	}
+	else if (_reactants[i].size() == 2)
+	{
+		InputParameters params = _factory.getValidParams("ProductionSecondOrder");
+		params.set<std::vector<VariableName>>("v") = {(_reactants[i][0])};
+		params.set<std::vector<VariableName>>("w") = {(_reactants[i][1])};
+		params.set<AuxVariableName>("variable") = {"rate" + std::to_string(i)};
+            	params.set<std::vector<VariableName>>("rate_coefficient") = {_aux_var_name[i]};
+		params.set<Real>("coefficient") = 1;//_reaction_stoichiometric_coeff[i].back();
+        	params.set<ExecFlagEnum>("execute_on") = "TIMESTEP_BEGIN";
+		_problem->addAuxScalarKernel(
+            "ProductionSecondOrder", "Calc_Production_Rate" + std::to_string(i), params);
+	}
+
+	else if (_reactants[i].size() == 3)
+	{
+		InputParameters params = _factory.getValidParams("ProductionThirdOrder");
+		params.set<std::vector<VariableName>>("v") = {(_reactants[i][0])};
+		params.set<std::vector<VariableName>>("w") = {(_reactants[i][1])};
+		params.set<std::vector<VariableName>>("z") = {(_reactants[i][2])};
+		params.set<AuxVariableName>("variable") = {"rate" + std::to_string(i)};
+            	params.set<std::vector<VariableName>>("rate_coefficient") = {_aux_var_name[i]};
+		params.set<Real>("coefficient") = 1;//_reaction_stoichiometric_coeff[i].back();
+        	params.set<ExecFlagEnum>("execute_on") = "TIMESTEP_BEGIN";
+		_problem->addAuxScalarKernel(
+            "ProductionThirdOrder", "Calc_Production_Rate" + std::to_string(i), params);
+	}
       }
     }
   }

--- a/src/actions/ChemicalReactionsBase.C
+++ b/src/actions/ChemicalReactionsBase.C
@@ -53,6 +53,8 @@ validParams<ChemicalReactionsBase>()
       "include_electrons", false, "Whether or not electrons are being considered.");
   params.addParam<bool>(
       "use_log", false, "Whether or not to use logarithmic densities. (N = exp(n))");
+  params.addParam<bool>(
+      "track_rates", true, "Whether or not to track production rates for each reaction");
   params.addParam<std::string>("electron_density", "The variable used for density of electrons.");
   params.addParam<std::vector<NonlinearVariableName>>(
       "electron_energy", "Electron energy, used for energy-dependent reaction rates.");
@@ -113,8 +115,9 @@ ChemicalReactionsBase::ChemicalReactionsBase(InputParameters params)
     _r_units(getParam<Real>("position_units")),
     _sampling_variable(getParam<std::string>("sampling_variable")),
     _use_log(getParam<bool>("use_log")),
+    _track_rates(getParam<bool>("track_rates")),
     _use_bolsig(getParam<bool>("use_bolsig"))
-// _use_moles(getParam<bool>("use_moles"))
+	// _use_moles(getParam<bool>("use_moles"))
 {
   std::istringstream iss(_input_reactions);
   std::string token;

--- a/src/auxkernels/ProcRateForRateCoeffThreeBody_Crane.C
+++ b/src/auxkernels/ProcRateForRateCoeffThreeBody_Crane.C
@@ -1,0 +1,48 @@
+//* This file is part of Zapdos, an open-source
+//* application for the simulation of plasmas
+//* https://github.com/shannon-lab/zapdos
+//*
+//* Zapdos is powered by the MOOSE Framework
+//* https://www.mooseframework.org
+//*
+//* Licensed under LGPL 2.1, please see LICENSE for details
+//* https://www.gnu.org/licenses/lgpl-2.1.html
+
+#include "ProcRateForRateCoeffThreeBody_Crane.h"
+
+registerMooseObject("ZapdosApp", ProcRateForRateCoeffThreeBody_Crane);
+
+template <>
+InputParameters
+validParams<ProcRateForRateCoeffThreeBody_Crane>()
+{
+  InputParameters params = validParams<AuxKernel>();
+
+  params.addCoupledVar("v", "The first variable that is reacting to create u.");
+  params.addCoupledVar("w", "The second variable that is reacting to create u.");
+  params.addCoupledVar("vv", "The second variable that is reacting to create u.");
+  params.addRequiredParam<std::string>("reaction", "The full reaction equation.");
+  params.addClassDescription(
+    "Reaction rate for three body collisions in units of #/m^3s. User can pass"
+    "choice of elastic, excitation, or ionization reaction rate coefficients");
+
+  return params;
+}
+
+ProcRateForRateCoeffThreeBody_Crane::ProcRateForRateCoeffThreeBody_Crane(const InputParameters & parameters)
+  : AuxKernel(parameters),
+
+  _v(coupledValue("v")),
+  _w(coupledValue("w")),
+  _vv(coupledValue("vv")),
+  _reaction_coeff(getMaterialProperty<Real>("k_" + getParam<std::string>("reaction")))
+{
+}
+
+Real
+ProcRateForRateCoeffThreeBody_Crane::computeValue()
+{
+
+  return 6.02e23 * _reaction_coeff[_qp] * std::exp(_v[_qp]) * std::exp(_w[_qp]) * std::exp(_vv[_qp]);
+
+}

--- a/src/auxkernels/ProcRateForRateCoeffThreeBody_Crane.C
+++ b/src/auxkernels/ProcRateForRateCoeffThreeBody_Crane.C
@@ -1,16 +1,20 @@
-//* This file is part of Zapdos, an open-source
-//* application for the simulation of plasmas
-//* https://github.com/shannon-lab/zapdos
-//*
-//* Zapdos is powered by the MOOSE Framework
-//* https://www.mooseframework.org
-//*
-//* Licensed under LGPL 2.1, please see LICENSE for details
-//* https://www.gnu.org/licenses/lgpl-2.1.html
+/****************************************************************/
+/*               DO NOT MODIFY THIS HEADER                      */
+/* MOOSE - Multiphysics Object Oriented Simulation Environment  */
+/*                                                              */
+/*           (c) 2010 Battelle Energy Alliance, LLC             */
+/*                   ALL RIGHTS RESERVED                        */
+/*                                                              */
+/*          Prepared by Battelle Energy Alliance, LLC           */
+/*            Under Contract No. DE-AC07-05ID14517              */
+/*            With the U. S. Department of Energy               */
+/*                                                              */
+/*            See COPYRIGHT for full restrictions               */
+/****************************************************************/
 
 #include "ProcRateForRateCoeffThreeBody_Crane.h"
 
-registerMooseObject("ZapdosApp", ProcRateForRateCoeffThreeBody_Crane);
+registerMooseObject("CraneApp", ProcRateForRateCoeffThreeBody_Crane);
 
 template <>
 InputParameters

--- a/src/auxkernels/ProcRateForRateCoeff_Crane.C
+++ b/src/auxkernels/ProcRateForRateCoeff_Crane.C
@@ -1,0 +1,46 @@
+//* This file is part of Zapdos, an open-source
+//* application for the simulation of plasmas
+//* https://github.com/shannon-lab/zapdos
+//*
+//* Zapdos is powered by the MOOSE Framework
+//* https://www.mooseframework.org
+//*
+//* Licensed under LGPL 2.1, please see LICENSE for details
+//* https://www.gnu.org/licenses/lgpl-2.1.html
+
+#include "ProcRateForRateCoeff_Crane.h"
+
+registerMooseObject("ZapdosApp", ProcRateForRateCoeff_Crane);
+
+template <>
+InputParameters
+validParams<ProcRateForRateCoeff_Crane>()
+{
+  InputParameters params = validParams<AuxKernel>();
+
+  params.addCoupledVar("v", "The first variable that is reacting to create u.");
+  params.addCoupledVar("w", "The second variable that is reacting to create u.");
+  params.addRequiredParam<std::string>("reaction", "The full reaction equation.");
+  params.addClassDescription(
+    "Reaction rate for two body collisions in units of #/m^3s. User can pass"
+    "choice of elastic, excitation, or ionization reaction rate coefficients");
+
+  return params;
+}
+
+ProcRateForRateCoeff_Crane::ProcRateForRateCoeff_Crane(const InputParameters & parameters)
+  : AuxKernel(parameters),
+
+  _v(coupledValue("v")),
+  _w(coupledValue("w")),
+  _reaction_coeff(getMaterialProperty<Real>("k_" + getParam<std::string>("reaction")))
+{
+}
+
+Real
+ProcRateForRateCoeff_Crane::computeValue()
+{
+
+  return 6.02e23 * _reaction_coeff[_qp] * std::exp(_v[_qp]) * std::exp(_w[_qp]);
+
+}

--- a/src/auxkernels/ProcRateForRateCoeff_Crane.C
+++ b/src/auxkernels/ProcRateForRateCoeff_Crane.C
@@ -1,16 +1,20 @@
-//* This file is part of Zapdos, an open-source
-//* application for the simulation of plasmas
-//* https://github.com/shannon-lab/zapdos
-//*
-//* Zapdos is powered by the MOOSE Framework
-//* https://www.mooseframework.org
-//*
-//* Licensed under LGPL 2.1, please see LICENSE for details
-//* https://www.gnu.org/licenses/lgpl-2.1.html
+/****************************************************************/
+/*               DO NOT MODIFY THIS HEADER                      */
+/* MOOSE - Multiphysics Object Oriented Simulation Environment  */
+/*                                                              */
+/*           (c) 2010 Battelle Energy Alliance, LLC             */
+/*                   ALL RIGHTS RESERVED                        */
+/*                                                              */
+/*          Prepared by Battelle Energy Alliance, LLC           */
+/*            Under Contract No. DE-AC07-05ID14517              */
+/*            With the U. S. Department of Energy               */
+/*                                                              */
+/*            See COPYRIGHT for full restrictions               */
+/****************************************************************/
 
 #include "ProcRateForRateCoeff_Crane.h"
 
-registerMooseObject("ZapdosApp", ProcRateForRateCoeff_Crane);
+registerMooseObject("CraneApp", ProcRateForRateCoeff_Crane);
 
 template <>
 InputParameters

--- a/src/auxkernels/ProcRateForRateCoeff_OneBody_Crane.C
+++ b/src/auxkernels/ProcRateForRateCoeff_OneBody_Crane.C
@@ -1,0 +1,41 @@
+//* This file is part of Zapdos, an open-source
+//* application for the simulation of plasmas
+//* https://github.com/shannon-lab/zapdos
+//*
+//* Zapdos is powered by the MOOSE Framework
+//* https://www.mooseframework.org
+//*
+//* Licensed under LGPL 2.1, please see LICENSE for details
+//* https://www.gnu.org/licenses/lgpl-2.1.html
+
+#include "ProcRateForRateCoeff_OneBody_Crane.h"
+
+registerMooseObject("ZapdosApp", ProcRateForRateCoeff_OneBody_Crane);
+
+template <>
+InputParameters
+validParams<ProcRateForRateCoeff_OneBody_Crane>()
+{
+  InputParameters params = validParams<AuxKernel>();
+
+  params.addCoupledVar("v", "The first variable that is reacting to create u.");
+  params.addRequiredParam<std::string>("reaction", "The full reaction equation.");
+
+  return params;
+}
+
+ProcRateForRateCoeff_OneBody_Crane::ProcRateForRateCoeff_OneBody_Crane(const InputParameters & parameters)
+  : AuxKernel(parameters),
+
+  _v(coupledValue("v")),
+  _reaction_coeff(getMaterialProperty<Real>("k_" + getParam<std::string>("reaction")))
+{
+}
+
+Real
+ProcRateForRateCoeff_OneBody_Crane::computeValue()
+{
+
+  return 6.02e23 * _reaction_coeff[_qp] * std::exp(_v[_qp]);
+
+}

--- a/src/auxkernels/ProcRateForRateCoeff_OneBody_Crane.C
+++ b/src/auxkernels/ProcRateForRateCoeff_OneBody_Crane.C
@@ -1,16 +1,20 @@
-//* This file is part of Zapdos, an open-source
-//* application for the simulation of plasmas
-//* https://github.com/shannon-lab/zapdos
-//*
-//* Zapdos is powered by the MOOSE Framework
-//* https://www.mooseframework.org
-//*
-//* Licensed under LGPL 2.1, please see LICENSE for details
-//* https://www.gnu.org/licenses/lgpl-2.1.html
+/****************************************************************/
+/*               DO NOT MODIFY THIS HEADER                      */
+/* MOOSE - Multiphysics Object Oriented Simulation Environment  */
+/*                                                              */
+/*           (c) 2010 Battelle Energy Alliance, LLC             */
+/*                   ALL RIGHTS RESERVED                        */
+/*                                                              */
+/*          Prepared by Battelle Energy Alliance, LLC           */
+/*            Under Contract No. DE-AC07-05ID14517              */
+/*            With the U. S. Department of Energy               */
+/*                                                              */
+/*            See COPYRIGHT for full restrictions               */
+/****************************************************************/
 
 #include "ProcRateForRateCoeff_OneBody_Crane.h"
 
-registerMooseObject("ZapdosApp", ProcRateForRateCoeff_OneBody_Crane);
+registerMooseObject("CraneApp", ProcRateForRateCoeff_OneBody_Crane);
 
 template <>
 InputParameters

--- a/src/auxkernels/ProcRateForRateCoeff_Townsend_Crane.C
+++ b/src/auxkernels/ProcRateForRateCoeff_Townsend_Crane.C
@@ -1,16 +1,20 @@
-//* This file is part of Zapdos, an open-source
-//* application for the simulation of plasmas
-//* https://github.com/shannon-lab/zapdos
-//*
-//* Zapdos is powered by the MOOSE Framework
-//* https://www.mooseframework.org
-//*
-//* Licensed under LGPL 2.1, please see LICENSE for details
-//* https://www.gnu.org/licenses/lgpl-2.1.html
+/****************************************************************/
+/*               DO NOT MODIFY THIS HEADER                      */
+/* MOOSE - Multiphysics Object Oriented Simulation Environment  */
+/*                                                              */
+/*           (c) 2010 Battelle Energy Alliance, LLC             */
+/*                   ALL RIGHTS RESERVED                        */
+/*                                                              */
+/*          Prepared by Battelle Energy Alliance, LLC           */
+/*            Under Contract No. DE-AC07-05ID14517              */
+/*            With the U. S. Department of Energy               */
+/*                                                              */
+/*            See COPYRIGHT for full restrictions               */
+/****************************************************************/
 
 #include "ProcRateForRateCoeff_Townsend_Crane.h"
 
-registerMooseObject("ZapdosApp", ProcRateForRateCoeff_Townsend_Crane);
+registerMooseObject("CraneApp", ProcRateForRateCoeff_Townsend_Crane);
 
 template <>
 InputParameters

--- a/src/auxkernels/ProcRateForRateCoeff_Townsend_Crane.C
+++ b/src/auxkernels/ProcRateForRateCoeff_Townsend_Crane.C
@@ -1,0 +1,68 @@
+//* This file is part of Zapdos, an open-source
+//* application for the simulation of plasmas
+//* https://github.com/shannon-lab/zapdos
+//*
+//* Zapdos is powered by the MOOSE Framework
+//* https://www.mooseframework.org
+//*
+//* Licensed under LGPL 2.1, please see LICENSE for details
+//* https://www.gnu.org/licenses/lgpl-2.1.html
+
+#include "ProcRateForRateCoeff_Townsend_Crane.h"
+
+registerMooseObject("ZapdosApp", ProcRateForRateCoeff_Townsend_Crane);
+
+template <>
+InputParameters
+validParams<ProcRateForRateCoeff_Townsend_Crane>()
+{
+  InputParameters params = validParams<AuxKernel>();
+
+  params.addRequiredCoupledVar("mean_en", "The electron mean energy.");
+  params.addRequiredCoupledVar("potential", "The potential.");
+  params.addRequiredCoupledVar("em", "The electron density.");
+  params.addCoupledVar("target", "The coupled target. If none, assumed to be background gas from BOLSIG+.");
+  params.addRequiredParam<Real>("position_units", "Units of position.");
+  params.addRequiredParam<std::string>("reaction", "Stores the full reaction equation.");
+  params.addRequiredParam<std::string>("reaction_coefficient_name",
+                                       "Stores the name of the reaction rate/townsend coefficient, "
+                                       "unique to each individual reaction.");
+  return params;
+}
+
+ProcRateForRateCoeff_Townsend_Crane::ProcRateForRateCoeff_Townsend_Crane(const InputParameters & parameters)
+  : AuxKernel(parameters),
+
+    _r_units(1. / getParam<Real>("position_units")),
+    _reaction_coeff_name(getParam<std::string>("reaction_coefficient_name")),
+    _reaction_name(getParam<std::string>("reaction")),
+    _diffem(getMaterialProperty<Real>("diffem")),
+    _muem(getMaterialProperty<Real>("muem")),
+    // _alpha(getMaterialProperty<Real>("alpha_iz")),
+    _alpha(getMaterialProperty<Real>(_reaction_coeff_name)),
+    // _d_iz_d_actual_mean_en(getMaterialProperty<Real>("d_iz_d_actual_mean_en")),
+    _d_iz_d_actual_mean_en(getMaterialProperty<Real>("d_alpha_d_en_" + _reaction_name)),
+    _d_muem_d_actual_mean_en(getMaterialProperty<Real>("d_muem_d_actual_mean_en")),
+    _d_diffem_d_actual_mean_en(getMaterialProperty<Real>("d_diffem_d_actual_mean_en")),
+    _mean_en(coupledValue("mean_en")),
+    _grad_potential(coupledGradient("potential")),
+    _em(coupledValue("em")),
+    _grad_em(coupledGradient("em")),
+    _mean_en_id(coupled("mean_en")),
+    _potential_id(coupled("potential")),
+    _em_id(coupled("em")),
+    _target(isCoupled("target") ? coupledValue("target") : _zero),
+    _target_id(isCoupled("target") ? coupled("target") : 12345678) 
+{
+}
+
+Real
+ProcRateForRateCoeff_Townsend_Crane::computeValue()
+{
+
+  Real electron_flux_mag = (-_muem[_qp] * -_grad_potential[_qp] * _r_units * std::exp(_em[_qp]) -
+                            _diffem[_qp] * std::exp(_em[_qp]) * _grad_em[_qp] * _r_units)
+                               .norm();
+  return _alpha[_qp] * electron_flux_mag;
+
+}

--- a/src/auxkernels/ProductionFirstOrder.C
+++ b/src/auxkernels/ProductionFirstOrder.C
@@ -1,0 +1,42 @@
+/****************************************************************/
+/*               DO NOT MODIFY THIS HEADER                      */
+/* MOOSE - Multiphysics Object Oriented Simulation Environment  */
+/*                                                              */
+/*           (c) 2010 Battelle Energy Alliance, LLC             */
+/*                   ALL RIGHTS RESERVED                        */
+/*                                                              */
+/*          Prepared by Battelle Energy Alliance, LLC           */
+/*            Under Contract No. DE-AC07-05ID14517              */
+/*            With the U. S. Department of Energy               */
+/*                                                              */
+/*            See COPYRIGHT for full restrictions               */
+/****************************************************************/
+
+#include "ProductionFirstOrder.h"
+
+registerMooseObject("CraneApp", ProductionFirstOrder);
+
+template <>
+InputParameters
+validParams<ProductionFirstOrder>()
+{
+  InputParameters params = validParams<AuxScalarKernel>();
+  params.addRequiredCoupledVar("v", "The first variable that is reacting to create u.");
+  params.addCoupledVar("rate_coefficient", 0, "Coupled reaction coefficient (if equation-based).");
+  params.addRequiredParam<Real>("coefficient", "The stoichiometric coeffient.");
+  return params;
+}
+
+ProductionFirstOrder::ProductionFirstOrder(const InputParameters & parameters)
+  : AuxScalarKernel(parameters),
+    _v(coupledScalarValue("v")),
+    _rate_coefficient(coupledScalarValue("rate_coefficient")),
+    _stoichiometric_coeff(getParam<Real>("coefficient"))
+{
+}
+
+Real
+ProductionFirstOrder::computeValue()
+{
+  return _stoichiometric_coeff * _rate_coefficient[_i] * _v[_i]; 
+}

--- a/src/auxkernels/ProductionSecondOrder.C
+++ b/src/auxkernels/ProductionSecondOrder.C
@@ -1,0 +1,44 @@
+/****************************************************************/
+/*               DO NOT MODIFY THIS HEADER                      */
+/* MOOSE - Multiphysics Object Oriented Simulation Environment  */
+/*                                                              */
+/*           (c) 2010 Battelle Energy Alliance, LLC             */
+/*                   ALL RIGHTS RESERVED                        */
+/*                                                              */
+/*          Prepared by Battelle Energy Alliance, LLC           */
+/*            Under Contract No. DE-AC07-05ID14517              */
+/*            With the U. S. Department of Energy               */
+/*                                                              */
+/*            See COPYRIGHT for full restrictions               */
+/****************************************************************/
+
+#include "ProductionSecondOrder.h"
+
+registerMooseObject("CraneApp", ProductionSecondOrder);
+
+template <>
+InputParameters
+validParams<ProductionSecondOrder>()
+{
+  InputParameters params = validParams<AuxScalarKernel>();
+  params.addRequiredCoupledVar("v", "The first variable that is reacting to create u.");
+  params.addRequiredCoupledVar("w", "The second variable that is reacting to create u.");
+  params.addCoupledVar("rate_coefficient", 0, "Coupled reaction coefficient (if equation-based).");
+  params.addRequiredParam<Real>("coefficient", "The stoichiometric coeffient.");
+  return params;
+}
+
+ProductionSecondOrder::ProductionSecondOrder(const InputParameters & parameters)
+  : AuxScalarKernel(parameters),
+    _v(coupledScalarValue("v")),
+    _w(coupledScalarValue("w")),
+    _rate_coefficient(coupledScalarValue("rate_coefficient")),
+    _stoichiometric_coeff(getParam<Real>("coefficient"))
+{
+}
+
+Real
+ProductionSecondOrder::computeValue()
+{
+  return _stoichiometric_coeff * _rate_coefficient[_i] * _v[_i] * _w[_i];
+}

--- a/src/auxkernels/ProductionThirdOrder.C
+++ b/src/auxkernels/ProductionThirdOrder.C
@@ -1,0 +1,46 @@
+/****************************************************************/
+/*               DO NOT MODIFY THIS HEADER                      */
+/* MOOSE - Multiphysics Object Oriented Simulation Environment  */
+/*                                                              */
+/*           (c) 2010 Battelle Energy Alliance, LLC             */
+/*                   ALL RIGHTS RESERVED                        */
+/*                                                              */
+/*          Prepared by Battelle Energy Alliance, LLC           */
+/*            Under Contract No. DE-AC07-05ID14517              */
+/*            With the U. S. Department of Energy               */
+/*                                                              */
+/*            See COPYRIGHT for full restrictions               */
+/****************************************************************/
+
+#include "ProductionThirdOrder.h"
+
+registerMooseObject("CraneApp", ProductionThirdOrder);
+
+template <>
+InputParameters
+validParams<ProductionThirdOrder>()
+{
+  InputParameters params = validParams<AuxScalarKernel>();
+  params.addRequiredCoupledVar("v", "The first variable that is reacting to create u.");
+  params.addRequiredCoupledVar("w", "The second variable that is reacting to create u.");
+  params.addRequiredCoupledVar("z", "The second variable that is reacting to create u.");
+  params.addCoupledVar("rate_coefficient", 0, "Coupled reaction coefficient (if equation-based).");
+  params.addRequiredParam<Real>("coefficient", "The stoichiometric coeffient.");
+  return params;
+}
+
+ProductionThirdOrder::ProductionThirdOrder(const InputParameters & parameters)
+  : AuxScalarKernel(parameters),
+    _v(coupledScalarValue("v")),
+    _w(coupledScalarValue("w")),
+    _z(coupledScalarValue("z")),
+    _rate_coefficient(coupledScalarValue("rate_coefficient")),
+    _stoichiometric_coeff(getParam<Real>("coefficient"))
+{
+}
+
+Real
+ProductionThirdOrder::computeValue()
+{
+  return _stoichiometric_coeff * _rate_coefficient[_i] * _v[_i] * _w[_i] * _z[_i];
+}

--- a/src/kernels/ElectronImpactReactionProduct.C
+++ b/src/kernels/ElectronImpactReactionProduct.C
@@ -69,6 +69,7 @@ ElectronImpactReactionProduct::computeQpResidual()
   // Real iz_term = alpha * electron_flux_mag;
 
   // return -_test[_i][_qp] * iz_term;
+ 
   return -_test[_i][_qp] * _alpha[_qp] * electron_flux_mag;
 }
 

--- a/src/kernels/ElectronProductSecondOrderLog.C
+++ b/src/kernels/ElectronProductSecondOrderLog.C
@@ -53,7 +53,6 @@ ElectronProductSecondOrderLog::computeQpResidual()
   {
     mult2 = _n_gas[_qp];
   }
-
   return -_test[_i][_qp] * _stoichiometric_coeff * _reaction_coeff[_qp] * std::exp(_electron[_qp]) *
          mult2;
 }


### PR DESCRIPTION
Added auxiliary kernels to calculate the production rate of each species at the end of each timestep, to allow outputting of the production rate from each reaction as a function of time at each point in space. Rates are tracked by default, and can be turned off by including "track_rates = false" in the chemical_reactions block of the input file. 