### PR TITLE
Lumped species for similar reactions

### DIFF
--- a/include/actions/ChemicalReactionsBase.h
+++ b/include/actions/ChemicalReactionsBase.h
@@ -69,4 +69,7 @@ protected:
   std::vector<bool> _electron_energy_term;
   std::vector<NonlinearVariableName> _energy_variable;
   bool _use_bolsig;
+
+  std::vector<bool> _lumped_variable;
+  std::vector<int> _lumped_index;
 };

--- a/include/actions/ChemicalReactionsBase.h
+++ b/include/actions/ChemicalReactionsBase.h
@@ -70,6 +70,8 @@ protected:
   std::vector<NonlinearVariableName> _energy_variable;
   bool _use_bolsig;
 
-  std::vector<bool> _lumped_variable;
-  std::vector<int> _lumped_index;
+  std::vector<bool> _reaction_lumped;
+  std::vector<int> _lumped_species_index;
+  std::vector<int> _lumped_reaction;
+  std::vector<std::string> _lumped_species;
 };

--- a/src/actions/AddScalarReactions.C
+++ b/src/actions/AddScalarReactions.C
@@ -89,6 +89,7 @@ AddScalarReactions::AddScalarReactions(InputParameters params)
 void
 AddScalarReactions::act()
 {
+  // Some quick error checks
   int v_index;
   std::vector<int> other_index;
   std::vector<int> reactant_indices;

--- a/src/actions/ChemicalReactionsBase.C
+++ b/src/actions/ChemicalReactionsBase.C
@@ -466,6 +466,7 @@ ChemicalReactionsBase::ChemicalReactionsBase(InputParameters params)
     _superelastic_reaction.resize(_num_reactions);
     _reversible_reaction.resize(_num_reactions);
     _reaction_lumped.resize(_num_reactions);
+    _species_count.resize(_num_reactions);
 
     unsigned int lumped_counter;
     unsigned int lumped_index;
@@ -488,6 +489,7 @@ ChemicalReactionsBase::ChemicalReactionsBase(InputParameters params)
         _superelastic_reaction[lumped_index] = _superelastic_reaction[_lumped_reaction[i]];
         _reversible_reaction[lumped_index] = _reversible_reaction[_lumped_reaction[i]];
         _reaction_lumped[lumped_index] = false;
+        _species_count[lumped_index] = _species_count[_lumped_reaction[i]];
         for (unsigned int k = 0; k < _reactants[_lumped_reaction[i]].size(); ++k)
         {
           if (_reactants[_lumped_reaction[i]][k] == getParam<std::string>("lumped_name"))


### PR DESCRIPTION
This PR adds support for a lumped species variable, intended to be used for situations in which many identical reactions may occur with any of the neutral species in the system. For example:

O- + N+ + [any neutral species] -> O + N + [any neutral species]

Rather than adding multiple identical reactions with only one species changed, a lumped variable may be defined in the action's parameters: 

lumped_species = true
lumped = 'N2 O2 N ...'
lumped_name = 'NEUTRAL'
reactions = 'O- + N+ + NEUTRAL -> O + N + NEUTRAL : 1e-20'

If "NEUTRAL" accounts for 10 species, the ChemicalReactions action will automatically split this reaction into 10 with the appropriate reactants and products. 

Note that the same system may also be addressed with an auxiliary variable without adding more reactions, e.g. add an aux variable named 'NEUTRAL', add an AuxKernel that sums the species together every linear and nonlinear step, and include 'NEUTRAL' in the aux species list in the action. The aux variable method is less expensive than the lumped species approach since it involves fewer total reactions, but comes at the cost of not including all species in the Jacobian. While in principle this is an issue because the Newton solver requires correct jacobians, in general this has not been an issue with large reaction networks since the reactions treated in this way are rarely dominant, so their Jacobian contributions are small enough to not trouble the Newton solver. 

