### PR TITLE
Fixing bug that prevented multiple reactions with the same reactants …

### DIFF
--- a/include/actions/AddReactions.h
+++ b/include/actions/AddReactions.h
@@ -1,5 +1,4 @@
-#ifndef ADDREACTIONS_H
-#define ADDREACTIONS_H
+#pragma once
 
 #include "AddVariableAction.h"
 #include "Action.h"
@@ -23,5 +22,3 @@ protected:
   std::vector<std::string> _aux_species;
 
 };
-
-#endif // ADDREACTIONS_H

--- a/include/actions/AddScalarReactions.h
+++ b/include/actions/AddScalarReactions.h
@@ -1,5 +1,4 @@
-#ifndef ADDSCALARREACTIONS_H
-#define ADDSCALARREACTIONS_H
+#pragma once
 
 #include "AddVariableAction.h"
 #include "Action.h"
@@ -21,8 +20,4 @@ public:
 
 protected:
   std::vector<std::string> _aux_species;
-
-
 };
-
-#endif // ADDSCALARREACTIONS_H

--- a/include/actions/AddScalarReactionsOld.h
+++ b/include/actions/AddScalarReactionsOld.h
@@ -1,5 +1,4 @@
-#ifndef ADDSCALARREACTIONSOLD_H
-#define ADDSCALARREACTIONSOLD_H
+#pragma once
 
 #include "AddVariableAction.h"
 #include "Action.h"
@@ -59,7 +58,4 @@ protected:
   std::vector<std::string> _rate_equation_string;
   /// Number of reactions
   unsigned int _num_reactions;
-
 };
-
-#endif // ADDSCALARREACTIONSOLD_H

--- a/include/actions/AddSpecies.h
+++ b/include/actions/AddSpecies.h
@@ -1,5 +1,4 @@
-#ifndef ADDSPECIES_H
-#define ADDSPECIES_H
+#pragma once
 
 #include "AddVariableAction.h"
 #include "Action.h"
@@ -28,5 +27,3 @@ private:
   /// Variable scaling
   const std::vector<Real> _scale_factor;
 };
-
-#endif // ADDSPECIES_H

--- a/include/actions/AddZapdosReactions.h
+++ b/include/actions/AddZapdosReactions.h
@@ -1,5 +1,4 @@
-#ifndef ADDZAPDOSREACTIONS_H
-#define ADDZAPDOSREACTIONS_H
+#pragma once
 
 #include "AddVariableAction.h"
 #include "Action.h"
@@ -20,8 +19,4 @@ public:
 protected:
   std::string _coefficient_format;
   std::vector<std::string> _aux_species;
-
-
 };
-
-#endif // ADDZAPDOSREACTIONS_H

--- a/include/actions/ChemicalReactions.h
+++ b/include/actions/ChemicalReactions.h
@@ -1,5 +1,4 @@
-#ifndef CHEMICALREACTIONS_H
-#define CHEMICALREACTIONS_H
+#pragma once
 
 #include "AddVariableAction.h"
 #include "Action.h"
@@ -59,7 +58,4 @@ protected:
   std::vector<std::string> _rate_equation_string;
   /// Number of reactions
   unsigned int _num_reactions;
-
 };
-
-#endif // CHEMICALREACTIONS_H

--- a/include/actions/ChemicalReactionsBase.h
+++ b/include/actions/ChemicalReactionsBase.h
@@ -1,5 +1,4 @@
-#ifndef CHEMICALREACTIONSBASE_H
-#define CHEMICALREACTIONSBASE_H
+#pragma once
 
 #include "AddVariableAction.h"
 #include "Action.h"
@@ -71,5 +70,3 @@ protected:
   std::vector<NonlinearVariableName> _energy_variable;
   bool _use_bolsig;
 };
-
-#endif // CHEMICALREACTIONSBASE_H

--- a/include/auxkernels/AuxInitialConditionScalar.h
+++ b/include/auxkernels/AuxInitialConditionScalar.h
@@ -12,8 +12,7 @@
 /*            See COPYRIGHT for full restrictions               */
 /****************************************************************/
 
-#ifndef AUXINITIALCONDITIONSCALAR_H
-#define AUXINITIALCONDITIONSCALAR_H
+#pragma once
 
 #include "AuxScalarKernel.h"
 #include "SplineInterpolation.h"
@@ -32,5 +31,3 @@ protected:
   virtual Real computeValue();
   Real _value;
 };
-
-#endif // AUXINITIALCONDITIONSCALAR_H

--- a/include/auxkernels/BolsigValueScalar.h
+++ b/include/auxkernels/BolsigValueScalar.h
@@ -12,8 +12,7 @@
 /*            See COPYRIGHT for full restrictions               */
 /****************************************************************/
 
-#ifndef BOLSIGVALUESCALAR_H
-#define BOLSIGVALUESCALAR_H
+#pragma once
 
 #include "AuxScalarKernel.h"
 #include "SplineInterpolation.h"
@@ -37,5 +36,3 @@ protected:
   bool _sample_value;
   const VariableValue & _sampler_var;
 };
-
-#endif // BOLSIGVALUESCALAR_H

--- a/include/auxkernels/DataRead.h
+++ b/include/auxkernels/DataRead.h
@@ -12,8 +12,7 @@
 /*            See COPYRIGHT for full restrictions               */
 /****************************************************************/
 
-#ifndef DATAREAD_H
-#define DATAREAD_H
+#pragma once
 
 #include "AuxKernel.h"
 #include "SplineInterpolation.h"
@@ -40,5 +39,3 @@ protected:
   bool _use_log;
   Real _scale_factor;
 };
-
-#endif // DATAREAD_H

--- a/include/auxkernels/DataReadScalar.h
+++ b/include/auxkernels/DataReadScalar.h
@@ -12,8 +12,7 @@
 /*            See COPYRIGHT for full restrictions               */
 /****************************************************************/
 
-#ifndef DATAREADSCALAR_H
-#define DATAREADSCALAR_H
+#pragma once
 
 #include "AuxScalarKernel.h"
 #include "SplineInterpolation.h"
@@ -40,5 +39,3 @@ protected:
   bool _use_log;
   Real _scale_factor;
 };
-
-#endif // DATAREADSCALAR_H

--- a/include/auxkernels/DensityLogConvert.h
+++ b/include/auxkernels/DensityLogConvert.h
@@ -1,5 +1,4 @@
-#ifndef DENSITYLOGCONVERT_H
-#define DENSITYLOGCONVERT_H
+#pragma once
 
 #include "AuxKernel.h"
 
@@ -22,5 +21,3 @@ protected:
   bool _convert_moles;
   // const MaterialProperty<Real> & _N_A;
 };
-
-#endif // DENSITYLOGCONVERT_H

--- a/include/auxkernels/DensityLogConvertScalar.h
+++ b/include/auxkernels/DensityLogConvertScalar.h
@@ -1,5 +1,4 @@
-#ifndef DENSITYLOGCONVERTSCALAR_H
-#define DENSITYLOGCONVERTSCALAR_H
+#pragma once
 
 #include "AuxScalarKernel.h"
 
@@ -22,5 +21,3 @@ protected:
   bool _convert_moles;
   // const MaterialProperty<Real> & _N_A;
 };
-
-#endif // DENSITYLOGCONVERTSCALAR_H

--- a/include/auxkernels/EEDFRateCoefficientScalar.h
+++ b/include/auxkernels/EEDFRateCoefficientScalar.h
@@ -12,8 +12,7 @@
 /*            See COPYRIGHT for full restrictions               */
 /****************************************************************/
 
-#ifndef EEDFRATECOEFFICIENTSCALAR_H
-#define EEDFRATECOEFFICIENTSCALAR_H
+#pragma once
 
 #include "AuxScalarKernel.h"
 #include "SplineInterpolation.h"
@@ -37,5 +36,3 @@ protected:
   bool _sample_value;
   const VariableValue & _sampler_var;
 };
-
-#endif // EEDFRATECOEFFICIENTSCALAR_H

--- a/include/auxkernels/ElectronMobility.h
+++ b/include/auxkernels/ElectronMobility.h
@@ -1,5 +1,4 @@
-#ifndef ELECTRONMOBILITY_H_
-#define ELECTRONMOBILITY_H_
+#pragma once
 
 #include "AuxScalarKernel.h"
 #include "SplineInterpolation.h"
@@ -23,5 +22,3 @@ protected:
 
   const VariableValue & _reduced_field;
 };
-
-#endif /* ELECTRONMOBILITY */

--- a/include/auxkernels/MoleFraction.h
+++ b/include/auxkernels/MoleFraction.h
@@ -12,8 +12,7 @@
 /*            See COPYRIGHT for full restrictions               */
 /****************************************************************/
 
-#ifndef MOLEFRACTION_H
-#define MOLEFRACTION_H
+#pragma once
 
 #include "AuxScalarKernel.h"
 // #include "SplineInterpolation.h"
@@ -33,5 +32,3 @@ protected:
   const VariableValue & _neutral_density;
   const VariableValue & _species_density;
 };
-
-#endif // MOLEFRACTION_H

--- a/include/auxkernels/ParsedAuxScalar.h
+++ b/include/auxkernels/ParsedAuxScalar.h
@@ -1,5 +1,4 @@
-#ifndef PARSEDAUXSCALAR_H
-#define PARSEDAUXSCALAR_H
+#pragma once
 
 #include "AuxScalarKernel.h"
 #include "FunctionParserUtils.h"
@@ -31,5 +30,3 @@ protected:
   /// function parser object for the resudual and on-diagonal Jacobian
   ADFunctionPtr _func_F;
 };
-
-#endif /* PARSEDAUXSCALAR_H */

--- a/include/auxkernels/ParsedScalarRateCoefficient.h
+++ b/include/auxkernels/ParsedScalarRateCoefficient.h
@@ -12,8 +12,7 @@
 /*            See COPYRIGHT for full restrictions               */
 /****************************************************************/
 
-#ifndef PARSEDSCALARRATECOEFFICIENT_H
-#define PARSEDSCALARRATECOEFFICIENT_H
+#pragma once
 
 #include "AuxScalarKernel.h"
 #include "FunctionParserUtils.h"
@@ -53,7 +52,4 @@ protected:
   // const ValueProvider & _data;
 
   ADFunctionPtr _func_F;
-
 };
-
-#endif // PARSEDSCALARRATECOEFFICIENT_H

--- a/include/auxkernels/ReactionRateOneBody.h
+++ b/include/auxkernels/ReactionRateOneBody.h
@@ -12,30 +12,26 @@
 /*            See COPYRIGHT for full restrictions               */
 /****************************************************************/
 
-#ifndef PROCRATEFORRATECOEFF_CRANE_H
-#define PROCRATEFORRATECOEFF_CRANE_H
+#pragma once
 
 #include "AuxKernel.h"
 
-class ProcRateForRateCoeff_Crane;
+class ReactionRateOneBody;
 
 template <>
-InputParameters validParams<ProcRateForRateCoeff_Crane>();
+InputParameters validParams<ReactionRateOneBody>();
 
-class ProcRateForRateCoeff_Crane : public AuxKernel
+class ReactionRateOneBody : public AuxKernel
 {
 public:
-  ProcRateForRateCoeff_Crane(const InputParameters & parameters);
+  ReactionRateOneBody(const InputParameters & parameters);
 
-  virtual ~ProcRateForRateCoeff_Crane() {}
+  virtual ~ReactionRateOneBody() {}
   virtual Real computeValue();
 
 protected:
 
 
   const VariableValue & _v;
-  const VariableValue & _w;
   const MaterialProperty<Real> & _reaction_coeff;
 };
-
-#endif // ProcRateForRateCoeff_Crane_H

--- a/include/auxkernels/ReactionRateOneBodyScalar.h
+++ b/include/auxkernels/ReactionRateOneBodyScalar.h
@@ -12,31 +12,27 @@
 /*            See COPYRIGHT for full restrictions               */
 /****************************************************************/
 
-#ifndef PRODUCTIONFIRSTORDER_H
-#define PRODUCTIONFIRSTORDER_H
+#pragma once
 
-#include "Kernel.h"
+#include "AuxScalarKernel.h"
 
 // Forward Declaration
-class ProductionFirstOrder;
+class ReactionRateOneBodyScalar;
 
 template <>
-InputParameters validParams<ProductionFirstOrder>();
+InputParameters validParams<ReactionRateOneBodyScalar>();
 
-class ProductionFirstOrder : public AuxScalarKernel
+class ReactionRateOneBodyScalar : public AuxScalarKernel
 {
 public:
-  ProductionFirstOrder(const InputParameters & parameters);
+  ReactionRateOneBodyScalar(const InputParameters & parameters);
 
 protected:
   virtual Real computeValue();
 
-  // MooseVariable & _coupled_var_A;
-  // MooseVariable & _coupled_var_B;
   const VariableValue & _v;
 
   // The reaction coefficient
   const VariableValue & _rate_coefficient;
   Real _stoichiometric_coeff;
 };
-#endif // PRODUCTIONFIRSTORDER_H

--- a/include/auxkernels/ReactionRateThreeBody.h
+++ b/include/auxkernels/ReactionRateThreeBody.h
@@ -12,32 +12,27 @@
 /*            See COPYRIGHT for full restrictions               */
 /****************************************************************/
 
-#ifndef PRODUCTIONSECONDORDER_H
-#define PRODUCTIONSECONDORDER_H
+#pragma once
 
-#include "Kernel.h"
+#include "AuxKernel.h"
 
-// Forward Declaration
-class ProductionSecondOrder;
+class ReactionRateThreeBody;
 
 template <>
-InputParameters validParams<ProductionSecondOrder>();
+InputParameters validParams<ReactionRateThreeBody>();
 
-class ProductionSecondOrder : public AuxScalarKernel
+class ReactionRateThreeBody : public AuxKernel
 {
 public:
-  ProductionSecondOrder(const InputParameters & parameters);
+  ReactionRateThreeBody(const InputParameters & parameters);
 
-protected:
+  virtual ~ReactionRateThreeBody() {}
   virtual Real computeValue();
 
-  // MooseVariable & _coupled_var_A;
-  // MooseVariable & _coupled_var_B;
+protected:
   const VariableValue & _v;
   const VariableValue & _w;
-
-  // The reaction coefficient
-  const VariableValue & _rate_coefficient;
-  Real _stoichiometric_coeff;
+  const VariableValue & _vv;
+  const MaterialProperty<Real> & _reaction_coeff;
 };
-#endif // PRODUCTIONSECONDORDER_H
+

--- a/include/auxkernels/ReactionRateThreeBodyScalar.h
+++ b/include/auxkernels/ReactionRateThreeBodyScalar.h
@@ -12,31 +12,28 @@
 /*            See COPYRIGHT for full restrictions               */
 /****************************************************************/
 
-#ifndef PROCRATEFORRATECOEFFTHREEBODY_CRANE_H
-#define PROCRATEFORRATECOEFFTHREEBODY_CRANE_H
+#pragma once
 
-#include "AuxKernel.h"
+#include "AuxScalarKernel.h"
 
-class ProcRateForRateCoeffThreeBody_Crane;
+// Forward Declaration
+class ReactionRateThreeBodyScalar;
 
 template <>
-InputParameters validParams<ProcRateForRateCoeffThreeBody_Crane>();
+InputParameters validParams<ReactionRateThreeBodyScalar>();
 
-class ProcRateForRateCoeffThreeBody_Crane : public AuxKernel
+class ReactionRateThreeBodyScalar : public AuxScalarKernel
 {
 public:
-  ProcRateForRateCoeffThreeBody_Crane(const InputParameters & parameters);
-
-  virtual ~ProcRateForRateCoeffThreeBody_Crane() {}
-  virtual Real computeValue();
+  ReactionRateThreeBodyScalar(const InputParameters & parameters);
 
 protected:
-
+  virtual Real computeValue();
 
   const VariableValue & _v;
   const VariableValue & _w;
-  const VariableValue & _vv;
-  const MaterialProperty<Real> & _reaction_coeff;
-};
+  const VariableValue & _z;
 
-#endif // ProcRateForRateCoeffThreeBody_Crane_H
+  const VariableValue & _rate_coefficient;
+  Real _stoichiometric_coeff;
+};

--- a/include/auxkernels/ReactionRateTownsend.h
+++ b/include/auxkernels/ReactionRateTownsend.h
@@ -12,24 +12,23 @@
 /*            See COPYRIGHT for full restrictions               */
 /****************************************************************/
 
-#ifndef PROCRATEFORRATECOEFF_TOWNSEND_CRANE_H
-#define PROCRATEFORRATECOEFF_TOWNSEND_CRANE_H
+#pragma once
 
 #include "AuxKernel.h"
 
-class ProcRateForRateCoeff_Townsend_Crane;
+class ReactionRateTownsend;
 
 template <>
-InputParameters validParams<ProcRateForRateCoeff_Townsend_Crane>();
+InputParameters validParams<ReactionRateTownsend>();
 
-class ProcRateForRateCoeff_Townsend_Crane : public AuxKernel
+class ReactionRateTownsend : public AuxKernel
 {
 public:
-  ProcRateForRateCoeff_Townsend_Crane(const InputParameters & parameters);
-  virtual ~ProcRateForRateCoeff_Townsend_Crane() {}
+  ReactionRateTownsend(const InputParameters & parameters);
+  virtual ~ReactionRateTownsend() {}
   virtual Real computeValue();
-protected:
 
+protected:
   Real _r_units;
   std::string _reaction_coeff_name;
   std::string _reaction_name;
@@ -51,5 +50,3 @@ protected:
   const VariableValue & _target;
   unsigned int _target_id;
 };
-
-#endif /* PROCRATEFORRATECOEFF_TOWNSEND_CRANE_H */

--- a/include/auxkernels/ReactionRateTwoBody.h
+++ b/include/auxkernels/ReactionRateTwoBody.h
@@ -12,34 +12,26 @@
 /*            See COPYRIGHT for full restrictions               */
 /****************************************************************/
 
-#include "ProcRateForRateCoeff_OneBody_Crane.h"
+#pragma once
 
-registerMooseObject("CraneApp", ProcRateForRateCoeff_OneBody_Crane);
+#include "AuxKernel.h"
+
+class ReactionRateTwoBody;
 
 template <>
-InputParameters
-validParams<ProcRateForRateCoeff_OneBody_Crane>()
+InputParameters validParams<ReactionRateTwoBody>();
+
+class ReactionRateTwoBody : public AuxKernel
 {
-  InputParameters params = validParams<AuxKernel>();
+public:
+  ReactionRateTwoBody(const InputParameters & parameters);
 
-  params.addCoupledVar("v", "The first variable that is reacting to create u.");
-  params.addRequiredParam<std::string>("reaction", "The full reaction equation.");
+  virtual ~ReactionRateTwoBody() {}
+  virtual Real computeValue();
 
-  return params;
-}
+protected:
+  const VariableValue & _v;
+  const VariableValue & _w;
+  const MaterialProperty<Real> & _reaction_coeff;
+};
 
-ProcRateForRateCoeff_OneBody_Crane::ProcRateForRateCoeff_OneBody_Crane(const InputParameters & parameters)
-  : AuxKernel(parameters),
-
-  _v(coupledValue("v")),
-  _reaction_coeff(getMaterialProperty<Real>("k_" + getParam<std::string>("reaction")))
-{
-}
-
-Real
-ProcRateForRateCoeff_OneBody_Crane::computeValue()
-{
-
-  return 6.02e23 * _reaction_coeff[_qp] * std::exp(_v[_qp]);
-
-}

--- a/include/auxkernels/ReactionRateTwoBodyScalar.h
+++ b/include/auxkernels/ReactionRateTwoBodyScalar.h
@@ -12,33 +12,27 @@
 /*            See COPYRIGHT for full restrictions               */
 /****************************************************************/
 
-#ifndef PRODUCTIONTHIRDORDER_H
-#define PRODUCTIONTHIRDORDER_H
+#pragma once
 
-#include "Kernel.h"
+#include "AuxScalarKernel.h"
 
 // Forward Declaration
-class ProductionThirdOrder;
+class ReactionRateTwoBodyScalar;
 
 template <>
-InputParameters validParams<ProductionThirdOrder>();
+InputParameters validParams<ReactionRateTwoBodyScalar>();
 
-class ProductionThirdOrder : public AuxScalarKernel
+class ReactionRateTwoBodyScalar : public AuxScalarKernel
 {
 public:
-  ProductionThirdOrder(const InputParameters & parameters);
+  ReactionRateTwoBodyScalar(const InputParameters & parameters);
 
 protected:
   virtual Real computeValue();
 
-  // MooseVariable & _coupled_var_A;
-  // MooseVariable & _coupled_var_B;
   const VariableValue & _v;
   const VariableValue & _w;
-  const VariableValue & _z;
 
-  // The reaction coefficient
   const VariableValue & _rate_coefficient;
   Real _stoichiometric_coeff;
 };
-#endif // PRODUCTIONTHIRDORDER_H

--- a/include/auxkernels/ReducedField.h
+++ b/include/auxkernels/ReducedField.h
@@ -1,5 +1,4 @@
-#ifndef REDUCEDFIELD_H_
-#define REDUCEDFIELD_H_
+#pragma once
 
 #include "AuxScalarKernel.h"
 #include "SplineInterpolation.h"
@@ -21,5 +20,3 @@ protected:
 
   const VariableValue & _mobility;
 };
-
-#endif /* REDUCEDFIELD_H_ */

--- a/include/auxkernels/ReducedFieldScalar.h
+++ b/include/auxkernels/ReducedFieldScalar.h
@@ -7,8 +7,7 @@
 //* Licensed under LGPL 2.1, please see LICENSE for details
 //* https://www.gnu.org/licenses/lgpl-2.1.html
 
-#ifndef REDUCEDFIELDSCALAR_H_
-#define REDUCEDFIELDSCALAR_H_
+#pragma once
 
 #include "AuxScalarKernel.h"
 
@@ -35,5 +34,3 @@ protected:
   const VariableValue & _electron_density;
   const VariableValue & _gas_density;
 };
-
-#endif /* REDUCEDFIELDSCALAR_H_ */

--- a/include/auxkernels/SuperelasticRateCoefficientScalar.h
+++ b/include/auxkernels/SuperelasticRateCoefficientScalar.h
@@ -12,8 +12,7 @@
 /*            See COPYRIGHT for full restrictions               */
 /****************************************************************/
 
-#ifndef SUPERELASTICRATECOEFFICIENTSCALAR_H
-#define SUPERELASTICRATECOEFFICIENTSCALAR_H
+#pragma once
 
 #include "AuxScalarKernel.h"
 #include "SplineInterpolation.h"
@@ -37,5 +36,3 @@ protected:
   Real _Tgas_const;
   const PolynomialCoefficients & _polynomial;
 };
-
-#endif // SUPERELASTICRATECOEFFICIENTSCALAR_H

--- a/include/auxkernels/VariableSum.h
+++ b/include/auxkernels/VariableSum.h
@@ -12,8 +12,7 @@
 /*            See COPYRIGHT for full restrictions               */
 /****************************************************************/
 
-#ifndef VARIABLESUM_H
-#define VARIABLESUM_H
+#pragma once
 
 #include "AuxScalarKernel.h"
 // #include "SplineInterpolation.h"
@@ -33,5 +32,3 @@ protected:
   unsigned int _nargs;
   std::vector<const VariableValue *> _args;
 };
-
-#endif // VARIABLESUM_H

--- a/include/base/CraneApp.h
+++ b/include/base/CraneApp.h
@@ -6,8 +6,7 @@
 //*
 //* Licensed under LGPL 2.1, please see LICENSE for details
 //* https://www.gnu.org/licenses/lgpl-2.1.html
-#ifndef CRANEAPP_H
-#define CRANEAPP_H
+#pragma once
 
 #include "MooseApp.h"
 
@@ -25,5 +24,3 @@ public:
   static void registerApps();
   static void registerAll(Factory & f, ActionFactory & af, Syntax & s);
 };
-
-#endif /* CRANEAPP_H */

--- a/include/kernels/ElectronEnergyTermElasticTownsend.h
+++ b/include/kernels/ElectronEnergyTermElasticTownsend.h
@@ -8,8 +8,7 @@
 //* Licensed under LGPL 2.1, please see LICENSE for details
 //* https://www.gnu.org/licenses/lgpl-2.1.html
 
-#ifndef ELECTRONENERGYTERMELASTICTOWNSEND_H
-#define ELECTRONENERGYTERMELASTICTOWNSEND_H
+#pragma once
 
 #include "Kernel.h"
 
@@ -48,5 +47,3 @@ protected:
   unsigned int _em_id;
   Real _massem;
 };
-
-#endif /* ELECTRONENERGYLOSSFROMELASTIC_H */

--- a/include/kernels/ElectronEnergyTermTownsend.h
+++ b/include/kernels/ElectronEnergyTermTownsend.h
@@ -12,8 +12,7 @@
 /*            See COPYRIGHT for full restrictions               */
 /****************************************************************/
 
-#ifndef ELECTRONENERGYTERMTOWNSEND_H
-#define ELECTRONENERGYTERMTOWNSEND_H
+#pragma once
 
 #include "Kernel.h"
 
@@ -55,5 +54,3 @@ protected:
 
   Real _energy_change;
 };
-
-#endif /* ELECTRONENERGYTERMTOWNSEND_H */

--- a/include/kernels/ElectronImpactReactionProduct.h
+++ b/include/kernels/ElectronImpactReactionProduct.h
@@ -12,8 +12,7 @@
 /*            See COPYRIGHT for full restrictions               */
 /****************************************************************/
 
-#ifndef ELECTRONIMPACTREACTIONPRODUCT_H
-#define ELECTRONIMPACTREACTIONPRODUCT_H
+#pragma once
 
 #include "Kernel.h"
 
@@ -54,5 +53,3 @@ protected:
   const VariableValue & _target;
   unsigned int _target_id;
 };
-
-#endif /* ELECTRONIMPACTREACTIONPRODUCT_H */

--- a/include/kernels/ElectronImpactReactionReactant.h
+++ b/include/kernels/ElectronImpactReactionReactant.h
@@ -12,8 +12,7 @@
 /*            See COPYRIGHT for full restrictions               */
 /****************************************************************/
 
-#ifndef ELECTRONIMPACTREACTIONREACTANT_H
-#define ELECTRONIMPACTREACTIONREACTANT_H
+#pragma once
 
 #include "Kernel.h"
 
@@ -54,5 +53,3 @@ protected:
   const VariableValue & _target;
   unsigned int _target_id;
 };
-
-#endif /* ELECTRONIMPACTREACTIONREACTANT_H */

--- a/include/kernels/ElectronProductSecondOrderLog.h
+++ b/include/kernels/ElectronProductSecondOrderLog.h
@@ -12,8 +12,7 @@
 /*            See COPYRIGHT for full restrictions               */
 /****************************************************************/
 
-#ifndef ELECTRONPRODUCTSECONDORDERLOG_H
-#define ELECTRONPRODUCTSECONDORDERLOG_H
+#pragma once
 
 #include "Kernel.h"
 
@@ -51,4 +50,3 @@ protected:
   bool _target_eq_u;
   bool _target_coupled;
 };
-#endif // ELECTRONPRODUCTSECONDORDERLOG_H

--- a/include/kernels/ElectronReactantSecondOrderLog.h
+++ b/include/kernels/ElectronReactantSecondOrderLog.h
@@ -12,8 +12,7 @@
 /*            See COPYRIGHT for full restrictions               */
 /****************************************************************/
 
-#ifndef ELECTRONREACTANTSECONDORDERLOG_H
-#define ELECTRONREACTANTSECONDORDERLOG_H
+#pragma once
 
 #include "Kernel.h"
 
@@ -45,4 +44,3 @@ protected:
   Real _stoichiometric_coeff;
   bool _v_eq_electron;
 };
-#endif // ELECTRONREACTANTSECONDORDERLOG_H

--- a/include/kernels/EnergyTermRate.h
+++ b/include/kernels/EnergyTermRate.h
@@ -12,8 +12,7 @@
 /*            See COPYRIGHT for full restrictions               */
 /****************************************************************/
 
-#ifndef ENERGYTERMRATE_H
-#define ENERGYTERMRATE_H
+#pragma once
 
 #include "Kernel.h"
 
@@ -44,5 +43,3 @@ protected:
   unsigned int _v_id;
   unsigned int _w_id;
 };
-
-#endif /* ENERGYTERMRATE_H */

--- a/include/kernels/LogStabilization.h
+++ b/include/kernels/LogStabilization.h
@@ -12,8 +12,7 @@
 /*            See COPYRIGHT for full restrictions               */
 /****************************************************************/
 
-#ifndef LOGSTABILIZATION_H
-#define LOGSTABILIZATION_H
+#pragma once
 
 #include "Kernel.h"
 
@@ -34,5 +33,3 @@ protected:
 
   Real _offset;
 };
-
-#endif /* LOGSTABILIZATION_H */

--- a/include/kernels/ProductFirstOrder.h
+++ b/include/kernels/ProductFirstOrder.h
@@ -12,8 +12,7 @@
 /*            See COPYRIGHT for full restrictions               */
 /****************************************************************/
 
-#ifndef PRODUCTFIRSTORDER_H
-#define PRODUCTFIRSTORDER_H
+#pragma once
 
 #include "Kernel.h"
 
@@ -41,4 +40,3 @@ protected:
   Real _stoichiometric_coeff;
   bool _v_eq_u;
 };
-#endif // ProductFirstOrder_H

--- a/include/kernels/ProductFirstOrderLog.h
+++ b/include/kernels/ProductFirstOrderLog.h
@@ -12,8 +12,7 @@
 /*            See COPYRIGHT for full restrictions               */
 /****************************************************************/
 
-#ifndef PRODUCTFIRSTORDERLOG_H
-#define PRODUCTFIRSTORDERLOG_H
+#pragma once
 
 #include "Kernel.h"
 
@@ -42,4 +41,3 @@ protected:
   Real _stoichiometric_coeff;
   bool _v_eq_u;
 };
-#endif // PRODUCTFIRSTORDERLOG_H

--- a/include/kernels/ProductSecondOrder.h
+++ b/include/kernels/ProductSecondOrder.h
@@ -12,8 +12,7 @@
 /*            See COPYRIGHT for full restrictions               */
 /****************************************************************/
 
-#ifndef PRODUCTSECONDORDER_H
-#define PRODUCTSECONDORDER_H
+#pragma once
 
 #include "Kernel.h"
 
@@ -46,4 +45,3 @@ protected:
   bool _v_eq_u;
   bool _w_eq_u;
 };
-#endif // PRODUCTSECONDORDER_H

--- a/include/kernels/ProductSecondOrderLog.h
+++ b/include/kernels/ProductSecondOrderLog.h
@@ -12,8 +12,7 @@
 /*            See COPYRIGHT for full restrictions               */
 /****************************************************************/
 
-#ifndef PRODUCTSECONDORDERLOG_H
-#define PRODUCTSECONDORDERLOG_H
+#pragma once
 
 #include "Kernel.h"
 
@@ -44,4 +43,3 @@ protected:
   bool _v_eq_u;
   bool _w_eq_u;
 };
-#endif // PRODUCTSECONDORDERLOG_H

--- a/include/kernels/ProductThirdOrder.h
+++ b/include/kernels/ProductThirdOrder.h
@@ -12,8 +12,7 @@
 /*            See COPYRIGHT for full restrictions               */
 /****************************************************************/
 
-#ifndef PRODUCTTHIRDORDER_H
-#define PRODUCTTHIRDORDER_H
+#pragma once
 
 #include "Kernel.h"
 
@@ -50,4 +49,3 @@ protected:
   bool _w_eq_u;
   bool _x_eq_u;
 };
-#endif // PRODUCTTHIRDORDER_H

--- a/include/kernels/ProductThirdOrderLog.h
+++ b/include/kernels/ProductThirdOrderLog.h
@@ -12,8 +12,7 @@
 /*            See COPYRIGHT for full restrictions               */
 /****************************************************************/
 
-#ifndef PRODUCTTHIRDORDERLOG_H
-#define PRODUCTTHIRDORDERLOG_H
+#pragma once
 
 #include "Kernel.h"
 
@@ -46,4 +45,3 @@ protected:
   const MaterialProperty<Real> & _reaction_coeff;
   Real _stoichiometric_coeff;
 };
-#endif // PRODUCTTHIRDORDERLOG_H

--- a/include/kernels/ReactantFirstOrder.h
+++ b/include/kernels/ReactantFirstOrder.h
@@ -12,8 +12,7 @@
 /*            See COPYRIGHT for full restrictions               */
 /****************************************************************/
 
-#ifndef REACTANTFIRSTORDER_H
-#define REACTANTFIRSTORDER_H
+#pragma once
 
 #include "Kernel.h"
 
@@ -39,4 +38,3 @@ protected:
   // const MaterialProperty<Real> & _n_gas;
   Real _stoichiometric_coeff;
 };
-#endif // ReactantFirstOrder_H

--- a/include/kernels/ReactantFirstOrderLog.h
+++ b/include/kernels/ReactantFirstOrderLog.h
@@ -12,8 +12,7 @@
 /*            See COPYRIGHT for full restrictions               */
 /****************************************************************/
 
-#ifndef REACTANTFIRSTORDERLOG_H
-#define REACTANTFIRSTORDERLOG_H
+#pragma once
 
 #include "Kernel.h"
 
@@ -36,4 +35,3 @@ protected:
   const MaterialProperty<Real> & _reaction_coeff;
   Real _stoichiometric_coeff;
 };
-#endif // REACTANTFIRSTORDERLOG_H

--- a/include/kernels/ReactantSecondOrder.h
+++ b/include/kernels/ReactantSecondOrder.h
@@ -12,8 +12,7 @@
 /*            See COPYRIGHT for full restrictions               */
 /****************************************************************/
 
-#ifndef REACTANTSECONDORDER_H
-#define REACTANTSECONDORDER_H
+#pragma once
 
 #include "Kernel.h"
 
@@ -41,4 +40,3 @@ protected:
   bool _v_eq_u;
 
 };
-#endif // ReactantSecondOrder_H

--- a/include/kernels/ReactantSecondOrderLog.h
+++ b/include/kernels/ReactantSecondOrderLog.h
@@ -12,8 +12,7 @@
 /*            See COPYRIGHT for full restrictions               */
 /****************************************************************/
 
-#ifndef REACTANTSECONDORDERLOG_H
-#define REACTANTSECONDORDERLOG_H
+#pragma once
 
 #include "Kernel.h"
 
@@ -42,4 +41,3 @@ protected:
   Real _stoichiometric_coeff;
   bool _v_eq_u;
 };
-#endif // REACTANTSECONDORDERLOG_H

--- a/include/kernels/ReactantThirdOrder.h
+++ b/include/kernels/ReactantThirdOrder.h
@@ -12,8 +12,7 @@
 /*            See COPYRIGHT for full restrictions               */
 /****************************************************************/
 
-#ifndef REACTANTTHIRDORDER_H
-#define REACTANTTHIRDORDER_H
+#pragma once
 
 #include "Kernel.h"
 
@@ -45,4 +44,3 @@ protected:
   bool _w_eq_u;
 
 };
-#endif // REACTANTTHIRDORDER_H

--- a/include/kernels/ReactantThirdOrderLog.h
+++ b/include/kernels/ReactantThirdOrderLog.h
@@ -12,8 +12,7 @@
 /*            See COPYRIGHT for full restrictions               */
 /****************************************************************/
 
-#ifndef REACTANTTHIRDORDERLOG_H
-#define REACTANTTHIRDORDERLOG_H
+#pragma once
 
 #include "Kernel.h"
 
@@ -42,4 +41,3 @@ protected:
   bool _w_eq_u;
   Real _stoichiometric_coeff;
 };
-#endif // REACTANTTHIRDORDERLOG_H

--- a/include/kernels/TimeDerivativeLog.h
+++ b/include/kernels/TimeDerivativeLog.h
@@ -12,8 +12,7 @@
 /*            See COPYRIGHT for full restrictions               */
 /****************************************************************/
 
-#ifndef TIMEDERIVATIVELOG_H
-#define TIMEDERIVATIVELOG_H
+#pragma once
 
 #include "TimeKernel.h"
 
@@ -37,5 +36,3 @@ protected:
 
   bool _lumping;
 };
-
-#endif // TIMEDERIVATIVELOG_H

--- a/include/materials/DiffusionRateTemp.h
+++ b/include/materials/DiffusionRateTemp.h
@@ -11,8 +11,7 @@
 /*                                                              */
 /*              See COPYRIGHT for full restrictions             */
 /****************************************************************/
-#ifndef DIFFUSIONRATETEMP_H_
-#define DIFFUSIONRATETEMP_H_
+#pragma once
 
 #include "Material.h"
 #include "SplineInterpolation.h"
@@ -36,5 +35,3 @@ protected:
   const MaterialProperty<Real> & _gap_length;
   const MaterialProperty<Real> & _radius;
 };
-
-#endif // DIFFUSIONRATETEMP_H_

--- a/include/materials/EEDFRateConstant.h
+++ b/include/materials/EEDFRateConstant.h
@@ -11,8 +11,7 @@
 /*                                                              */
 /*              See COPYRIGHT for full restrictions             */
 /****************************************************************/
-#ifndef EEDFRATECONSTANT_H_
-#define EEDFRATECONSTANT_H_
+#pragma once
 
 #include "Material.h"
 /* #include "LinearInterpolation.h" */
@@ -46,5 +45,3 @@ protected:
   const VariableValue & _em;
   const VariableValue & _mean_en;
 };
-
-#endif // EEDFRATECONSTANT_H_

--- a/include/materials/EEDFRateConstantTownsend.h
+++ b/include/materials/EEDFRateConstantTownsend.h
@@ -11,8 +11,7 @@
 /*                                                              */
 /*              See COPYRIGHT for full restrictions             */
 /****************************************************************/
-#ifndef EEDFRATECONSTANTTOWNSEND_H_
-#define EEDFRATECONSTANTTOWNSEND_H_
+#pragma once
 
 #include "Material.h"
 /* #include "LinearInterpolation.h" */
@@ -55,5 +54,3 @@ protected:
 
   bool _elastic_collision;
 };
-
-#endif // EEDFRATECONSTANTTOWNSEND_H_

--- a/include/materials/ElectricField.h
+++ b/include/materials/ElectricField.h
@@ -11,8 +11,7 @@
 /*                                                              */
 /*              See COPYRIGHT for full restrictions             */
 /****************************************************************/
-#ifndef ELECTRICFIELD_H_
-#define ELECTRICFIELD_H_
+#pragma once
 
 #include "Material.h"
 #include "SplineInterpolation.h"
@@ -46,5 +45,3 @@ protected:
   const MaterialProperty<Real> & _n_gas;
 
 };
-
-#endif // ELECTRICFIELD_H_

--- a/include/materials/GenericRateConstant.h
+++ b/include/materials/GenericRateConstant.h
@@ -11,8 +11,7 @@
 /*                                                              */
 /*              See COPYRIGHT for full restrictions             */
 /****************************************************************/
-#ifndef GENERICRATECONSTANT_H_
-#define GENERICRATECONSTANT_H_
+#pragma once
 
 #include "Material.h"
 
@@ -35,5 +34,3 @@ protected:
   Real _rate_value;
 
 };
-
-#endif // GENERICRATECONSTANT_H_

--- a/include/materials/HeatCapacityRatio.h
+++ b/include/materials/HeatCapacityRatio.h
@@ -11,8 +11,7 @@
 /*                                                              */
 /*              See COPYRIGHT for full restrictions             */
 /****************************************************************/
-#ifndef HEATCAPACITYRATIO_H_
-#define HEATCAPACITYRATIO_H_
+#pragma once
 
 // #include "Material.h"
 #include "SpeciesSum.h"
@@ -40,5 +39,3 @@ private:
   std::vector<const VariableValue *> _vals;
 
 };
-
-#endif // HEATCAPACITYRATIO_H_

--- a/include/materials/SpeciesSum.h
+++ b/include/materials/SpeciesSum.h
@@ -11,8 +11,7 @@
 /*                                                              */
 /*              See COPYRIGHT for full restrictions             */
 /****************************************************************/
-#ifndef SPECIESSUM_H_
-#define SPECIESSUM_H_
+#pragma once
 
 #include "Material.h"
 
@@ -36,5 +35,3 @@ private:
   // std::vector<const VariableGradient *> _grad_vals;
 
 };
-
-#endif // SPECIESSUM_H_

--- a/include/materials/SuperelasticReactionRate.h
+++ b/include/materials/SuperelasticReactionRate.h
@@ -11,8 +11,7 @@
 /*                                                              */
 /*              See COPYRIGHT for full restrictions             */
 /****************************************************************/
-#ifndef SUPERELASTICREACTIONRATE_H_
-#define SUPERELASTICREACTIONRATE_H_
+#pragma once
 
 #include "Material.h"
 
@@ -41,5 +40,3 @@ protected:
   Real _equilibrium_constant;
 
 };
-
-#endif // SUPERELASTICREACTIONRATE_H_

--- a/include/materials/ZapdosEEDFRateConstant.h
+++ b/include/materials/ZapdosEEDFRateConstant.h
@@ -11,8 +11,7 @@
 /*                                                              */
 /*              See COPYRIGHT for full restrictions             */
 /****************************************************************/
-#ifndef ZAPDOSEEDFRATECONSTANT_H_
-#define ZAPDOSEEDFRATECONSTANT_H_
+#pragma once
 
 #include "Material.h"
 /* #include "LinearInterpolation.h" */
@@ -47,5 +46,3 @@ protected:
   const VariableValue & _em;
   const VariableValue & _mean_en;
 };
-
-#endif // ZAPDOSEEDFRATECONSTANT_H_

--- a/include/postprocessors/ElectricFieldCalculator.h
+++ b/include/postprocessors/ElectricFieldCalculator.h
@@ -1,5 +1,4 @@
-#ifndef ELECTRICFIELDCALCULATOR_H
-#define ELECTRICFIELDCALCULATOR_H
+#pragma once
 
 // MOOSE includes
 #include "GeneralPostprocessor.h"
@@ -29,5 +28,3 @@ protected:
   const VariableValue & _electron_density;
 
 };
-
-#endif // ELECTRICFIELDCALCULATOR_H

--- a/include/scalarkernels/EnergyTermScalar.h
+++ b/include/scalarkernels/EnergyTermScalar.h
@@ -1,5 +1,4 @@
-#ifndef ENERGYTERMSCALAR_H
-#define ENERGYTERMSCALAR_H
+#pragma once
 
 #include "ODEKernel.h"
 // #include "RateCoefficientProvider.h"
@@ -35,5 +34,3 @@ protected:
 
   // const RateCoefficientProvider & _data;
 };
-
-#endif /* ENERGYTERMSCALAR_H */

--- a/include/scalarkernels/LogStabilizationScalar.h
+++ b/include/scalarkernels/LogStabilizationScalar.h
@@ -12,8 +12,7 @@
 /*            See COPYRIGHT for full restrictions               */
 /****************************************************************/
 
-#ifndef LOGSTABILIZATIONSCALAR_H
-#define LOGSTABILIZATIONSCALAR_H
+#pragma once
 
 #include "ODEKernel.h"
 
@@ -34,5 +33,3 @@ protected:
 
   Real _offset;
 };
-
-#endif /* LOGSTABILIZATIONSCALAR_H */

--- a/include/scalarkernels/ODETimeDerivativeLog.h
+++ b/include/scalarkernels/ODETimeDerivativeLog.h
@@ -12,8 +12,7 @@
 /*            See COPYRIGHT for full restrictions               */
 /****************************************************************/
 
-#ifndef ODETIMEDERIVATIVELOG_H
-#define ODETIMEDERIVATIVELOG_H
+#pragma once
 
 #include "ODETimeKernel.h"
 
@@ -37,5 +36,3 @@ protected:
 
   bool _lumping;
 };
-
-#endif // ODETIMEDERIVATIVELOG_H

--- a/include/scalarkernels/ODETimeDerivativeTemperature.h
+++ b/include/scalarkernels/ODETimeDerivativeTemperature.h
@@ -7,8 +7,7 @@
 //* Licensed under LGPL 2.1, please see LICENSE for details
 //* https://www.gnu.org/licenses/lgpl-2.1.html
 
-#ifndef ODETIMEDERIVATIVETEMPERATURE_H
-#define ODETIMEDERIVATIVETEMPERATURE_H
+#pragma once
 
 #include "ODETimeKernel.h"
 
@@ -29,5 +28,3 @@ protected:
 
   Real _n_gas;
 };
-
-#endif // ODETIMEDERIVATIVETEMPERATURE_H

--- a/include/scalarkernels/ParsedScalarReaction.h
+++ b/include/scalarkernels/ParsedScalarReaction.h
@@ -1,5 +1,4 @@
-#ifndef PARSEDSCALARREACTION_H
-#define PARSEDSCALARREACTION_H
+#pragma once
 
 #include "ParsedODEKernel.h"
 #include "ParsedScalarReaction.h"
@@ -31,5 +30,3 @@ protected:
   // bool _v_eq_u;
 
 };
-
-#endif /* PARSEDSCALARREACTION_H */

--- a/include/scalarkernels/Product1BodyScalar.h
+++ b/include/scalarkernels/Product1BodyScalar.h
@@ -1,5 +1,4 @@
-#ifndef PRODUCT1BODYSCALAR_H
-#define PRODUCT1BODYSCALAR_H
+#pragma once
 
 #include "ODEKernel.h"
 // #include "RateCoefficientProvider.h"
@@ -31,5 +30,3 @@ protected:
 
   // const RateCoefficientProvider & _data;
 };
-
-#endif /* PRODUCT1BODYSCALAR_H */

--- a/include/scalarkernels/Product1BodyScalarLog.h
+++ b/include/scalarkernels/Product1BodyScalarLog.h
@@ -1,5 +1,4 @@
-#ifndef PRODUCT1BODYSCALARLOG_H
-#define PRODUCT1BODYSCALARLOG_H
+#pragma once
 
 #include "ODEKernel.h"
 // #include "RateCoefficientProvider.h"
@@ -32,5 +31,3 @@ protected:
 
   // const RateCoefficientProvider & _data;
 };
-
-#endif /* PRODUCT1BODYSCALARLOG_H */

--- a/include/scalarkernels/Product2BodyScalar.h
+++ b/include/scalarkernels/Product2BodyScalar.h
@@ -1,5 +1,4 @@
-#ifndef PRODUCT2BODYSCALAR_H
-#define PRODUCT2BODYSCALAR_H
+#pragma once
 
 #include "ODEKernel.h"
 // #include "RateCoefficientProvider.h"
@@ -34,5 +33,3 @@ protected:
 
   // const RateCoefficientProvider & _data;
 };
-
-#endif /* PRODUCT2BODYSCALAR_H */

--- a/include/scalarkernels/Product2BodyScalarLog.h
+++ b/include/scalarkernels/Product2BodyScalarLog.h
@@ -1,5 +1,4 @@
-#ifndef PRODUCT2BODYSCALARLOG_H
-#define PRODUCT2BODYSCALARLOG_H
+#pragma once
 
 #include "ODEKernel.h"
 // #include "RateCoefficientProvider.h"
@@ -36,5 +35,3 @@ protected:
 
   // const RateCoefficientProvider & _data;
 };
-
-#endif /* PRODUCT2BODYSCALARLOG_H */

--- a/include/scalarkernels/Product3BodyScalar.h
+++ b/include/scalarkernels/Product3BodyScalar.h
@@ -1,5 +1,4 @@
-#ifndef PRODUCT3BODYSCALAR_H
-#define PRODUCT3BODYSCALAR_H
+#pragma once
 
 #include "ODEKernel.h"
 // #include "RateCoefficientProvider.h"
@@ -37,5 +36,3 @@ protected:
 
   // const RateCoefficientProvider & _data;
 };
-
-#endif /* PRODUCT3BODYSCALAR_H */

--- a/include/scalarkernels/Product3BodyScalarLog.h
+++ b/include/scalarkernels/Product3BodyScalarLog.h
@@ -1,5 +1,4 @@
-#ifndef PRODUCT3BODYSCALARLOG_H
-#define PRODUCT3BODYSCALARLOG_H
+#pragma once
 
 #include "ODEKernel.h"
 
@@ -39,5 +38,3 @@ protected:
 
   // const RateCoefficientProvider & _data;
 };
-
-#endif /* PRODUCT3BODYSCALARLOG_H */

--- a/include/scalarkernels/Reactant1BodyScalar.h
+++ b/include/scalarkernels/Reactant1BodyScalar.h
@@ -1,5 +1,4 @@
-#ifndef REACTANT1BODYSCALAR_H
-#define REACTANT1BODYSCALAR_H
+#pragma once
 
 #include "ODEKernel.h"
 // #include "RateCoefficientProvider.h"
@@ -25,5 +24,3 @@ protected:
 
   // const RateCoefficientProvider & _data;
 };
-
-#endif /* REACTANT1BODYSCALAR_H */

--- a/include/scalarkernels/Reactant1BodyScalarLog.h
+++ b/include/scalarkernels/Reactant1BodyScalarLog.h
@@ -1,5 +1,4 @@
-#ifndef REACTANT1BODYSCALARLOG_H
-#define REACTANT1BODYSCALARLOG_H
+#pragma once
 
 #include "ODEKernel.h"
 // #include "RateCoefficientProvider.h"
@@ -25,5 +24,3 @@ protected:
 
   // const RateCoefficientProvider & _data;
 };
-
-#endif /* REACTANT1BODYSCALARLOG_H */

--- a/include/scalarkernels/Reactant2BodyScalar.h
+++ b/include/scalarkernels/Reactant2BodyScalar.h
@@ -1,5 +1,4 @@
-#ifndef REACTANT2BODYSCALAR_H
-#define REACTANT2BODYSCALAR_H
+#pragma once
 
 #include "ODEKernel.h"
 // #include "RateCoefficientProvider.h"
@@ -30,5 +29,3 @@ protected:
 
   // const RateCoefficientProvider & _data;
 };
-
-#endif /* REACTANT2BODYSCALAR_H */

--- a/include/scalarkernels/Reactant2BodyScalarLog.h
+++ b/include/scalarkernels/Reactant2BodyScalarLog.h
@@ -1,5 +1,4 @@
-#ifndef REACTANT2BODYSCALARLOG_H
-#define REACTANT2BODYSCALARLOG_H
+#pragma once
 
 #include "ODEKernel.h"
 // #include "RateCoefficientProvider.h"
@@ -31,5 +30,3 @@ protected:
 
   // const RateCoefficientProvider & _data;
 };
-
-#endif /* REACTANT2BODYSCALARLOG_H */

--- a/include/scalarkernels/Reactant3BodyScalar.h
+++ b/include/scalarkernels/Reactant3BodyScalar.h
@@ -1,5 +1,4 @@
-#ifndef REACTANT3BODYSCALAR_H
-#define REACTANT3BODYSCALAR_H
+#pragma once
 
 #include "ODEKernel.h"
 // #include "RateCoefficientProvider.h"
@@ -34,5 +33,3 @@ protected:
 
   // const RateCoefficientProvider & _data;
 };
-
-#endif /* REACTANT3BODYSCALAR_H */

--- a/include/scalarkernels/Reactant3BodyScalarLog.h
+++ b/include/scalarkernels/Reactant3BodyScalarLog.h
@@ -1,5 +1,4 @@
-#ifndef REACTANT3BODYSCALARLOG_H
-#define REACTANT3BODYSCALARLOG_H
+#pragma once
 
 #include "ODEKernel.h"
 // #include "RateCoefficientProvider.h"
@@ -36,5 +35,3 @@ protected:
 
   // const RateCoefficientProvider & _data;
 };
-
-#endif /* REACTANT3BODYSCALARLOG_H */

--- a/include/scalarkernels/ScalarDiffusion.h
+++ b/include/scalarkernels/ScalarDiffusion.h
@@ -1,5 +1,4 @@
-#ifndef SCALARDIFFUSION_H
-#define SCALARDIFFUSION_H
+#pragma once
 
 #include "ODEKernel.h"
 #include "RateCoefficientProvider.h"
@@ -21,5 +20,3 @@ protected:
 
   Real _rate;
 };
-
-#endif /* SCALARDIFFUSION_H */

--- a/include/userobjects/BoltzmannSolverScalar.h
+++ b/include/userobjects/BoltzmannSolverScalar.h
@@ -12,8 +12,7 @@
 /*            See COPYRIGHT for full restrictions               */
 /****************************************************************/
 
-#ifndef BOLTZMANNSOLVERSCALAR_H
-#define BOLTZMANNSOLVERSCALAR_H
+#pragma once
 
 #include "GeneralUserObject.h"
 #include "SplineInterpolation.h"
@@ -79,5 +78,3 @@ protected:
   SplineInterpolation _temperature_interpolation;
   SplineInterpolation _mobility_interpolation;
 };
-
-#endif /* BOLTZMANNSOLVERSCALAR_H */

--- a/include/userobjects/ObjTest.h
+++ b/include/userobjects/ObjTest.h
@@ -12,8 +12,7 @@
 /*            See COPYRIGHT for full restrictions               */
 /****************************************************************/
 
-#ifndef OBJTEST_H
-#define OBJTEST_H
+#pragma once
 
 #include "GeneralUserObject.h"
 
@@ -39,5 +38,3 @@ public:
 protected:
   Real _reaction_coefficient;
 };
-
-#endif

--- a/include/userobjects/PolynomialCoefficients.h
+++ b/include/userobjects/PolynomialCoefficients.h
@@ -12,8 +12,7 @@
 /*            See COPYRIGHT for full restrictions               */
 /****************************************************************/
 
-#ifndef POLYNOMIALCOEFFICIENTS_H
-#define POLYNOMIALCOEFFICIENTS_H
+#pragma once
 
 #include "GeneralUserObject.h"
 #include "SplineInterpolation.h"
@@ -47,5 +46,3 @@ protected:
   std::vector<Real> _delta_a;
   Real _power_coefficient;
 };
-
-#endif /* POLYNOMIALCOEFFICIENTS_H */

--- a/include/userobjects/RateCoefficientProvider.h
+++ b/include/userobjects/RateCoefficientProvider.h
@@ -12,8 +12,7 @@
 /*            See COPYRIGHT for full restrictions               */
 /****************************************************************/
 
-#ifndef RATECOEFFICIENTPROVIDER_H
-#define RATECOEFFICIENTPROVIDER_H
+#pragma once
 
 #include "GeneralUserObject.h"
 #include "SplineInterpolation.h"
@@ -55,4 +54,3 @@ protected:
   // std::string _sampling_format;
 };
 
-#endif /* RateCoefficientProvider_H */

--- a/include/userobjects/ValueProvider.h
+++ b/include/userobjects/ValueProvider.h
@@ -12,8 +12,7 @@
 /*            See COPYRIGHT for full restrictions               */
 /****************************************************************/
 
-#ifndef ValueProvider_H
-#define ValueProvider_H
+#pragma once
 
 #include "GeneralUserObject.h"
 #include "SplineInterpolation.h"
@@ -45,5 +44,3 @@ protected:
   std::string _sampling_format;
   std::string _rate_format;
 };
-
-#endif /* ValueProvider_H */

--- a/src/actions/ChemicalReactionsBase.C
+++ b/src/actions/ChemicalReactionsBase.C
@@ -117,7 +117,7 @@ ChemicalReactionsBase::ChemicalReactionsBase(InputParameters params)
     _use_log(getParam<bool>("use_log")),
     _track_rates(getParam<bool>("track_rates")),
     _use_bolsig(getParam<bool>("use_bolsig"))
-	// _use_moles(getParam<bool>("use_moles"))
+// _use_moles(getParam<bool>("use_moles"))
 {
   std::istringstream iss(_input_reactions);
   std::string token;
@@ -139,21 +139,24 @@ ChemicalReactionsBase::ChemicalReactionsBase(InputParameters params)
   while (std::getline(iss >> std::ws,
                       token)) // splits by \n character (default) and ignores leading whitespace
   {
-    // Define check for change of energy
-    // bool _energy_change = false;
+    // Skip commented lines
+    // (Reactions with comments attached to the end will still be read.)
+    if (token.find('#') == 0)
+    {
+      continue;
+    }
+
     pos = token.find(':'); // Looks for colon, which separates reaction and rate coefficients
 
     // Brackets enclose the energy gain/loss (if applicable)
     pos_start = token.find('[');
     pos_end = token.find(']');
 
-    // Curly braces enclose equation constants (Arrhenius form)
+    // Curly braces enclose function-based constants
     eq_start = token.find('{');
     eq_end = token.find('}');
 
     // Parentheses enclose the reaction identifier (ionization, excitation, de-excitation, etc.)
-    // Note that both [] and () will never be used, since energy changes are included in the cross
-    // section data
     rxn_identifier_start = token.find('(');
     rxn_identifier_end = token.find(')');
 
@@ -293,9 +296,13 @@ ChemicalReactionsBase::ChemicalReactionsBase(InputParameters params)
   _electron_index.resize(_num_reactions, 0);
   // _species_electron.resize(_num_reactions, std::vector<bool>(_species.size()));
 
-  // Split each reaction equation into reactants and products
-  int superelastic_reactions =
-      0; // stores number of superelastic reactions, which will be added to _num_reactions
+  /*
+   * Split each reaction equation into reactants and products
+   */
+
+  // superelastic_reactions stores number of superelastic reactions, which will be added to
+  // _num_reactions
+  int superelastic_reactions = 0;
   for (unsigned int i = 0; i < _num_reactions; ++i)
   {
     std::istringstream iss2(_reaction[i]);

--- a/src/auxkernels/ReactionRateOneBody.C
+++ b/src/auxkernels/ReactionRateOneBody.C
@@ -12,29 +12,32 @@
 /*            See COPYRIGHT for full restrictions               */
 /****************************************************************/
 
-#ifndef PROCRATEFORRATECOEFF_ONEBODY_CRANE_H
-#define PROCRATEFORRATECOEFF_ONEBODY_CRANE_H
+#include "ReactionRateOneBody.h"
 
-#include "AuxKernel.h"
-
-class ProcRateForRateCoeff_OneBody_Crane;
+registerMooseObject("CraneApp", ReactionRateOneBody);
 
 template <>
-InputParameters validParams<ProcRateForRateCoeff_OneBody_Crane>();
-
-class ProcRateForRateCoeff_OneBody_Crane : public AuxKernel
+InputParameters
+validParams<ReactionRateOneBody>()
 {
-public:
-  ProcRateForRateCoeff_OneBody_Crane(const InputParameters & parameters);
+  InputParameters params = validParams<AuxKernel>();
 
-  virtual ~ProcRateForRateCoeff_OneBody_Crane() {}
-  virtual Real computeValue();
+  params.addCoupledVar("v", "The first variable that is reacting to create u.");
+  params.addRequiredParam<std::string>("reaction", "The full reaction equation.");
 
-protected:
+  return params;
+}
 
+ReactionRateOneBody::ReactionRateOneBody(const InputParameters & parameters)
+  : AuxKernel(parameters),
+    _v(coupledValue("v")),
+    _reaction_coeff(getMaterialProperty<Real>("k_" + getParam<std::string>("reaction")))
+{
+}
 
-  const VariableValue & _v;
-  const MaterialProperty<Real> & _reaction_coeff;
-};
+Real
+ReactionRateOneBody::computeValue()
+{
 
-#endif // ProcRateForRateCoeff_OneBody_Crane_H
+  return 6.02e23 * _reaction_coeff[_qp] * std::exp(_v[_qp]);
+}

--- a/src/auxkernels/ReactionRateOneBodyScalar.C
+++ b/src/auxkernels/ReactionRateOneBodyScalar.C
@@ -12,33 +12,31 @@
 /*            See COPYRIGHT for full restrictions               */
 /****************************************************************/
 
-#include "ProductionSecondOrder.h"
+#include "ReactionRateOneBodyScalar.h"
 
-registerMooseObject("CraneApp", ProductionSecondOrder);
+registerMooseObject("CraneApp", ReactionRateOneBodyScalar);
 
 template <>
 InputParameters
-validParams<ProductionSecondOrder>()
+validParams<ReactionRateOneBodyScalar>()
 {
   InputParameters params = validParams<AuxScalarKernel>();
   params.addRequiredCoupledVar("v", "The first variable that is reacting to create u.");
-  params.addRequiredCoupledVar("w", "The second variable that is reacting to create u.");
   params.addCoupledVar("rate_coefficient", 0, "Coupled reaction coefficient (if equation-based).");
   params.addRequiredParam<Real>("coefficient", "The stoichiometric coeffient.");
   return params;
 }
 
-ProductionSecondOrder::ProductionSecondOrder(const InputParameters & parameters)
+ReactionRateOneBodyScalar::ReactionRateOneBodyScalar(const InputParameters & parameters)
   : AuxScalarKernel(parameters),
     _v(coupledScalarValue("v")),
-    _w(coupledScalarValue("w")),
     _rate_coefficient(coupledScalarValue("rate_coefficient")),
     _stoichiometric_coeff(getParam<Real>("coefficient"))
 {
 }
 
 Real
-ProductionSecondOrder::computeValue()
+ReactionRateOneBodyScalar::computeValue()
 {
-  return _stoichiometric_coeff * _rate_coefficient[_i] * _v[_i] * _w[_i];
+  return _stoichiometric_coeff * _rate_coefficient[_i] * _v[_i];
 }

--- a/src/auxkernels/ReactionRateThreeBody.C
+++ b/src/auxkernels/ReactionRateThreeBody.C
@@ -12,13 +12,13 @@
 /*            See COPYRIGHT for full restrictions               */
 /****************************************************************/
 
-#include "ProcRateForRateCoeffThreeBody_Crane.h"
+#include "ReactionRateThreeBody.h"
 
-registerMooseObject("CraneApp", ProcRateForRateCoeffThreeBody_Crane);
+registerMooseObject("CraneApp", ReactionRateThreeBody);
 
 template <>
 InputParameters
-validParams<ProcRateForRateCoeffThreeBody_Crane>()
+validParams<ReactionRateThreeBody>()
 {
   InputParameters params = validParams<AuxKernel>();
 
@@ -27,26 +27,26 @@ validParams<ProcRateForRateCoeffThreeBody_Crane>()
   params.addCoupledVar("vv", "The second variable that is reacting to create u.");
   params.addRequiredParam<std::string>("reaction", "The full reaction equation.");
   params.addClassDescription(
-    "Reaction rate for three body collisions in units of #/m^3s. User can pass"
-    "choice of elastic, excitation, or ionization reaction rate coefficients");
+      "Reaction rate for three body collisions in units of #/m^3s. User can pass"
+      "choice of elastic, excitation, or ionization reaction rate coefficients");
 
   return params;
 }
 
-ProcRateForRateCoeffThreeBody_Crane::ProcRateForRateCoeffThreeBody_Crane(const InputParameters & parameters)
+ReactionRateThreeBody::ReactionRateThreeBody(const InputParameters & parameters)
   : AuxKernel(parameters),
 
-  _v(coupledValue("v")),
-  _w(coupledValue("w")),
-  _vv(coupledValue("vv")),
-  _reaction_coeff(getMaterialProperty<Real>("k_" + getParam<std::string>("reaction")))
+    _v(coupledValue("v")),
+    _w(coupledValue("w")),
+    _vv(coupledValue("vv")),
+    _reaction_coeff(getMaterialProperty<Real>("k_" + getParam<std::string>("reaction")))
 {
 }
 
 Real
-ProcRateForRateCoeffThreeBody_Crane::computeValue()
+ReactionRateThreeBody::computeValue()
 {
 
-  return 6.02e23 * _reaction_coeff[_qp] * std::exp(_v[_qp]) * std::exp(_w[_qp]) * std::exp(_vv[_qp]);
-
+  return 6.02e23 * _reaction_coeff[_qp] * std::exp(_v[_qp]) * std::exp(_w[_qp]) *
+         std::exp(_vv[_qp]);
 }

--- a/src/auxkernels/ReactionRateThreeBodyScalar.C
+++ b/src/auxkernels/ReactionRateThreeBodyScalar.C
@@ -12,31 +12,35 @@
 /*            See COPYRIGHT for full restrictions               */
 /****************************************************************/
 
-#include "ProductionFirstOrder.h"
+#include "ReactionRateThreeBodyScalar.h"
 
-registerMooseObject("CraneApp", ProductionFirstOrder);
+registerMooseObject("CraneApp", ReactionRateThreeBodyScalar);
 
 template <>
 InputParameters
-validParams<ProductionFirstOrder>()
+validParams<ReactionRateThreeBodyScalar>()
 {
   InputParameters params = validParams<AuxScalarKernel>();
   params.addRequiredCoupledVar("v", "The first variable that is reacting to create u.");
+  params.addRequiredCoupledVar("w", "The second variable that is reacting to create u.");
+  params.addRequiredCoupledVar("z", "The second variable that is reacting to create u.");
   params.addCoupledVar("rate_coefficient", 0, "Coupled reaction coefficient (if equation-based).");
   params.addRequiredParam<Real>("coefficient", "The stoichiometric coeffient.");
   return params;
 }
 
-ProductionFirstOrder::ProductionFirstOrder(const InputParameters & parameters)
+ReactionRateThreeBodyScalar::ReactionRateThreeBodyScalar(const InputParameters & parameters)
   : AuxScalarKernel(parameters),
     _v(coupledScalarValue("v")),
+    _w(coupledScalarValue("w")),
+    _z(coupledScalarValue("z")),
     _rate_coefficient(coupledScalarValue("rate_coefficient")),
     _stoichiometric_coeff(getParam<Real>("coefficient"))
 {
 }
 
 Real
-ProductionFirstOrder::computeValue()
+ReactionRateThreeBodyScalar::computeValue()
 {
-  return _stoichiometric_coeff * _rate_coefficient[_i] * _v[_i]; 
+  return _stoichiometric_coeff * _rate_coefficient[_i] * _v[_i] * _w[_i] * _z[_i];
 }

--- a/src/auxkernels/ReactionRateTownsend.C
+++ b/src/auxkernels/ReactionRateTownsend.C
@@ -12,13 +12,13 @@
 /*            See COPYRIGHT for full restrictions               */
 /****************************************************************/
 
-#include "ProcRateForRateCoeff_Townsend_Crane.h"
+#include "ReactionRateTownsend.h"
 
-registerMooseObject("CraneApp", ProcRateForRateCoeff_Townsend_Crane);
+registerMooseObject("CraneApp", ReactionRateTownsend);
 
 template <>
 InputParameters
-validParams<ProcRateForRateCoeff_Townsend_Crane>()
+validParams<ReactionRateTownsend>()
 {
   InputParameters params = validParams<AuxKernel>();
 
@@ -34,7 +34,7 @@ validParams<ProcRateForRateCoeff_Townsend_Crane>()
   return params;
 }
 
-ProcRateForRateCoeff_Townsend_Crane::ProcRateForRateCoeff_Townsend_Crane(const InputParameters & parameters)
+ReactionRateTownsend::ReactionRateTownsend(const InputParameters & parameters)
   : AuxKernel(parameters),
 
     _r_units(1. / getParam<Real>("position_units")),
@@ -61,7 +61,7 @@ ProcRateForRateCoeff_Townsend_Crane::ProcRateForRateCoeff_Townsend_Crane(const I
 }
 
 Real
-ProcRateForRateCoeff_Townsend_Crane::computeValue()
+ReactionRateTownsend::computeValue()
 {
 
   Real electron_flux_mag = (-_muem[_qp] * -_grad_potential[_qp] * _r_units * std::exp(_em[_qp]) -

--- a/src/auxkernels/ReactionRateTwoBody.C
+++ b/src/auxkernels/ReactionRateTwoBody.C
@@ -12,13 +12,13 @@
 /*            See COPYRIGHT for full restrictions               */
 /****************************************************************/
 
-#include "ProcRateForRateCoeff_Crane.h"
+#include "ReactionRateTwoBody.h"
 
-registerMooseObject("CraneApp", ProcRateForRateCoeff_Crane);
+registerMooseObject("CraneApp", ReactionRateTwoBody);
 
 template <>
 InputParameters
-validParams<ProcRateForRateCoeff_Crane>()
+validParams<ReactionRateTwoBody>()
 {
   InputParameters params = validParams<AuxKernel>();
 
@@ -26,25 +26,22 @@ validParams<ProcRateForRateCoeff_Crane>()
   params.addCoupledVar("w", "The second variable that is reacting to create u.");
   params.addRequiredParam<std::string>("reaction", "The full reaction equation.");
   params.addClassDescription(
-    "Reaction rate for two body collisions in units of #/m^3s. User can pass"
-    "choice of elastic, excitation, or ionization reaction rate coefficients");
+      "Reaction rate for two body collisions in units of #/m^3s. User can pass"
+      "choice of elastic, excitation, or ionization reaction rate coefficients");
 
   return params;
 }
 
-ProcRateForRateCoeff_Crane::ProcRateForRateCoeff_Crane(const InputParameters & parameters)
+ReactionRateTwoBody::ReactionRateTwoBody(const InputParameters & parameters)
   : AuxKernel(parameters),
-
-  _v(coupledValue("v")),
-  _w(coupledValue("w")),
-  _reaction_coeff(getMaterialProperty<Real>("k_" + getParam<std::string>("reaction")))
+    _v(coupledValue("v")),
+    _w(coupledValue("w")),
+    _reaction_coeff(getMaterialProperty<Real>("k_" + getParam<std::string>("reaction")))
 {
 }
 
 Real
-ProcRateForRateCoeff_Crane::computeValue()
+ReactionRateTwoBody::computeValue()
 {
-
   return 6.02e23 * _reaction_coeff[_qp] * std::exp(_v[_qp]) * std::exp(_w[_qp]);
-
 }

--- a/src/auxkernels/ReactionRateTwoBodyScalar.C
+++ b/src/auxkernels/ReactionRateTwoBodyScalar.C
@@ -12,35 +12,33 @@
 /*            See COPYRIGHT for full restrictions               */
 /****************************************************************/
 
-#include "ProductionThirdOrder.h"
+#include "ReactionRateTwoBodyScalar.h"
 
-registerMooseObject("CraneApp", ProductionThirdOrder);
+registerMooseObject("CraneApp", ReactionRateTwoBodyScalar);
 
 template <>
 InputParameters
-validParams<ProductionThirdOrder>()
+validParams<ReactionRateTwoBodyScalar>()
 {
   InputParameters params = validParams<AuxScalarKernel>();
   params.addRequiredCoupledVar("v", "The first variable that is reacting to create u.");
   params.addRequiredCoupledVar("w", "The second variable that is reacting to create u.");
-  params.addRequiredCoupledVar("z", "The second variable that is reacting to create u.");
   params.addCoupledVar("rate_coefficient", 0, "Coupled reaction coefficient (if equation-based).");
   params.addRequiredParam<Real>("coefficient", "The stoichiometric coeffient.");
   return params;
 }
 
-ProductionThirdOrder::ProductionThirdOrder(const InputParameters & parameters)
+ReactionRateTwoBodyScalar::ReactionRateTwoBodyScalar(const InputParameters & parameters)
   : AuxScalarKernel(parameters),
     _v(coupledScalarValue("v")),
     _w(coupledScalarValue("w")),
-    _z(coupledScalarValue("z")),
     _rate_coefficient(coupledScalarValue("rate_coefficient")),
     _stoichiometric_coeff(getParam<Real>("coefficient"))
 {
 }
 
 Real
-ProductionThirdOrder::computeValue()
+ReactionRateTwoBodyScalar::computeValue()
 {
-  return _stoichiometric_coeff * _rate_coefficient[_i] * _v[_i] * _w[_i] * _z[_i];
+  return _stoichiometric_coeff * _rate_coefficient[_i] * _v[_i] * _w[_i];
 }


### PR DESCRIPTION
…and products; fixing warning for deprecated AuxScalarVariable declaration; updating old header files with pragma statements.

This is a relatively large PR with lots of minor changes.

- Renamed AuxKernels for tracking reaction rates to be more consistent
- Replaced header definitions with "#pragma once"
- Replaced deprecated "addAuxScalarVariable" definitions in AddScalarReactions action
- Added functionality to allow multiple reactions with the same reactants and products to be added without error. This is relevant primarily for excitation reactions with lumped excited species, since multiple different cross sections/rate constants can be used to produce a single lumped state (for example, using Ar* to represent all excited states in argon.)
- Allows comments to be included in reaction list. Commented lines will be skipped. This is mainly for user friendliness; the user may put commented sections with notes to group reactions together and make the list more easily readable.