### PR TITLE
Fixing scalar log kernel bugs; general cleanup of files

### DIFF
--- a/include/actions/ChemicalReactionsBase.h
+++ b/include/actions/ChemicalReactionsBase.h
@@ -74,4 +74,5 @@ protected:
   std::vector<int> _lumped_species_index;
   std::vector<int> _lumped_reaction;
   std::vector<std::string> _lumped_species;
+  std::vector<int> num_particles;
 };

--- a/include/auxkernels/VariableSumLog.h
+++ b/include/auxkernels/VariableSumLog.h
@@ -1,0 +1,34 @@
+/****************************************************************/
+/*               DO NOT MODIFY THIS HEADER                      */
+/* MOOSE - Multiphysics Object Oriented Simulation Environment  */
+/*                                                              */
+/*           (c) 2010 Battelle Energy Alliance, LLC             */
+/*                   ALL RIGHTS RESERVED                        */
+/*                                                              */
+/*          Prepared by Battelle Energy Alliance, LLC           */
+/*            Under Contract No. DE-AC07-05ID14517              */
+/*            With the U. S. Department of Energy               */
+/*                                                              */
+/*            See COPYRIGHT for full restrictions               */
+/****************************************************************/
+
+#pragma once
+
+#include "AuxScalarKernel.h"
+// #include "SplineInterpolation.h"
+
+class VariableSumLog;
+
+template <>
+InputParameters validParams<VariableSumLog>();
+
+class VariableSumLog : public AuxScalarKernel
+{
+public:
+  VariableSumLog(const InputParameters & parameters);
+
+protected:
+  virtual Real computeValue();
+  unsigned int _nargs;
+  std::vector<const VariableValue *> _args;
+};

--- a/include/scalarkernels/Product1BodyScalar.h
+++ b/include/scalarkernels/Product1BodyScalar.h
@@ -22,7 +22,6 @@ protected:
   const VariableValue & _v;
   const VariableValue & _rate_coefficient;
 
-  Real _n_gas;
   Real _stoichiometric_coeff;
   // Real _reaction_coeff;
   bool _v_eq_u;

--- a/include/scalarkernels/Product1BodyScalarLog.h
+++ b/include/scalarkernels/Product1BodyScalarLog.h
@@ -22,9 +22,7 @@ protected:
   const VariableValue & _v;
   const VariableValue & _rate_coefficient;
 
-  Real _n_gas;
   Real _stoichiometric_coeff;
-  // Real _reaction_coeff;
   bool _v_eq_u;
   bool _v_coupled;
   bool _rate_constant_equation;

--- a/include/scalarkernels/Product2BodyScalar.h
+++ b/include/scalarkernels/Product2BodyScalar.h
@@ -24,7 +24,6 @@ protected:
   const VariableValue & _w;
   const VariableValue & _rate_coefficient;
 
-  Real _n_gas;
   Real _stoichiometric_coeff;
   // Real _reaction_coeff;
   bool _v_eq_u;

--- a/include/scalarkernels/Product2BodyScalarLog.h
+++ b/include/scalarkernels/Product2BodyScalarLog.h
@@ -24,7 +24,6 @@ protected:
   const VariableValue & _w;
   const VariableValue & _rate_coefficient;
 
-  Real _n_gas;
   Real _stoichiometric_coeff;
   // Real _reaction_coeff;
   bool _v_eq_u;

--- a/include/scalarkernels/Product3BodyScalar.h
+++ b/include/scalarkernels/Product3BodyScalar.h
@@ -26,9 +26,7 @@ protected:
   const VariableValue & _x;
   const VariableValue & _rate_coefficient;
 
-  Real _n_gas;
   Real _stoichiometric_coeff;
-  // Real _reaction_coeff;
   bool _v_eq_u;
   bool _w_eq_u;
   bool _x_eq_u;

--- a/include/scalarkernels/Product3BodyScalarLog.h
+++ b/include/scalarkernels/Product3BodyScalarLog.h
@@ -25,7 +25,6 @@ protected:
   const VariableValue & _x;
   const VariableValue & _rate_coefficient;
 
-  Real _n_gas;
   Real _stoichiometric_coeff;
   // Real _reaction_coeff;
   bool _v_eq_u;

--- a/include/scalarkernels/Reactant1BodyScalar.h
+++ b/include/scalarkernels/Reactant1BodyScalar.h
@@ -16,9 +16,8 @@ public:
 protected:
   virtual Real computeQpResidual() override;
   virtual Real computeQpJacobian() override;
-  virtual Real computeQpOffDiagJacobian(unsigned int jvar) override;
+  //virtual Real computeQpOffDiagJacobian(unsigned int jvar) override;
   const VariableValue & _rate_coefficient;
-  Real _n_gas;
   Real _stoichiometric_coeff;
   bool _rate_constant_equation;
 

--- a/include/scalarkernels/Reactant1BodyScalarLog.h
+++ b/include/scalarkernels/Reactant1BodyScalarLog.h
@@ -16,9 +16,8 @@ public:
 protected:
   virtual Real computeQpResidual() override;
   virtual Real computeQpJacobian() override;
-  virtual Real computeQpOffDiagJacobian(unsigned int jvar) override;
+  //virtual Real computeQpOffDiagJacobian(unsigned int jvar) override;
   const VariableValue & _rate_coefficient;
-  Real _n_gas;
   Real _stoichiometric_coeff;
   bool _rate_constant_equation;
 

--- a/include/scalarkernels/Reactant2BodyScalar.h
+++ b/include/scalarkernels/Reactant2BodyScalar.h
@@ -22,7 +22,6 @@ protected:
   const VariableValue & _v;
   const VariableValue & _rate_coefficient;
 
-  Real _n_gas;
   Real _stoichiometric_coeff;
   bool _v_eq_u;
   bool _rate_constant_equation;

--- a/include/scalarkernels/Reactant2BodyScalarLog.h
+++ b/include/scalarkernels/Reactant2BodyScalarLog.h
@@ -22,7 +22,6 @@ protected:
   const VariableValue & _v;
   const VariableValue & _rate_coefficient;
 
-  Real _n_gas;
   Real _stoichiometric_coeff;
   bool _v_eq_u;
   bool _v_coupled;

--- a/include/scalarkernels/Reactant3BodyScalar.h
+++ b/include/scalarkernels/Reactant3BodyScalar.h
@@ -24,7 +24,6 @@ protected:
   const VariableValue & _w;
   const VariableValue & _rate_coefficient;
 
-  Real _n_gas;
   Real _stoichiometric_coeff;
   // Real _reaction_coeff;
   bool _v_eq_u;

--- a/include/scalarkernels/Reactant3BodyScalarLog.h
+++ b/include/scalarkernels/Reactant3BodyScalarLog.h
@@ -24,7 +24,6 @@ protected:
   const VariableValue & _w;
   const VariableValue & _rate_coefficient;
 
-  Real _n_gas;
   Real _stoichiometric_coeff;
   // Real _reaction_coeff;
   bool _v_eq_u;

--- a/src/actions/AddScalarReactions.C
+++ b/src/actions/AddScalarReactions.C
@@ -474,7 +474,6 @@ AddScalarReactions::act()
             InputParameters params = _factory.getValidParams(reactant_kernel_name);
             params.set<NonlinearVariableName>("variable") = _species[j];
             params.set<Real>("coefficient") = _species_count[i][j];
-            params.set<Real>("n_gas") = 3.219e18;
             params.set<std::vector<VariableName>>("rate_coefficient") = {_aux_var_name[i]};
             params.set<bool>("rate_constant_equation") = true;
             if (find_other)
@@ -508,7 +507,6 @@ AddScalarReactions::act()
           {
             InputParameters params = _factory.getValidParams(product_kernel_name);
             params.set<NonlinearVariableName>("variable") = _species[j];
-            params.set<Real>("n_gas") = 3.219e18;
             params.set<std::vector<VariableName>>("rate_coefficient") = {_aux_var_name[i]};
             params.set<bool>("rate_constant_equation") = true;
             params.set<Real>("coefficient") = _species_count[i][j];

--- a/src/auxkernels/VariableSumLog.C
+++ b/src/auxkernels/VariableSumLog.C
@@ -1,0 +1,47 @@
+/****************************************************************/
+/*               DO NOT MODIFY THIS HEADER                      */
+/* MOOSE - Multiphysics Object Oriented Simulation Environment  */
+/*                                                              */
+/*           (c) 2010 Battelle Energy Alliance, LLC             */
+/*                   ALL RIGHTS RESERVED                        */
+/*                                                              */
+/*          Prepared by Battelle Energy Alliance, LLC           */
+/*            Under Contract No. DE-AC07-05ID14517              */
+/*            With the U. S. Department of Energy               */
+/*                                                              */
+/*            See COPYRIGHT for full restrictions               */
+/****************************************************************/
+
+#include "VariableSumLog.h"
+
+registerMooseObject("CraneApp", VariableSumLog);
+
+template <>
+InputParameters
+validParams<VariableSumLog>()
+{
+  InputParameters params = validParams<AuxScalarKernel>();
+  params.addCoupledVar("args", "The variables to sum.");
+  return params;
+}
+
+VariableSumLog::VariableSumLog(const InputParameters & parameters)
+  : AuxScalarKernel(parameters),
+    _nargs(coupledScalarComponents("args")),
+    _args(_nargs)
+{
+}
+
+Real
+VariableSumLog::computeValue()
+{
+  Real variable_sum = 0;
+  for (unsigned int i = 0; i < _nargs; ++i)
+  {
+    // variables += (i == 0 ? "" : ",") + getScalarVar("args", i)->name();
+    // _args[i] = &coupledScalarValue("args", i);
+    // std::cout << (*_args[i])[_i] << std::endl;
+    variable_sum += std::exp(coupledScalarValue("args", i)[_i]);
+  }
+  return std::log(variable_sum);
+}

--- a/src/scalarkernels/Product1BodyScalar.C
+++ b/src/scalarkernels/Product1BodyScalar.C
@@ -7,15 +7,12 @@ InputParameters
 validParams<Product1BodyScalar>()
 {
   InputParameters params = validParams<ODEKernel>();
-  params.addCoupledVar("v", 0, "Coupled variable 1.");
+  params.addRequiredCoupledVar("v", "Coupled variable 1.");
   params.addCoupledVar("rate_coefficient", 0, "Coupled reaction coefficient (if equation-based).");
-  params.addRequiredParam<Real>("n_gas", "The gas density.");
   params.addRequiredParam<Real>("coefficient", "The stoichiometric coefficient.");
-  // params.addRequiredParam<Real>("reaction_coefficient", "The reaction coefficient.");
   params.addParam<bool>("v_eq_u", false, "Whether or not u = v.");
-  params.addParam<bool>("rate_constant_equation", false, "True if rate constant is provided by equation.");
-  // params.addRequiredParam<UserObjectName>("rate_provider",
-  //     "The name of the UserObject that can provide the rate coefficient.");
+  params.addParam<bool>(
+      "rate_constant_equation", false, "True if rate constant is provided by equation.");
   return params;
 }
 
@@ -24,88 +21,55 @@ Product1BodyScalar::Product1BodyScalar(const InputParameters & parameters)
     _v_var(isCoupledScalar("v") ? coupledScalar("v") : -1),
     _v(coupledScalarValue("v")),
     _rate_coefficient(coupledScalarValue("rate_coefficient")),
-    _n_gas(getParam<Real>("n_gas")),
     _stoichiometric_coeff(getParam<Real>("coefficient")),
     _v_eq_u(getParam<bool>("v_eq_u")),
     _rate_constant_equation(getParam<bool>("rate_constant_equation"))
-    // _data(getUserObject<RateCoefficientProvider>("rate_provider"))
 {
 }
 
 Real
 Product1BodyScalar::computeQpResidual()
 {
-  Real mult1;
-  if (isCoupledScalar("v"))
-    mult1 = _v[_i];
-  else
-    mult1 = _n_gas;
-
-
-  // if (_rate_constant_equation)
-  return -_stoichiometric_coeff * _rate_coefficient[_i] * mult1;
-  // else
-  //   return -_stoichiometric_coeff * _data.reaction_coefficient() * mult1;
-  // return -_stoichiometric_coeff * _data.reaction_coefficient() * mult1;
+  return -_stoichiometric_coeff * _rate_coefficient[_i] * _v[_i];
 }
 
 Real
 Product1BodyScalar::computeQpJacobian()
 {
-  Real mult1;
   Real power, eq_u_mult, gas_mult;
-  Real rate_constant;
+
   power = 0.0;
   eq_u_mult = 1.0;
   gas_mult = 1.0;
 
-  if (isCoupledScalar("v"))
-    mult1 = _v[_i];
-  else
-    mult1 = _n_gas;
-
   if (isCoupledScalar("v") && _v_eq_u)
   {
     power += 1.0;
-    eq_u_mult = mult1;
+    eq_u_mult = _v[_i];
   }
   else
-    gas_mult *= mult1;
+    gas_mult *= _v[_i];
 
-  // if (_rate_constant_equation)
-  rate_constant = _rate_coefficient[_i];
-  // else
-  //   rate_constant = _data.reaction_coefficient();
-
-  return -_stoichiometric_coeff * rate_constant * gas_mult * power * std::pow(eq_u_mult, power-1);
+  return -_stoichiometric_coeff * _rate_coefficient[_i] * gas_mult * power *
+         std::pow(eq_u_mult, power - 1);
 }
 
 Real
 Product1BodyScalar::computeQpOffDiagJacobian(unsigned int jvar)
 {
-  Real power, mult1, deriv_factor, other_factor;
-  Real rate_constant;
+  Real power, deriv_factor, other_factor;
   power = 0;
   other_factor = 1;
   deriv_factor = 1;
-  if (isCoupledScalar("v"))
-    mult1 = _v[_i];
-  else
-    mult1 = _n_gas;
 
   if (jvar == _v_var && !_v_eq_u)
   {
     power += 1;
-    deriv_factor = mult1;
+    deriv_factor = _v[_i];
   }
   else
-    other_factor *= mult1;
+    other_factor *= _v[_i];
 
-  // if (_rate_constant_equation)
-  rate_constant = _rate_coefficient[_i];
-  // else
-  //   rate_constant = _data.reaction_coefficient();
-
-  return -_stoichiometric_coeff * rate_constant * other_factor * power
-    * std::pow(deriv_factor, power-1);
+  return -_stoichiometric_coeff * _rate_coefficient[_i] * other_factor * power *
+         std::pow(deriv_factor, power - 1);
 }

--- a/src/scalarkernels/Product1BodyScalarLog.C
+++ b/src/scalarkernels/Product1BodyScalarLog.C
@@ -7,15 +7,11 @@ InputParameters
 validParams<Product1BodyScalarLog>()
 {
   InputParameters params = validParams<ODEKernel>();
-  params.addCoupledVar("v", 0, "Coupled variable 1.");
+  params.addRequiredCoupledVar("v", "Coupled variable 1.");
   params.addCoupledVar("rate_coefficient", 0, "Coupled reaction coefficient (if equation-based).");
-  params.addRequiredParam<Real>("n_gas", "The gas density.");
   params.addRequiredParam<Real>("coefficient", "The stoichiometric coefficient.");
-  // params.addRequiredParam<Real>("reaction_coefficient", "The reaction coefficient.");
   params.addParam<bool>("v_eq_u", false, "Whether or not u = v.");
   params.addParam<bool>("rate_constant_equation", false, "True if rate constant is provided by equation.");
-  // params.addRequiredParam<UserObjectName>("rate_provider",
-  //     "The name of the UserObject that can provide the rate coefficient.");
   return params;
 }
 
@@ -24,56 +20,38 @@ Product1BodyScalarLog::Product1BodyScalarLog(const InputParameters & parameters)
     _v_var(isCoupledScalar("v") ? coupledScalar("v") : 0),
     _v(coupledScalarValue("v")),
     _rate_coefficient(coupledScalarValue("rate_coefficient")),
-    _n_gas(getParam<Real>("n_gas")),
     _stoichiometric_coeff(getParam<Real>("coefficient")),
     _v_eq_u(getParam<bool>("v_eq_u")),
     _v_coupled(isCoupledScalar("v") ? true : false),
     _rate_constant_equation(getParam<bool>("rate_constant_equation"))
-    // _data(getUserObject<RateCoefficientProvider>("rate_provider"))
 {
 }
 
 Real
 Product1BodyScalarLog::computeQpResidual()
 {
-  Real mult1;
-  if (isCoupledScalar("v"))
-    mult1 = std::exp(_v[_i]);
-  else
-    mult1 = _n_gas;
-
-
-  // if (_rate_constant_equation)
-  return -_stoichiometric_coeff * _rate_coefficient[_i] * mult1;
-  // else
-  //   return -_stoichiometric_coeff * _data.reaction_coefficient() * mult1;
-  // return -_stoichiometric_coeff * _data.reaction_coefficient() * mult1;
+  return -_stoichiometric_coeff * _rate_coefficient[_i] * std::exp(_v[_i]);
 }
 
 Real
 Product1BodyScalarLog::computeQpJacobian()
 {
-  Real mult1;
   Real power, eq_u_mult, gas_mult;
-  // Real rate_constant;
   power = 0.0;
   eq_u_mult = 0.0;
   gas_mult = 0.0;
 
-  if (_v_coupled)
-    mult1 = _v[_i];
-  else
-    mult1 = _n_gas;
-
   if (_v_coupled && _v_eq_u)
   {
     power += 1;
-    eq_u_mult += mult1;
+    eq_u_mult += _v[_i];
   }
   else
-    gas_mult += mult1;
+    gas_mult += _v[_i];
 
-  return -_stoichiometric_coeff * _rate_coefficient[_i] * std::exp(gas_mult) * power * std::exp(eq_u_mult);
+  //return -_stoichiometric_coeff * _rate_coefficient[_i] * std::exp(gas_mult) * power * std::exp(eq_u_mult);
+  return -_stoichiometric_coeff * _rate_coefficient[_i] * std::exp(gas_mult + eq_u_mult) * power;
+
   // Real mult1;
   // Real power, eq_u_mult, gas_mult;
   // Real rate_constant;
@@ -105,26 +83,24 @@ Product1BodyScalarLog::computeQpJacobian()
 Real
 Product1BodyScalarLog::computeQpOffDiagJacobian(unsigned int jvar)
 {
-  Real power, mult1;
+  Real power;
   Real gas_mult,off_diag;
   // Real rate_constant;
   power = 0;
   gas_mult = 0;
   off_diag = 0;
-  if (_v_coupled)
-    mult1 = _v[_i];
-  else
-    mult1 = _n_gas;
 
   if (_v_coupled && !_v_eq_u && jvar==_v_var)
   {
     power += 1;
-    off_diag += mult1;
+    off_diag += _v[_i];
   }
   else
-    gas_mult += mult1;
+    gas_mult += _v[_i];
 
-  return -_stoichiometric_coeff * _rate_coefficient[_i] * std::exp(gas_mult) * power * std::exp(off_diag);
+  //return -_stoichiometric_coeff * _rate_coefficient[_i] * std::exp(gas_mult) * power * std::exp(off_diag);
+  return -_stoichiometric_coeff * _rate_coefficient[_i] * std::exp(gas_mult + off_diag) * power;
+
   // Real power, mult1, deriv_factor, other_factor;
   // Real rate_constant;
   // power = 0;

--- a/src/scalarkernels/Product2BodyScalar.C
+++ b/src/scalarkernels/Product2BodyScalar.C
@@ -7,17 +7,14 @@ InputParameters
 validParams<Product2BodyScalar>()
 {
   InputParameters params = validParams<ODEKernel>();
-  params.addCoupledVar("v", 0, "Coupled variable 1.");
-  params.addCoupledVar("w", 0, "Coupled variable 2.");
+  params.addRequiredCoupledVar("v", "Coupled variable 1.");
+  params.addRequiredCoupledVar("w", "Coupled variable 2.");
   params.addCoupledVar("rate_coefficient", 0, "Coupled reaction coefficient (if equation-based).");
-  params.addRequiredParam<Real>("n_gas", "The gas density.");
   params.addRequiredParam<Real>("coefficient", "The stoichiometric coefficient.");
-  // params.addRequiredParam<Real>("reaction_coefficient", "The reaction coefficient.");
   params.addParam<bool>("v_eq_u", false, "Whether or not u = v.");
   params.addParam<bool>("w_eq_u", false, "Whether or not u = w.");
-  params.addParam<bool>("rate_constant_equation", false, "True if rate constant is provided by equation.");
-  // params.addRequiredParam<UserObjectName>("rate_provider",
-  //     "The name of the UserObject that can provide the rate coefficient.");
+  params.addParam<bool>(
+      "rate_constant_equation", false, "True if rate constant is provided by equation.");
   return params;
 }
 
@@ -28,207 +25,72 @@ Product2BodyScalar::Product2BodyScalar(const InputParameters & parameters)
     _w_var(isCoupledScalar("w") ? coupledScalar("w") : -1),
     _w(coupledScalarValue("w")),
     _rate_coefficient(coupledScalarValue("rate_coefficient")),
-    _n_gas(getParam<Real>("n_gas")),
     _stoichiometric_coeff(getParam<Real>("coefficient")),
-    // _reaction_coeff(getParam<Real>("reaction_coefficient")),
     _v_eq_u(getParam<bool>("v_eq_u")),
     _w_eq_u(getParam<bool>("w_eq_u")),
     _rate_constant_equation(getParam<bool>("rate_constant_equation"))
-    // _data(getUserObject<RateCoefficientProvider>("rate_provider"))
 {
 }
 
 Real
 Product2BodyScalar::computeQpResidual()
 {
-  Real mult1, mult2;
-  if (isCoupledScalar("v"))
-    mult1 = _v[_i];
-  else
-    mult1 = _n_gas;
-
-  if (isCoupledScalar("w"))
-    mult2 = _w[_i];
-  else
-    mult2 = _n_gas;
-
-  // if (_rate_constant_equation)
-  return -_stoichiometric_coeff * _rate_coefficient[_i] * mult1 * mult2;
-  // else
-  //   return -_stoichiometric_coeff * _data.reaction_coefficient() * mult1 * mult2;
-  // return -_stoichiometric_coeff * _reaction_coeff * mult1 * mult2;
-  // return -_stoichiometric_coeff * _data.reaction_coefficient() * mult1 * mult2;
-  // return -_stoichiometric_coeff * 1e-16 * _n_gas * _n_gas;
+  return -_stoichiometric_coeff * _rate_coefficient[_i] * _v[_i] * _w[_i];
 }
 
 Real
 Product2BodyScalar::computeQpJacobian()
 {
-  Real mult1, mult2;
   Real power, eq_u_mult, gas_mult;
   Real rate_constant;
   power = 0.0;
   eq_u_mult = 1.0;
   gas_mult = 1.0;
 
-  if (isCoupledScalar("v"))
-    mult1 = _v[_i];
-  else
-    mult1 = _n_gas;
-
-  if (isCoupledScalar("w"))
-    mult2 = _w[_i];
-  else
-    mult2 = _n_gas;
-
   if (isCoupledScalar("v") && _v_eq_u)
   {
     power += 1.0;
-    eq_u_mult = mult1;
+    eq_u_mult = _v[_i];
   }
   else
-    gas_mult *= mult1;
+    gas_mult *= _v[_i];
 
   if (isCoupledScalar("w") && _w_eq_u)
   {
     power += 1.0;
-    eq_u_mult = mult2;
+    eq_u_mult = _w[_i];
   }
   else
-    gas_mult *= mult2;
+    gas_mult *= _w[_i];
 
-  // if (_rate_constant_equation)
-  rate_constant = _rate_coefficient[_i];
-  // else
-  //   rate_constant = _data.reaction_coefficient();
-  // std::cout << -_stoichiometric_coeff * rate_constant * gas_mult * power * std::pow(eq_u_mult, power-1) << std::endl;
-  return -_stoichiometric_coeff * rate_constant * gas_mult * power * std::pow(eq_u_mult, power-1);
-  // return -_stoichiometric_coeff * _data.reaction_coefficient() * gas_mult * power * eq_u_mult;
-  // return 0.0;
-  // if (_v_eq_u && _w_eq_u)
-  // {
-  //   // return -_stoichiometric_coeff * 1e-16 * 2.0 * _u[_i];
-  //   return -_stoichiometric_coeff * _data.reaction_coefficient() * 2.0 * _u[_i];
-  // }
-  // else if (_v_eq_u && !_w_eq_u)
-  // {
-  //   // return -_stoichiometric_coeff * 1e-16 * mult2;
-  //   return -_stoichiometric_coeff * _data.reaction_coefficient() * mult2;
-  // }
-  // else if (!_v_eq_u && _w_eq_u)
-  // {
-  //   // return -_stoichiometric_coeff * 1e-16 * mult1;
-  //   return -_stoichiometric_coeff * _data.reaction_coefficient() * mult1;
-  // }
-  // else
-  // {
-  //   return 0.0;
-  // }
-
+  return -_stoichiometric_coeff * _rate_coefficient[_i] * gas_mult * power *
+         std::pow(eq_u_mult, power - 1);
 }
 
 Real
 Product2BodyScalar::computeQpOffDiagJacobian(unsigned int jvar)
 {
-  Real power, mult1, mult2, deriv_factor, other_factor;
-  Real rate_constant;
+  Real power, deriv_factor, other_factor;
   power = 0;
   other_factor = 1;
   deriv_factor = 1;
-  if (isCoupledScalar("v"))
-    mult1 = _v[_i];
-  else
-    mult1 = _n_gas;
-
-  if (isCoupledScalar("w"))
-    mult2 = _w[_i];
-  else
-    mult2 = _n_gas;
 
   if (jvar == _v_var && !_v_eq_u)
   {
     power += 1;
-    deriv_factor = mult1;
+    deriv_factor = _v[_i];
   }
   else
-    other_factor *= mult1;
+    other_factor *= _v[_i];
 
   if (jvar == _w_var && !_w_eq_u)
   {
     power += 1;
-    deriv_factor = mult2;
+    deriv_factor = _w[_i];
   }
   else
-    other_factor *= mult2;
+    other_factor *= _w[_i];
 
-  // if (_rate_constant_equation)
-  rate_constant = _rate_coefficient[_i];
-  // std::cout << -_stoichiometric_coeff * rate_constant * other_factor * power * std::pow(deriv_factor, power-1) << std::endl;
-  // else
-  //   rate_constant = _data.reaction_coefficient();
-  // return -_stoichiometric_coeff * _data.reaction_coefficient() * other_factor * power * deriv_factor;
-  // std::cout << -_stoichiometric_coeff * _data.reaction_coefficient() * other_factor * power
-    // * std::pow(deriv_factor, power-1) << std::endl;
-  return -_stoichiometric_coeff * rate_constant * other_factor * power
-    * std::pow(deriv_factor, power-1);
-
-  // return -_stoichiometric_coeff * _data.reaction_coefficient() * (v_power + w_power) *
-  //   std::pow(mult1, v_power - 1) * std::pow(mult2, w_power-1);
-
-  // return 0;
-  // Real mult1,mult2;
-  //
-  // if (isCoupledScalar("v"))
-  //   mult1 = _v[_i];
-  // else
-  //   mult1 = _n_gas;
-  //
-  // if (isCoupledScalar("w"))
-  //   mult2 = _w[_i];
-  // else
-  //   mult2 = _n_gas;
-  //
-  // if (isCoupledScalar("v") && isCoupledScalar("w"))
-  // {
-  //   if (!_v_eq_u && !_w_eq_u)
-  //   {
-  //     if (_v_var != _w_var)
-  //     {
-  //       if (jvar == _v_var)
-  //         return -_stoichiometric_coeff * _data.reaction_coefficient() * mult2;
-  //       else if (jvar == _w_var)
-  //         return -_stoichiometric_coeff * _data.reaction_coefficient() * mult1;
-  //       else
-  //         return 0.0;
-  //     }
-  //     else
-  //     {
-  //       if (jvar == _v_var)
-  //         return -_stoichiometric_coeff * _data.reaction_coefficient() * 2.0 * mult1;
-  //       else
-  //         return 0.0;
-  //     }
-  //   }
-  //   else
-  //     return 0.0;
-  // }
-  // else if (isCoupledScalar("v") && !isCoupledScalar("w"))
-  // {
-  //   if (jvar == _v_var)
-  //   {
-  //     return -_stoichiometric_coeff * _data.reaction_coefficient() * mult2;
-  //   }
-  //   else
-  //     return 0.0;
-  // }
-  // else if (!isCoupledScalar("v") && isCoupledScalar("w"))
-  // {
-  //   if (jvar == _w_var)
-  //     return -_stoichiometric_coeff * _data.reaction_coefficient() * mult1;
-  //   else
-  //     return 0.0;
-  // }
-  // else
-  //   return 0.0;
-
+  return -_stoichiometric_coeff * _rate_coefficient[_i] * other_factor * power *
+         std::pow(deriv_factor, power - 1);
 }

--- a/src/scalarkernels/Product2BodyScalarLog.C
+++ b/src/scalarkernels/Product2BodyScalarLog.C
@@ -7,17 +7,14 @@ InputParameters
 validParams<Product2BodyScalarLog>()
 {
   InputParameters params = validParams<ODEKernel>();
-  params.addCoupledVar("v", 0, "Coupled variable 1.");
-  params.addCoupledVar("w", 0, "Coupled variable 2.");
+  params.addRequiredCoupledVar("v", "Coupled variable 1.");
+  params.addRequiredCoupledVar("w", "Coupled variable 2.");
   params.addCoupledVar("rate_coefficient", 0, "Coupled reaction coefficient (if equation-based).");
-  params.addRequiredParam<Real>("n_gas", "The gas density.");
   params.addRequiredParam<Real>("coefficient", "The stoichiometric coefficient.");
-  // params.addRequiredParam<Real>("reaction_coefficient", "The reaction coefficient.");
   params.addParam<bool>("v_eq_u", false, "Whether or not u = v.");
   params.addParam<bool>("w_eq_u", false, "Whether or not u = w.");
-  params.addParam<bool>("rate_constant_equation", false, "True if rate constant is provided by equation.");
-  // params.addRequiredParam<UserObjectName>("rate_provider",
-  //     "The name of the UserObject that can provide the rate coefficient.");
+  params.addParam<bool>(
+      "rate_constant_equation", false, "True if rate constant is provided by equation.");
   return params;
 }
 
@@ -28,249 +25,56 @@ Product2BodyScalarLog::Product2BodyScalarLog(const InputParameters & parameters)
     _w_var(isCoupledScalar("w") ? coupledScalar("w") : 0),
     _w(coupledScalarValue("w")),
     _rate_coefficient(coupledScalarValue("rate_coefficient")),
-    _n_gas(getParam<Real>("n_gas")),
     _stoichiometric_coeff(getParam<Real>("coefficient")),
-    // _reaction_coeff(getParam<Real>("reaction_coefficient")),
     _v_eq_u(getParam<bool>("v_eq_u")),
     _w_eq_u(getParam<bool>("w_eq_u")),
     _v_coupled(isCoupledScalar("v") ? true : false),
     _w_coupled(isCoupledScalar("w") ? true : false),
     _rate_constant_equation(getParam<bool>("rate_constant_equation"))
-    // _data(getUserObject<RateCoefficientProvider>("rate_provider"))
 {
 }
 
 Real
 Product2BodyScalarLog::computeQpResidual()
 {
-  Real mult1, mult2;
-
-  if (_v_coupled)
-    mult1 = std::exp(_v[_i]);
-  else
-    mult1 = _n_gas;
-
-  if (_w_coupled)
-    mult2 = std::exp(_w[_i]);
-  else
-    mult2 = _n_gas;
-
-  return -_stoichiometric_coeff * _rate_coefficient[_i] * mult1 * mult2;
-
-  // if (_rate_constant_equation)
-  // return -_stoichiometric_coeff * _rate_coefficient[_i] * mult1 * mult2;
-  // else
-  //   return -_stoichiometric_coeff * _data.reaction_coefficient() * mult1 * mult2;
-  // return -_stoichiometric_coeff * _reaction_coeff * mult1 * mult2;
-  // return -_stoichiometric_coeff * _data.reaction_coefficient() * mult1 * mult2;
-  // return -_stoichiometric_coeff * 1e-16 * _n_gas * _n_gas;
+  return -_stoichiometric_coeff * _rate_coefficient[_i] * std::exp(_v[_i] + _w[_i]);
 }
 
 Real
 Product2BodyScalarLog::computeQpJacobian()
 {
-  Real mult1, mult2;
-  Real power, eq_u_mult, gas_mult;
-  // Real rate_constant;
+  Real power;
   power = 0.0;
-  eq_u_mult = 0.0;
-  gas_mult = 0.0;
 
-  if (_v_coupled)
-    mult1 = _v[_i];
-  else
-    mult1 = _n_gas;
-
-  if (_w_coupled)
-    mult2 = _w[_i];
-  else
-    mult2 = _n_gas;
-
+  // I can really check for _v_eq_u once at the beginning...no need to do it every single iteration.
   if (_v_coupled && _v_eq_u)
   {
     power += 1;
-    eq_u_mult += mult1;
   }
-  else
-    gas_mult += mult1;
 
   if (_w_coupled && _w_eq_u)
   {
     power += 1;
-    eq_u_mult += mult2;
   }
-  else
-    gas_mult += mult2;
-  // std::cout << -_stoichiometric_coeff * _rate_coefficient[_i] * std::exp(gas_mult) * power * std::exp(eq_u_mult) << std::endl;
-  return -_stoichiometric_coeff * _rate_coefficient[_i] * std::exp(gas_mult) * power * std::exp(eq_u_mult);
 
-  // if (isCoupledScalar("v") && _v_eq_u)
-  // {
-  //   power += 1.0;
-  //   eq_u_mult = mult1;
-  // }
-  // else
-  //   gas_mult *= mult1;
-  //
-  // if (isCoupledScalar("w") && _w_eq_u)
-  // {
-  //   power += 1.0;
-  //   eq_u_mult = mult2;
-  // }
-  // else
-  //   gas_mult *= mult2;
-  //
-  // // if (_rate_constant_equation)
-  // rate_constant = _rate_coefficient[_i];
-  // // else
-  // //   rate_constant = _data.reaction_coefficient();
-  //
-  // return -_stoichiometric_coeff * rate_constant * gas_mult * power * std::pow(eq_u_mult, power-1);
-  // return -_stoichiometric_coeff * _data.reaction_coefficient() * gas_mult * power * eq_u_mult;
-  // return 0.0;
-  // if (_v_eq_u && _w_eq_u)
-  // {
-  //   // return -_stoichiometric_coeff * 1e-16 * 2.0 * _u[_i];
-  //   return -_stoichiometric_coeff * _data.reaction_coefficient() * 2.0 * _u[_i];
-  // }
-  // else if (_v_eq_u && !_w_eq_u)
-  // {
-  //   // return -_stoichiometric_coeff * 1e-16 * mult2;
-  //   return -_stoichiometric_coeff * _data.reaction_coefficient() * mult2;
-  // }
-  // else if (!_v_eq_u && _w_eq_u)
-  // {
-  //   // return -_stoichiometric_coeff * 1e-16 * mult1;
-  //   return -_stoichiometric_coeff * _data.reaction_coefficient() * mult1;
-  // }
-  // else
-  // {
-  //   return 0.0;
-  // }
-
+  return -_stoichiometric_coeff * _rate_coefficient[_i] * std::exp(_v[_i] + _w[_i]) * power;
 }
 
 Real
 Product2BodyScalarLog::computeQpOffDiagJacobian(unsigned int jvar)
 {
-  Real power, mult1, mult2;
-  Real gas_mult,off_diag;
-  // Real rate_constant;
+  Real power;
   power = 0;
-  gas_mult = 0;
-  off_diag = 0;
-  if (_v_coupled)
-    mult1 = _v[_i];
-  else
-    mult1 = _n_gas;
 
-  if (_w_coupled)
-    mult2 = _w[_i];
-  else
-    mult2 = _n_gas;
-
-  if (_v_coupled && !_v_eq_u && jvar==_v_var)
+  if (_v_coupled && !_v_eq_u && jvar == _v_var)
   {
     power += 1;
-    off_diag += mult1;
   }
-  else
-    gas_mult += mult1;
 
-  if (_w_coupled && !_w_eq_u && jvar==_w_var)
+  if (_w_coupled && !_w_eq_u && jvar == _w_var)
   {
     power += 1;
-    off_diag += mult2;
   }
-  else
-    gas_mult += mult2;
 
-  // std::cout << -_stoichiometric_coeff * _rate_coefficient[_i] * std::exp(gas_mult) * power * std::exp(off_diag) << std::endl;
-  return -_stoichiometric_coeff * _rate_coefficient[_i] * std::exp(gas_mult) * power * std::exp(off_diag);
-
-  // if (jvar == _v_var && !_v_eq_u)
-  // {
-  //   power += 1;
-  //   deriv_factor = mult1;
-  // }
-  // else
-  //   other_factor *= mult1;
-  //
-  // if (jvar == _w_var && !_w_eq_u)
-  // {
-  //   power += 1;
-  //   deriv_factor = mult2;
-  // }
-  // else
-  //   other_factor *= mult2;
-  //
-  // // if (_rate_constant_equation)
-  // rate_constant = _rate_coefficient[_i];
-  // // else
-  // //   rate_constant = _data.reaction_coefficient();
-  // // return -_stoichiometric_coeff * _data.reaction_coefficient() * other_factor * power * deriv_factor;
-  // // std::cout << -_stoichiometric_coeff * _data.reaction_coefficient() * other_factor * power
-  //   // * std::pow(deriv_factor, power-1) << std::endl;
-  // return -_stoichiometric_coeff * rate_constant * other_factor * power
-  //   * std::pow(deriv_factor, power-1);
-
-  // return -_stoichiometric_coeff * _data.reaction_coefficient() * (v_power + w_power) *
-  //   std::pow(mult1, v_power - 1) * std::pow(mult2, w_power-1);
-
-  // return 0;
-  // Real mult1,mult2;
-  //
-  // if (isCoupledScalar("v"))
-  //   mult1 = _v[_i];
-  // else
-  //   mult1 = _n_gas;
-  //
-  // if (isCoupledScalar("w"))
-  //   mult2 = _w[_i];
-  // else
-  //   mult2 = _n_gas;
-  //
-  // if (isCoupledScalar("v") && isCoupledScalar("w"))
-  // {
-  //   if (!_v_eq_u && !_w_eq_u)
-  //   {
-  //     if (_v_var != _w_var)
-  //     {
-  //       if (jvar == _v_var)
-  //         return -_stoichiometric_coeff * _data.reaction_coefficient() * mult2;
-  //       else if (jvar == _w_var)
-  //         return -_stoichiometric_coeff * _data.reaction_coefficient() * mult1;
-  //       else
-  //         return 0.0;
-  //     }
-  //     else
-  //     {
-  //       if (jvar == _v_var)
-  //         return -_stoichiometric_coeff * _data.reaction_coefficient() * 2.0 * mult1;
-  //       else
-  //         return 0.0;
-  //     }
-  //   }
-  //   else
-  //     return 0.0;
-  // }
-  // else if (isCoupledScalar("v") && !isCoupledScalar("w"))
-  // {
-  //   if (jvar == _v_var)
-  //   {
-  //     return -_stoichiometric_coeff * _data.reaction_coefficient() * mult2;
-  //   }
-  //   else
-  //     return 0.0;
-  // }
-  // else if (!isCoupledScalar("v") && isCoupledScalar("w"))
-  // {
-  //   if (jvar == _w_var)
-  //     return -_stoichiometric_coeff * _data.reaction_coefficient() * mult1;
-  //   else
-  //     return 0.0;
-  // }
-  // else
-  //   return 0.0;
-
+  return -_stoichiometric_coeff * _rate_coefficient[_i] * std::exp(_v[_i] + _w[_i]) * power;
 }

--- a/src/scalarkernels/Product3BodyScalar.C
+++ b/src/scalarkernels/Product3BodyScalar.C
@@ -7,19 +7,16 @@ InputParameters
 validParams<Product3BodyScalar>()
 {
   InputParameters params = validParams<ODEKernel>();
-  params.addCoupledVar("v", 0, "Coupled variable 1.");
-  params.addCoupledVar("w", 0, "Coupled variable 2.");
-  params.addCoupledVar("x", 0, "Coupled variable 3.");
+  params.addRequiredCoupledVar("v", "Coupled variable 1.");
+  params.addRequiredCoupledVar("w", "Coupled variable 2.");
+  params.addRequiredCoupledVar("x", "Coupled variable 3.");
   params.addCoupledVar("rate_coefficient", 0, "Coupled reaction coefficient (if equation-based).");
-  params.addRequiredParam<Real>("n_gas", "The gas density.");
   params.addRequiredParam<Real>("coefficient", "The stoichiometric coefficient.");
-  // params.addRequiredParam<Real>("reaction_coefficient", "The reaction coefficient.");
   params.addParam<bool>("v_eq_u", false, "Whether or not v = u.");
   params.addParam<bool>("w_eq_u", false, "Whether or not w = u.");
   params.addParam<bool>("x_eq_u", false, "Whether or not x = u.");
-  params.addParam<bool>("rate_constant_equation", false, "True if rate constant is provided by equation.");
-  // params.addRequiredParam<UserObjectName>("rate_provider",
-      // "The name of the UserObject that can provide the rate coefficient.");
+  params.addParam<bool>(
+      "rate_constant_equation", false, "True if rate constant is provided by equation.");
   return params;
 }
 
@@ -32,158 +29,89 @@ Product3BodyScalar::Product3BodyScalar(const InputParameters & parameters)
     _x_var(isCoupledScalar("x") ? coupledScalar("x") : -1),
     _x(coupledScalarValue("x")),
     _rate_coefficient(coupledScalarValue("rate_coefficient")),
-    _n_gas(getParam<Real>("n_gas")),
     _stoichiometric_coeff(getParam<Real>("coefficient")),
-    // _reaction_coeff(getParam<Real>("reaction_coefficient")),
     _v_eq_u(getParam<bool>("v_eq_u")),
     _w_eq_u(getParam<bool>("w_eq_u")),
     _x_eq_u(getParam<bool>("x_eq_u")),
     _rate_constant_equation(getParam<bool>("rate_constant_equation"))
-    // _data(getUserObject<RateCoefficientProvider>("rate_provider"))
 {
 }
 
 Real
 Product3BodyScalar::computeQpResidual()
 {
-  Real mult1, mult2, mult3;
-
-  if (isCoupledScalar("v"))
-    mult1 = _v[_i];
-  else
-    mult1 = _n_gas;
-
-  if (isCoupledScalar("w"))
-    mult2 = _w[_i];
-  else
-    mult2 = _n_gas;
-
-  if (isCoupledScalar("x"))
-    mult3 = _x[_i];
-  else
-    mult3 = _n_gas;
-
-  // if (_rate_constant_equation)
-  return -_stoichiometric_coeff * _rate_coefficient[_i] * mult1 * mult2 * mult3;
-  // else
-    // return -_stoichiometric_coeff * _data.reaction_coefficient() * mult1 * mult2 * mult3;
-  // return -_stoichiometric_coeff * _data.reaction_coefficient() * mult1 * mult2 * mult3;
+  return -_stoichiometric_coeff * _rate_coefficient[_i] * _v[_i] * _w[_i] * _x[_i];
 }
 
 Real
 Product3BodyScalar::computeQpJacobian()
 {
-  Real mult1, mult2, mult3;
   Real power, eq_u_mult, gas_mult;
   Real rate_constant;
   power = 0.0;
   eq_u_mult = 1.0;
   gas_mult = 1.0;
 
-  if (isCoupledScalar("v"))
-    mult1 = _v[_i];
-  else
-    mult1 = _n_gas;
-
-  if (isCoupledScalar("w"))
-    mult2 = _w[_i];
-  else
-    mult2 = _n_gas;
-
-  if (isCoupledScalar("x"))
-    mult3 = _x[_i];
-  else
-    mult3 = _n_gas;
-
   if (isCoupledScalar("v") && _v_eq_u)
   {
     power += 1.0;
-    eq_u_mult = mult1;
+    eq_u_mult = _v[_i];
   }
   else
-    gas_mult *= mult1;
+    gas_mult *= _v[_i];
 
   if (isCoupledScalar("w") && _w_eq_u)
   {
     power += 1.0;
-    eq_u_mult = mult2;
+    eq_u_mult = _w[_i];
   }
   else
-    gas_mult *= mult2;
+    gas_mult *= _w[_i];
 
   if (isCoupledScalar("x") && _x_eq_u)
   {
     power += 1.0;
-    eq_u_mult = mult3;
+    eq_u_mult = _x[_i];
   }
   else
-    gas_mult *= mult3;
+    gas_mult *= _x[_i];
 
-  // if (_rate_constant_equation)
-  rate_constant = _rate_coefficient[_i];
-  // else
-    // rate_constant = _data.reaction_coefficient();
-
-  return -_stoichiometric_coeff * rate_constant * gas_mult *
-    power * std::pow(eq_u_mult, power-1);
-
+  return -_stoichiometric_coeff * _rate_coefficient[_i] * gas_mult * power *
+         std::pow(eq_u_mult, power - 1);
 }
 
 Real
 Product3BodyScalar::computeQpOffDiagJacobian(unsigned int jvar)
 {
-  Real power, mult1, mult2, mult3, deriv_factor, other_factor;
-  Real rate_constant;
+  Real power, deriv_factor, other_factor;
   power = 0;
   other_factor = 1;
   deriv_factor = 1;
-  if (isCoupledScalar("v"))
-    mult1 = _v[_i];
-  else
-    mult1 = _n_gas;
-
-  if (isCoupledScalar("w"))
-    mult2 = _w[_i];
-  else
-    mult2 = _n_gas;
-
-  if (isCoupledScalar("x"))
-    mult3 = _x[_i];
-  else
-    mult3 = _n_gas;
-
 
   if (jvar == _v_var && !_v_eq_u)
   {
     power += 1;
-    deriv_factor = mult1;
+    deriv_factor = _v[_i];
   }
   else
-    other_factor *= mult1;
+    other_factor *= _v[_i];
 
   if (jvar == _w_var && !_w_eq_u)
   {
     power += 1;
-    deriv_factor = mult2;
+    deriv_factor = _w[_i];
   }
   else
-    other_factor *= mult2;
+    other_factor *= _w[_i];
 
   if (jvar == _x_var && !_x_eq_u)
   {
     power += 1;
-    deriv_factor = mult3;
+    deriv_factor = _x[_i];
   }
   else
-    other_factor *= mult3;
+    other_factor *= _x[_i];
 
-  // if (_rate_constant_equation)
-  rate_constant = _rate_coefficient[_i];
-  // else
-  //   rate_constant = _data.reaction_coefficient();
-
-  return -_stoichiometric_coeff * rate_constant * other_factor *
-    power * std::pow(deriv_factor, power-1);
-
-
+  return -_stoichiometric_coeff * _rate_coefficient[_i] * other_factor * power *
+         std::pow(deriv_factor, power - 1);
 }

--- a/src/scalarkernels/Product3BodyScalarLog.C
+++ b/src/scalarkernels/Product3BodyScalarLog.C
@@ -11,15 +11,12 @@ validParams<Product3BodyScalarLog>()
   params.addCoupledVar("w", 0, "Coupled variable 2.");
   params.addCoupledVar("x", 0, "Coupled variable 3.");
   params.addCoupledVar("rate_coefficient", 0, "Coupled reaction coefficient (if equation-based).");
-  params.addRequiredParam<Real>("n_gas", "The gas density.");
   params.addRequiredParam<Real>("coefficient", "The stoichiometric coefficient.");
-  // params.addRequiredParam<Real>("reaction_coefficient", "The reaction coefficient.");
   params.addParam<bool>("v_eq_u", false, "Whether or not v = u.");
   params.addParam<bool>("w_eq_u", false, "Whether or not w = u.");
   params.addParam<bool>("x_eq_u", false, "Whether or not x = u.");
-  params.addParam<bool>("rate_constant_equation", false, "True if rate constant is provided by equation.");
-  // params.addRequiredParam<UserObjectName>("rate_provider",
-      // "The name of the UserObject that can provide the rate coefficient.");
+  params.addParam<bool>(
+      "rate_constant_equation", false, "True if rate constant is provided by equation.");
   return params;
 }
 
@@ -32,9 +29,7 @@ Product3BodyScalarLog::Product3BodyScalarLog(const InputParameters & parameters)
     _x_var(isCoupledScalar("x") ? coupledScalar("x") : 0),
     _x(coupledScalarValue("x")),
     _rate_coefficient(coupledScalarValue("rate_coefficient")),
-    _n_gas(getParam<Real>("n_gas")),
     _stoichiometric_coeff(getParam<Real>("coefficient")),
-    // _reaction_coeff(getParam<Real>("reaction_coefficient")),
     _v_eq_u(getParam<bool>("v_eq_u")),
     _w_eq_u(getParam<bool>("w_eq_u")),
     _x_eq_u(getParam<bool>("x_eq_u")),
@@ -42,201 +37,61 @@ Product3BodyScalarLog::Product3BodyScalarLog(const InputParameters & parameters)
     _w_coupled(isCoupledScalar("w") ? true : false),
     _x_coupled(isCoupledScalar("x") ? true : false),
     _rate_constant_equation(getParam<bool>("rate_constant_equation"))
-    // _data(getUserObject<RateCoefficientProvider>("rate_provider"))
 {
 }
 
 Real
 Product3BodyScalarLog::computeQpResidual()
 {
-  Real mult1, mult2, mult3;
-
-  if (_v_coupled)
-    mult1 = std::exp(_v[_i]);
-  else
-    mult1 = _n_gas;
-
-  if (_w_coupled)
-    mult2 = std::exp(_w[_i]);
-  else
-    mult2 = _n_gas;
-
-  if (_x_coupled)
-    mult3 = std::exp(_x[_i]);
-  else
-    mult3 = _n_gas;
-
-  return -_stoichiometric_coeff * _rate_coefficient[_i] * mult1 * mult2 * mult3;
+  return -_stoichiometric_coeff * _rate_coefficient[_i] * std::exp(_v[_i] + _w[_i] + _x[_i]);
 }
 
 Real
 Product3BodyScalarLog::computeQpJacobian()
 {
-  Real mult1, mult2, mult3;
-  Real power, eq_u_mult, gas_mult;
+  Real power;
 
   power = 0.0;
-  eq_u_mult = 0.0;
-  gas_mult = 0.0;
-
-  if (_v_coupled)
-    mult1 = _v[_i];
-  else
-    mult1 = _n_gas;
-
-  if (_w_coupled)
-    mult2 = _w[_i];
-  else
-    mult2 = _n_gas;
-
-  if (_x_coupled)
-    mult3 = _x[_i];
-  else
-    mult3 = _n_gas;
-
 
   if (_v_coupled && _v_eq_u)
   {
     power += 1;
-    eq_u_mult += mult1;
   }
-  else
-    gas_mult += mult1;
 
   if (_w_coupled && _w_eq_u)
   {
     power += 1;
-    eq_u_mult += mult2;
   }
-  else
-    gas_mult += mult2;
 
   if (_x_coupled && _x_eq_u)
   {
     power += 1;
-    eq_u_mult += mult3;
   }
-  else
-    gas_mult += mult3;
 
-
-  return -_stoichiometric_coeff * _rate_coefficient[_i] * std::exp(gas_mult) * power * std::exp(eq_u_mult);
-  // if (isCoupledScalar("v") && _v_eq_u)
-  // {
-  //   power += 1.0;
-  //   eq_u_mult = mult1;
-  // }
-  // else
-  //   gas_mult *= mult1;
-
-  // if (isCoupledScalar("w") && _w_eq_u)
-  // {
-  //   power += 1.0;
-  //   eq_u_mult = mult2;
-  // }
-  // else
-  //   gas_mult *= mult2;
-  //
-  // if (isCoupledScalar("x") && _x_eq_u)
-  // {
-  //   power += 1.0;
-  //   eq_u_mult = mult3;
-  // }
-  // else
-  //   gas_mult *= mult3;
-  //
-  // // if (_rate_constant_equation)
-  // rate_constant = _rate_coefficient[_i];
-  // // else
-  //   // rate_constant = _data.reaction_coefficient();
-  //
-  // return -_stoichiometric_coeff * rate_constant * gas_mult *
-  //   power * std::pow(eq_u_mult, power-1);
-
+  return -_stoichiometric_coeff * _rate_coefficient[_i] * std::exp(_v[_i] + _w[_i] + _x[_i]) *
+         power;
 }
 
 Real
 Product3BodyScalarLog::computeQpOffDiagJacobian(unsigned int jvar)
 {
-  Real power, mult1, mult2, mult3;
-  Real gas_mult,off_diag;
-  // Real rate_constant;
-  power = 0;
-  gas_mult = 0;
-  off_diag = 0;
-  if (_v_coupled)
-    mult1 = _v[_i];
-  else
-    mult1 = _n_gas;
+  Real power;
 
-  if (_w_coupled)
-    mult2 = _w[_i];
-  else
-    mult2 = _n_gas;
-
-  if (_x_coupled)
-    mult3 = _x[_i];
-  else
-    mult3 = _n_gas;
-
-
-  if (_v_coupled && !_v_eq_u && jvar==_v_var)
+  if (_v_coupled && !_v_eq_u && jvar == _v_var)
   {
     power += 1;
-    off_diag += mult1;
   }
-  else
-    gas_mult += mult1;
 
-  if (_w_coupled && !_w_eq_u && jvar==_w_var)
+  if (_w_coupled && !_w_eq_u && jvar == _w_var)
   {
     power += 1;
-    off_diag += mult2;
   }
-  else
-    gas_mult += mult2;
 
-  if (_x_coupled && !_x_eq_u && jvar==_x_var)
+  if (_x_coupled && !_x_eq_u && jvar == _x_var)
   {
     power += 1;
-    off_diag += mult3;
   }
-  else
-    gas_mult += mult3;
 
-  return -_stoichiometric_coeff * _rate_coefficient[_i] * std::exp(gas_mult) * power * std::exp(off_diag);
-
-  // if (jvar == _v_var && !_v_eq_u)
-  // {
-  //   power += 1;
-  //   deriv_factor = mult1;
-  // }
-  // else
-  //   other_factor *= mult1;
-  //
-  // if (jvar == _w_var && !_w_eq_u)
-  // {
-  //   power += 1;
-  //   deriv_factor = mult2;
-  // }
-  // else
-  //   other_factor *= mult2;
-  //
-  // if (jvar == _x_var && !_x_eq_u)
-  // {
-  //   power += 1;
-  //   deriv_factor = mult3;
-  // }
-  // else
-  //   other_factor *= mult3;
-  //
-  // // if (_rate_constant_equation)
-  // rate_constant = _rate_coefficient[_i];
-  // // else
-  // //   rate_constant = _data.reaction_coefficient();
-  //
-  // return -_stoichiometric_coeff * rate_constant * other_factor *
-  //   power * std::pow(deriv_factor, power-1);
-
-
+  return -_stoichiometric_coeff * _rate_coefficient[_i] * std::exp(_v[_i] + _w[_i] + _x[_i]) *
+         power;
 }

--- a/src/scalarkernels/Reactant1BodyScalar.C
+++ b/src/scalarkernels/Reactant1BodyScalar.C
@@ -8,49 +8,28 @@ validParams<Reactant1BodyScalar>()
 {
   InputParameters params = validParams<ODEKernel>();
   params.addCoupledVar("rate_coefficient", 0, "Coupled reaction coefficient (if equation-based).");
-  params.addRequiredParam<Real>("n_gas", "The gas density.");
   params.addRequiredParam<Real>("coefficient", "The stoichiometric coefficient.");
   params.addParam<bool>(
       "rate_constant_equation", false, "True if rate constant is provided by equation.");
-  // params.addRequiredParam<UserObjectName>("rate_provider",
-  // "The name of the UserObject that can provide the rate coefficient.");
   return params;
 }
 
 Reactant1BodyScalar::Reactant1BodyScalar(const InputParameters & parameters)
   : ODEKernel(parameters),
     _rate_coefficient(coupledScalarValue("rate_coefficient")),
-    _n_gas(getParam<Real>("n_gas")),
     _stoichiometric_coeff(getParam<Real>("coefficient")),
     _rate_constant_equation(getParam<bool>("rate_constant_equation"))
-// _data(getUserObject<RateCoefficientProvider>("rate_provider"))
 {
 }
 
 Real
 Reactant1BodyScalar::computeQpResidual()
 {
-  // if (_rate_constant_equation)
-  return -_stoichiometric_coeff * _rate_coefficient[_i] * _u[_i];
-  // else
-  // return -_stoichiometric_coeff * _data.reaction_coefficient() * _u[_i];
-  // return -_stoichiometric_coeff * _data.reaction_coefficient() * _u[_i];
+    return -_stoichiometric_coeff * _rate_coefficient[_i] * _u[_i];
 }
 
 Real
 Reactant1BodyScalar::computeQpJacobian()
 {
-  Real rate_constant;
-  // if (_rate_constant_equation)
-  rate_constant = _rate_coefficient[_i];
-  // else
-  // rate_constant = _data.reaction_coefficient();
-
-  return -_stoichiometric_coeff * rate_constant;
-}
-
-Real
-Reactant1BodyScalar::computeQpOffDiagJacobian(unsigned int /*jvar*/)
-{
-  return 0.0;
+    return -_stoichiometric_coeff * _rate_coefficient[_i];
 }

--- a/src/scalarkernels/Reactant1BodyScalarLog.C
+++ b/src/scalarkernels/Reactant1BodyScalarLog.C
@@ -8,22 +8,17 @@ validParams<Reactant1BodyScalarLog>()
 {
   InputParameters params = validParams<ODEKernel>();
   params.addCoupledVar("rate_coefficient", 0, "Coupled reaction coefficient (if equation-based).");
-  params.addRequiredParam<Real>("n_gas", "The gas density.");
   params.addRequiredParam<Real>("coefficient", "The stoichiometric coefficient.");
   params.addParam<bool>(
       "rate_constant_equation", false, "True if rate constant is provided by equation.");
-  // params.addRequiredParam<UserObjectName>("rate_provider",
-  // "The name of the UserObject that can provide the rate coefficient.");
   return params;
 }
 
 Reactant1BodyScalarLog::Reactant1BodyScalarLog(const InputParameters & parameters)
   : ODEKernel(parameters),
     _rate_coefficient(coupledScalarValue("rate_coefficient")),
-    _n_gas(getParam<Real>("n_gas")),
     _stoichiometric_coeff(getParam<Real>("coefficient")),
     _rate_constant_equation(getParam<bool>("rate_constant_equation"))
-// _data(getUserObject<RateCoefficientProvider>("rate_provider"))
 {
 }
 
@@ -37,10 +32,4 @@ Real
 Reactant1BodyScalarLog::computeQpJacobian()
 {
   return -_stoichiometric_coeff * _rate_coefficient[_i] * std::exp(_u[_i]);
-}
-
-Real
-Reactant1BodyScalarLog::computeQpOffDiagJacobian(unsigned int /*jvar*/)
-{
-  return 0.0;
 }

--- a/src/scalarkernels/Reactant2BodyScalar.C
+++ b/src/scalarkernels/Reactant2BodyScalar.C
@@ -7,14 +7,12 @@ InputParameters
 validParams<Reactant2BodyScalar>()
 {
   InputParameters params = validParams<ODEKernel>();
-  params.addCoupledVar("v", 0, "Coupled variable 1.");
+  params.addRequiredCoupledVar("v", "Coupled variable 1.");
   params.addCoupledVar("rate_coefficient", 0, "Coupled reaction coefficient (if equation-based).");
-  params.addRequiredParam<Real>("n_gas", "The gas density.");
   params.addRequiredParam<Real>("coefficient", "The stoichiometric coefficient.");
   params.addParam<bool>("v_eq_u", false, "Whether or not u = v.");
-  params.addParam<bool>("rate_constant_equation", false, "True if rate constant is provided by equation.");
-  // params.addRequiredParam<UserObjectName>("rate_provider",
-      // "The name of the UserObject that can provide the rate coefficient.");
+  params.addParam<bool>(
+      "rate_constant_equation", false, "True if rate constant is provided by equation.");
   return params;
 }
 
@@ -23,78 +21,38 @@ Reactant2BodyScalar::Reactant2BodyScalar(const InputParameters & parameters)
     _v_var(isCoupledScalar("v") ? coupledScalar("v") : -1),
     _v(coupledScalarValue("v")),
     _rate_coefficient(coupledScalarValue("rate_coefficient")),
-    _n_gas(getParam<Real>("n_gas")),
     _stoichiometric_coeff(getParam<Real>("coefficient")),
     _v_eq_u(getParam<bool>("v_eq_u")),
     _rate_constant_equation(getParam<bool>("rate_constant_equation"))
-    // _data(getUserObject<RateCoefficientProvider>("rate_provider"))
 {
 }
 
 Real
 Reactant2BodyScalar::computeQpResidual()
 {
-  Real mult1;
-  if (isCoupledScalar("v"))
-    mult1 = _v[_i];
-  else
-    mult1 = _n_gas;
-
-  // if (_rate_constant_equation)
-  return -_stoichiometric_coeff * _rate_coefficient[_i] * _u[_i] * mult1;
-  // else
-    // return -_stoichiometric_coeff * _data.reaction_coefficient() * _u[_i] * mult1;
+  return -_stoichiometric_coeff * _rate_coefficient[_i] * _u[_i] * _v[_i];
 }
 
 Real
 Reactant2BodyScalar::computeQpJacobian()
 {
-  Real mult1;
-  Real rate_constant;
-  if (isCoupledScalar("v"))
-    mult1 = _v[_i];
-  else
-    mult1 = _n_gas;
-
-  // if (_rate_constant_equation)
-  rate_constant = _rate_coefficient[_i];
-  // else
-    // rate_constant = _data.reaction_coefficient();
 
   if (_v_eq_u)
   {
-    return -_stoichiometric_coeff * rate_constant * 2.0 * _u[_i];
+    return -_stoichiometric_coeff * _rate_coefficient[_i] * 2.0 * _u[_i];
   }
   else
-    return -_stoichiometric_coeff * rate_constant * mult1;
-  // if (_v_eq_u)
-  // {
-  //   return -_stoichiometric_coeff * _data.reaction_coefficient() * 2.0 * _u[_i];
-  // }
-  // else
-  //   return -_stoichiometric_coeff * _data.reaction_coefficient() * mult1;
+    return -_stoichiometric_coeff * _rate_coefficient[_i] * _v[_i];
 }
 
 Real
 Reactant2BodyScalar::computeQpOffDiagJacobian(unsigned int jvar)
 {
-  Real rate_constant;
 
-  // if (_rate_constant_equation)
-  rate_constant = _rate_coefficient[_i];
-  // else
-    // rate_constant = _data.reaction_coefficient();
-
-  if (isCoupledScalar("v"))
+  if (jvar == _v_var && !_v_eq_u)
   {
-    if (jvar == _v_var && !_v_eq_u)
-    {
-      return -_stoichiometric_coeff * rate_constant * _u[_i];
-    }
-    else
-      return 0.0;
+    return -_stoichiometric_coeff * _rate_coefficient[_i] * _u[_i];
   }
   else
     return 0.0;
-
 }

--- a/src/scalarkernels/Reactant2BodyScalarLog.C
+++ b/src/scalarkernels/Reactant2BodyScalarLog.C
@@ -7,14 +7,12 @@ InputParameters
 validParams<Reactant2BodyScalarLog>()
 {
   InputParameters params = validParams<ODEKernel>();
-  params.addCoupledVar("v", 0, "Coupled variable 1.");
+  params.addRequiredCoupledVar("v", "Coupled variable 1.");
   params.addCoupledVar("rate_coefficient", 0, "Coupled reaction coefficient (if equation-based).");
-  params.addRequiredParam<Real>("n_gas", "The gas density.");
   params.addRequiredParam<Real>("coefficient", "The stoichiometric coefficient.");
   params.addParam<bool>("v_eq_u", false, "Whether or not u = v.");
-  params.addParam<bool>("rate_constant_equation", false, "True if rate constant is provided by equation.");
-  // params.addRequiredParam<UserObjectName>("rate_provider",
-      // "The name of the UserObject that can provide the rate coefficient.");
+  params.addParam<bool>(
+      "rate_constant_equation", false, "True if rate constant is provided by equation.");
   return params;
 }
 
@@ -23,115 +21,44 @@ Reactant2BodyScalarLog::Reactant2BodyScalarLog(const InputParameters & parameter
     _v_var(isCoupledScalar("v") ? coupledScalar("v") : 0),
     _v(coupledScalarValue("v")),
     _rate_coefficient(coupledScalarValue("rate_coefficient")),
-    _n_gas(getParam<Real>("n_gas")),
     _stoichiometric_coeff(getParam<Real>("coefficient")),
     _v_eq_u(getParam<bool>("v_eq_u")),
     _v_coupled(isCoupledScalar("v") ? true : false),
     _rate_constant_equation(getParam<bool>("rate_constant_equation"))
-    // _data(getUserObject<RateCoefficientProvider>("rate_provider"))
 {
 }
 
 Real
 Reactant2BodyScalarLog::computeQpResidual()
 {
-  Real mult1;
-  if (_v_coupled)
-    mult1 = _v[_i];
-  else
-    mult1 = _n_gas;
-
-  // if (_rate_constant_equation)
-  // return -_stoichiometric_coeff * _rate_coefficient[_i] * std::exp(_u[_i]) * std::exp(mult1);
-
-  return -_stoichiometric_coeff * _rate_coefficient[_i] * std::exp(_u[_i] + mult1);
-  // else
-    // return -_stoichiometric_coeff * _data.reaction_coefficient() * _u[_i] * mult1;
+  return -_stoichiometric_coeff * _rate_coefficient[_i] * std::exp(_u[_i] + _v[_i]);
 }
 
 Real
 Reactant2BodyScalarLog::computeQpJacobian()
 {
-  Real mult1,power,u_mult,gas_mult;
-  // Real rate_constant;
-  if (_v_coupled)
-    mult1 = _v[_i];
-  else
-    mult1 = _n_gas;
+  Real power;
 
-  u_mult = _u[_i];
   power = 1;
-  gas_mult = 0;
   if (_v_coupled && _v_eq_u)
   {
     power += 1;
-    u_mult += mult1;
   }
-  else
-    gas_mult += mult1;
 
-  // return -_stoichiometric_coeff * _rate_coefficient[_i] * std::exp(gas_mult) * power * std::exp(u_mult);
-  return -_stoichiometric_coeff * _rate_coefficient[_i] * power * std::exp(u_mult + gas_mult);
-
-  // if (_rate_constant_equation)
-  // rate_constant = _rate_coefficient[_i];
-  // else
-    // rate_constant = _data.reaction_coefficient();
-
-  // if (_v_eq_u)
-  // {
-  //   return -_stoichiometric_coeff * rate_constant * 2.0 * _u[_i];
-  // }
-  // else
-  //   return -_stoichiometric_coeff * rate_constant * mult1;
-  // if (_v_eq_u)
-  // {
-  //   return -_stoichiometric_coeff * _data.reaction_coefficient() * 2.0 * _u[_i];
-  // }
-  // else
-  //   return -_stoichiometric_coeff * _data.reaction_coefficient() * mult1;
+  return -_stoichiometric_coeff * _rate_coefficient[_i] * power * std::exp(_u[_i] + _v[_i]);
 }
 
 Real
 Reactant2BodyScalarLog::computeQpOffDiagJacobian(unsigned int jvar)
 {
-  Real mult1,power,off_diag,gas_mult;
-  // Real rate_constant;
-  if (_v_coupled)
-    mult1 = _v[_i];
-  else
-    mult1 = _n_gas;
-
+  Real power;
 
   power = 0.0;
-  off_diag = 0.0;
-  gas_mult = 0.0;
 
-  if (_v_coupled && !_v_eq_u && jvar==_v_var)
+  if (_v_coupled && !_v_eq_u && jvar == _v_var)
   {
     power += 1;
-    off_diag += mult1;
   }
-  else
-    gas_mult += mult1;
 
-  return -_stoichiometric_coeff * _rate_coefficient[_i] * std::exp(_u[_i]) * std::exp(gas_mult) * power * std::exp(off_diag);
-
-  // if (_rate_constant_equation)
-  // rate_constant = _rate_coefficient[_i];
-  // else
-    // rate_constant = _data.reaction_coefficient();
-  //
-  // if (isCoupledScalar("v"))
-  // {
-  //   if (jvar == _v_var && !_v_eq_u)
-  //   {
-  //     return -_stoichiometric_coeff * rate_constant * _u[_i];
-  //   }
-  //   else
-  //     return 0.0;
-  // }
-  // else
-  //   return 0.0;
-
+  return -_stoichiometric_coeff * _rate_coefficient[_i] * std::exp(_u[_i] + _v[_i]) * power;
 }

--- a/src/scalarkernels/Reactant3BodyScalar.C
+++ b/src/scalarkernels/Reactant3BodyScalar.C
@@ -7,17 +7,14 @@ InputParameters
 validParams<Reactant3BodyScalar>()
 {
   InputParameters params = validParams<ODEKernel>();
-  params.addCoupledVar("v", 0, "Coupled variable 1.");
-  params.addCoupledVar("w", 0, "Coupled variable 2.");
+  params.addRequiredCoupledVar("v", "Coupled variable 1.");
+  params.addRequiredCoupledVar("w", "Coupled variable 2.");
   params.addCoupledVar("rate_coefficient", 0, "Coupled reaction coefficient (if equation-based).");
-  params.addRequiredParam<Real>("n_gas", "The gas density.");
   params.addRequiredParam<Real>("coefficient", "The stoichiometric coefficient.");
-  // params.addRequiredParam<Real>("reaction_coefficient", "The reaction coefficient.");
   params.addParam<bool>("v_eq_u", false, "Whether or not u = v.");
   params.addParam<bool>("w_eq_u", false, "Whether or not u = v.");
-  params.addParam<bool>("rate_constant_equation", false, "True if rate constant is provided by equation.");
-  // params.addRequiredParam<UserObjectName>("rate_provider",
-      // "The name of the UserObject that can provide the rate coefficient.");
+  params.addParam<bool>(
+      "rate_constant_equation", false, "True if rate constant is provided by equation.");
   return params;
 }
 
@@ -28,101 +25,43 @@ Reactant3BodyScalar::Reactant3BodyScalar(const InputParameters & parameters)
     _w_var(isCoupledScalar("w") ? coupledScalar("w") : -1),
     _w(coupledScalarValue("w")),
     _rate_coefficient(coupledScalarValue("rate_coefficient")),
-    _n_gas(getParam<Real>("n_gas")),
     _stoichiometric_coeff(getParam<Real>("coefficient")),
-    // _reaction_coeff(getParam<Real>("reaction_coefficient")),
     _v_eq_u(getParam<bool>("v_eq_u")),
     _w_eq_u(getParam<bool>("w_eq_u")),
     _rate_constant_equation(getParam<bool>("rate_constant_equation"))
-    // _data(getUserObject<RateCoefficientProvider>("rate_provider"))
 {
 }
 
 Real
 Reactant3BodyScalar::computeQpResidual()
 {
-  Real mult1, mult2;
-  if (isCoupledScalar("v"))
-    mult1 = _v[_i];
-  else
-    mult1 = _n_gas;
-
-  if (isCoupledScalar("w"))
-    mult2 = _w[_i];
-  else
-    mult2 = _n_gas;
-
-  // if (_rate_constant_equation)
-  return -_stoichiometric_coeff * _rate_coefficient[_i] * _u[_i] * mult1 * mult2;
-  // else
-    // return -_stoichiometric_coeff * _data.reaction_coefficient() * _u[_i] * mult1 * mult2;
-
-  // return -_stoichiometric_coeff * _reaction_coeff * mult1 * mult2;
-  // return -_stoichiometric_coeff * _data.reaction_coefficient() * _u[_i] * mult1 * mult2;
-  // return -_stoichiometric_coeff * 1e-16 * _n_gas * _n_gas;
+  return -_stoichiometric_coeff * _rate_coefficient[_i] * _u[_i] * _v[_i] * _w[_i];
 }
 
 Real
 Reactant3BodyScalar::computeQpJacobian()
 {
-  Real mult1, mult2;
-  Real rate_constant;
-
-  if (isCoupledScalar("v"))
-    mult1 = _v[_i];
-  else
-    mult1 = _n_gas;
-
-  if (isCoupledScalar("w"))
-    mult2 = _w[_i];
-  else
-    mult2 = _n_gas;
-
-  // if (_rate_constant_equation)
-  rate_constant = _rate_coefficient[_i];
-  // else
-    // rate_constant = _data.reaction_coefficient();
-
   if (_v_eq_u && _w_eq_u)
   {
-    return -_stoichiometric_coeff * rate_constant * 3.0 * std::pow(_u[_i], 2.0);
+    return -_stoichiometric_coeff * _rate_coefficient[_i] * 3.0 * std::pow(_u[_i], 2.0);
   }
   else if (_v_eq_u && !_w_eq_u)
   {
-    return -_stoichiometric_coeff * rate_constant * 2.0 * _u[_i] * mult2;
+    return -_stoichiometric_coeff * _rate_coefficient[_i] * 2.0 * _u[_i] * _w[_i];
   }
   else if (!_v_eq_u && _w_eq_u)
   {
-    return -_stoichiometric_coeff * rate_constant * 2.0 * _u[_i] * mult1;
+    return -_stoichiometric_coeff * _rate_coefficient[_i] * 2.0 * _u[_i] * _v[_i];
   }
   else
   {
-    return -_stoichiometric_coeff * rate_constant * mult1 * mult2;
+    return -_stoichiometric_coeff * _rate_coefficient[_i] * _v[_i] * _w[_i];
   }
-
 }
 
 Real
 Reactant3BodyScalar::computeQpOffDiagJacobian(unsigned int jvar)
 {
-  // return 0;
-  Real mult1,mult2;
-  Real rate_constant;
-  if (isCoupledScalar("v"))
-    mult1 = _v[_i];
-  else
-    mult1 = _n_gas;
-
-  if (isCoupledScalar("w"))
-    mult2 = _w[_i];
-  else
-    mult2 = _n_gas;
-
-  // if (_rate_constant_equation)
-    rate_constant = _rate_coefficient[_i];
-  // else
-    // rate_constant = _data.reaction_coefficient();
-
   if (isCoupledScalar("v") && isCoupledScalar("w"))
   {
     if (!_v_eq_u && !_w_eq_u)
@@ -130,16 +69,16 @@ Reactant3BodyScalar::computeQpOffDiagJacobian(unsigned int jvar)
       if (_v_var != _w_var)
       {
         if (jvar == _v_var)
-          return -_stoichiometric_coeff * rate_constant * _u[_i] * mult2;
+          return -_stoichiometric_coeff * _rate_coefficient[_i] * _u[_i] * _w[_i];
         else if (jvar == _w_var)
-          return -_stoichiometric_coeff * rate_constant * _u[_i] * mult1;
+          return -_stoichiometric_coeff * _rate_coefficient[_i] * _u[_i] * _v[_i];
         else
           return 0.0;
       }
       else
       {
         if (jvar == _v_var)
-          return -_stoichiometric_coeff * rate_constant * _u[_i] * 2.0 * mult1;
+          return -_stoichiometric_coeff * _rate_coefficient[_i] * _u[_i] * 2.0 * _v[_i];
         else
           return 0.0;
       }
@@ -151,7 +90,7 @@ Reactant3BodyScalar::computeQpOffDiagJacobian(unsigned int jvar)
   {
     if (jvar == _v_var && !_v_eq_u)
     {
-      return -_stoichiometric_coeff * rate_constant * _u[_i] * mult2;
+      return -_stoichiometric_coeff * _rate_coefficient[_i] * _u[_i] * _w[_i];
     }
     else
       return 0.0;
@@ -159,11 +98,10 @@ Reactant3BodyScalar::computeQpOffDiagJacobian(unsigned int jvar)
   else if (!isCoupledScalar("v") && isCoupledScalar("w"))
   {
     if (jvar == _w_var && !_w_eq_u)
-      return -_stoichiometric_coeff * rate_constant * _u[_i] * mult1;
+      return -_stoichiometric_coeff * _rate_coefficient[_i] * _u[_i] * _v[_i];
     else
       return 0.0;
   }
   else
     return 0.0;
-
 }

--- a/src/scalarkernels/Reactant3BodyScalarLog.C
+++ b/src/scalarkernels/Reactant3BodyScalarLog.C
@@ -7,17 +7,14 @@ InputParameters
 validParams<Reactant3BodyScalarLog>()
 {
   InputParameters params = validParams<ODEKernel>();
-  params.addCoupledVar("v", 0, "Coupled variable 1.");
-  params.addCoupledVar("w", 0, "Coupled variable 2.");
+  params.addRequiredCoupledVar("v", "Coupled variable 1.");
+  params.addRequiredCoupledVar("w", "Coupled variable 2.");
   params.addCoupledVar("rate_coefficient", 0, "Coupled reaction coefficient (if equation-based).");
-  params.addRequiredParam<Real>("n_gas", "The gas density.");
   params.addRequiredParam<Real>("coefficient", "The stoichiometric coefficient.");
-  // params.addRequiredParam<Real>("reaction_coefficient", "The reaction coefficient.");
   params.addParam<bool>("v_eq_u", false, "Whether or not u = v.");
   params.addParam<bool>("w_eq_u", false, "Whether or not u = v.");
-  params.addParam<bool>("rate_constant_equation", false, "True if rate constant is provided by equation.");
-  // params.addRequiredParam<UserObjectName>("rate_provider",
-      // "The name of the UserObject that can provide the rate coefficient.");
+  params.addParam<bool>(
+      "rate_constant_equation", false, "True if rate constant is provided by equation.");
   return params;
 }
 
@@ -28,193 +25,58 @@ Reactant3BodyScalarLog::Reactant3BodyScalarLog(const InputParameters & parameter
     _w_var(isCoupledScalar("w") ? coupledScalar("w") : 0),
     _w(coupledScalarValue("w")),
     _rate_coefficient(coupledScalarValue("rate_coefficient")),
-    _n_gas(getParam<Real>("n_gas")),
     _stoichiometric_coeff(getParam<Real>("coefficient")),
-    // _reaction_coeff(getParam<Real>("reaction_coefficient")),
     _v_eq_u(getParam<bool>("v_eq_u")),
     _w_eq_u(getParam<bool>("w_eq_u")),
     _v_coupled(isCoupledScalar("v") ? true : false),
     _w_coupled(isCoupledScalar("w") ? true : false),
     _rate_constant_equation(getParam<bool>("rate_constant_equation"))
-    // _data(getUserObject<RateCoefficientProvider>("rate_provider"))
 {
 }
 
 Real
 Reactant3BodyScalarLog::computeQpResidual()
 {
-  Real mult1, mult2;
-  if (_v_coupled)
-    mult1 = std::exp(_v[_i]);
-  else
-    mult1 = _n_gas;
-
-  if (_w_coupled)
-    mult2 = std::exp(_w[_i]);
-  else
-    mult2 = _n_gas;
-
-  // if (_rate_constant_equation)
-  return -_stoichiometric_coeff * _rate_coefficient[_i] * std::exp(_u[_i]) * mult1 * mult2;
-  // else
-    // return -_stoichiometric_coeff * _data.reaction_coefficient() * _u[_i] * mult1 * mult2;
-
-  // return -_stoichiometric_coeff * _reaction_coeff * mult1 * mult2;
-  // return -_stoichiometric_coeff * _data.reaction_coefficient() * _u[_i] * mult1 * mult2;
-  // return -_stoichiometric_coeff * 1e-16 * _n_gas * _n_gas;
+  return -_stoichiometric_coeff * _rate_coefficient[_i] * std::exp(_u[_i] + _v[_i] + _w[_i]);
 }
 
 Real
 Reactant3BodyScalarLog::computeQpJacobian()
 {
-  Real mult1, mult2;
-  Real power, u_mult, gas_mult;
-  Real rate_constant;
-  // power = 0.0;
-  // eq_u_mult = 1.0;
-  // gas_mult = 1.0;
-
-  if (_v_coupled)
-    mult1 = _v[_i];
-  else
-    mult1 = _n_gas;
-
-  if (_w_coupled)
-    mult2 = _w[_i];
-  else
-    mult2 = _n_gas;
-
-  u_mult = _u[_i];
-  // if (_rate_constant_equation)
-  rate_constant = _rate_coefficient[_i];
-  // else
-    // rate_constant = _data.reaction_coefficient();
-
-  // if (_v_eq_u && _w_eq_u)
-  // {
-  //   return -_stoichiometric_coeff * rate_constant * 3.0 * std::pow(_u[_i], 2.0);
-  // }
-  // else if (_v_eq_u && !_w_eq_u)
-  // {
-  //   return -_stoichiometric_coeff * rate_constant * 2.0 * _u[_i] * mult2;
-  // }
-  // else if (!_v_eq_u && _w_eq_u)
-  // {
-  //   return -_stoichiometric_coeff * rate_constant * 2.0 * _u[_i] * mult1;
-  // }
-  // else
-  // {
-  //   return -_stoichiometric_coeff * rate_constant * mult1 * mult2;
-  // }
+  Real power;
 
   power = 1;
-  gas_mult = 0;
   if (_v_coupled && _v_eq_u)
   {
     power += 1;
-    u_mult += mult1;
   }
-  else
-    gas_mult += mult1;
+
   if (_w_coupled && _w_eq_u)
   {
     power += 1;
-    u_mult += mult2;
   }
-  else
-    gas_mult += mult2;
 
-  return -_stoichiometric_coeff * rate_constant * std::exp(gas_mult) * power * std::exp(u_mult);
-
-
+  return -_stoichiometric_coeff * _rate_coefficient[_i] * std::exp(_u[_i] + _v[_i] + _w[_i]) *
+         power;
 }
 
 Real
 Reactant3BodyScalarLog::computeQpOffDiagJacobian(unsigned int jvar)
 {
-  Real mult1,mult2;
-  Real rate_constant,power,off_diag,gas_mult;
-
-  if (_v_coupled)
-    mult1 = _v[_i];
-  else
-    mult1 = _n_gas;
-
-  if (_w_coupled)
-    mult2 = _w[_i];
-  else
-    mult2 = _n_gas;
-
-  // if (_rate_constant_equation)
-  rate_constant = _rate_coefficient[_i];
-  // else
-    // rate_constant = _data.reaction_coefficient();
-
+  Real power;
 
   power = 0.0;
-  off_diag = 0.0;
-  gas_mult = 0.0;
 
-  if (_v_coupled && !_v_eq_u && jvar==_v_var)
+  if (_v_coupled && !_v_eq_u && jvar == _v_var)
   {
     power += 1;
-    off_diag += mult1;
   }
-  else
-    gas_mult += mult1;
 
-  if (_w_coupled && !_w_eq_u && jvar==_w_var)
+  if (_w_coupled && !_w_eq_u && jvar == _w_var)
   {
     power += 1;
-    off_diag += mult2;
   }
-  else
-    gas_mult += mult2;
 
-  return -_stoichiometric_coeff * rate_constant * std::exp(_u[_i]) * std::exp(gas_mult) * power * std::exp(off_diag);
-  // if (isCoupledScalar("v") && isCoupledScalar("w"))
-  // {
-  //   if (!_v_eq_u && !_w_eq_u)
-  //   {
-  //     if (_v_var != _w_var)
-  //     {
-  //       if (jvar == _v_var)
-  //         return -_stoichiometric_coeff * rate_constant * _u[_i] * mult2;
-  //       else if (jvar == _w_var)
-  //         return -_stoichiometric_coeff * rate_constant * _u[_i] * mult1;
-  //       else
-  //         return 0.0;
-  //     }
-  //     else
-  //     {
-  //       if (jvar == _v_var)
-  //         return -_stoichiometric_coeff * rate_constant * _u[_i] * 2.0 * mult1;
-  //       else
-  //         return 0.0;
-  //     }
-  //   }
-  //   else
-  //     return 0.0;
-  // }
-  // else if (isCoupledScalar("v") && !isCoupledScalar("w"))
-  // {
-  //   if (jvar == _v_var && !_v_eq_u)
-  //   {
-  //     return -_stoichiometric_coeff * rate_constant * _u[_i] * mult2;
-  //   }
-  //   else
-  //     return 0.0;
-  // }
-  // else if (!isCoupledScalar("v") && isCoupledScalar("w"))
-  // {
-  //   if (jvar == _w_var && !_w_eq_u)
-  //     return -_stoichiometric_coeff * rate_constant * _u[_i] * mult1;
-  //   else
-  //     return 0.0;
-  // }
-  // else
-  //   return 0.0;
-
-
-
+  return -_stoichiometric_coeff * _rate_coefficient[_i] * std::exp(_u[_i] + _v[_i] + _w[_i]) *
+         power;
 }


### PR DESCRIPTION
Fixes a bug in the log scalar kernel jacobians. Also consolidates all exponential multiplications under a log formulation into a single exp(...) to save computational time since std::exp can be expensive. (e.g. exp(n1) * exp(n2) * exp(n3) is now exp(n1 + n2 + n3))

Adds AuxKernel for computing the sum of species in log form. 