### PR TITLE
Fixing variable name discrepancy, causing test failure

### DIFF
--- a/include/actions/ChemicalReactionsBase.h
+++ b/include/actions/ChemicalReactionsBase.h
@@ -79,7 +79,7 @@ protected:
   std::vector<std::string> _lumped_species;
   std::vector<int> num_particles;
   bool _use_ad;
-  const std::string _name;
+  std::string _name;
   unsigned int _num_eedf_reactions;
   unsigned int _num_function_reactions;
   unsigned int _num_constant_reactions;

--- a/src/actions/AddScalarReactions.C
+++ b/src/actions/AddScalarReactions.C
@@ -129,7 +129,7 @@ AddScalarReactions::act()
       if (_track_rates == true)
       {
         //_problem->addAuxScalarVariable("rate" + std::to_string(i), FIRST);
-        _problem->addAuxVariable("MooseVariableScalar", _name + "_rate" + std::to_string(i), params);
+        _problem->addAuxVariable("MooseVariableScalar", _name + "rate" + std::to_string(i), params);
       }
     }
   }
@@ -225,7 +225,7 @@ AddScalarReactions::act()
           }
           params.set<std::string>("file_location") = getParam<std::string>("file_location");
           params.set<ExecFlagEnum>("execute_on") = "TIMESTEP_BEGIN";
-          _problem->addAuxScalarKernel("DataReadScalar", _name + "_aux_rate" + std::to_string(i), params);
+          _problem->addAuxScalarKernel("DataReadScalar", _name + "aux_rate" + std::to_string(i), params);
         }
       }
       else if (_rate_type[i] == "Equation" && !_superelastic_reaction[i])
@@ -262,7 +262,7 @@ AddScalarReactions::act()
         // params.set<ExecFlagEnum>("execute_on") = "TIMESTEP_BEGIN NONLINEAR";
         params.set<ExecFlagEnum>("execute_on") = "TIMESTEP_BEGIN";
         _problem->addAuxScalarKernel(
-            "ParsedScalarRateCoefficient", _name + "_aux_rate" + std::to_string(i), params);
+            "ParsedScalarRateCoefficient", _name + "aux_rate" + std::to_string(i), params);
       }
       else if (_rate_type[i] == "Constant" && !_superelastic_reaction[i])
       {
@@ -305,7 +305,7 @@ AddScalarReactions::act()
           params.set<Real>("coefficient") = 1; //_reaction_stoichiometric_coeff[i].back();
           params.set<ExecFlagEnum>("execute_on") = "TIMESTEP_BEGIN";
           _problem->addAuxScalarKernel(
-              "ReactionRateOneBodyScalar", _name + "_Calc_Production_Rate" + std::to_string(i), params);
+              "ReactionRateOneBodyScalar", _name + "Calc_Production_Rate" + std::to_string(i), params);
         }
         else if (_reactants[i].size() == 2)
         {
@@ -317,7 +317,7 @@ AddScalarReactions::act()
           params.set<Real>("coefficient") = 1; //_reaction_stoichiometric_coeff[i].back();
           params.set<ExecFlagEnum>("execute_on") = "TIMESTEP_BEGIN";
           _problem->addAuxScalarKernel(
-              "ReactionRateTwoBodyScalar", _name + "_Calc_Production_Rate" + std::to_string(i), params);
+              "ReactionRateTwoBodyScalar", _name + "Calc_Production_Rate" + std::to_string(i), params);
         }
 
         else if (_reactants[i].size() == 3)
@@ -331,7 +331,7 @@ AddScalarReactions::act()
           params.set<Real>("coefficient") = 1; //_reaction_stoichiometric_coeff[i].back();
           params.set<ExecFlagEnum>("execute_on") = "TIMESTEP_BEGIN";
           _problem->addAuxScalarKernel(
-              "ReactionRateThreeBodyScalar", _name + "_Calc_Production_Rate" + std::to_string(i), params);
+              "ReactionRateThreeBodyScalar", _name + "Calc_Production_Rate" + std::to_string(i), params);
         }
       }
     }
@@ -414,7 +414,7 @@ AddScalarReactions::act()
             params.set<Real>("threshold_energy") = energy_sign * _threshold_energy[i];
             params.set<Real>("position_units") = _r_units;
             _problem->addKernel(energy_kernel_name,
-                                _name + "_energy_kernel" + std::to_string(i) + "_" + _reaction[i],
+                                _name + "energy_kernel" + std::to_string(i) + "_" + _reaction[i],
                                 params);
           }
         }
@@ -479,7 +479,7 @@ AddScalarReactions::act()
                     _reactants[i][reactant_indices[k]]};
             }
             _problem->addScalarKernel(reactant_kernel_name,
-                                      _name + "_kernel" + std::to_string(i) + "_" + std::to_string(j) + "_" +
+                                      _name + "kernel" + std::to_string(i) + "_" + std::to_string(j) + "_" +
                                           _reaction[i],
                                       params);
           }

--- a/src/actions/ChemicalReactionsBase.C
+++ b/src/actions/ChemicalReactionsBase.C
@@ -37,7 +37,6 @@ validParams<ChemicalReactionsBase>()
 
   InputParameters params = validParams<AddVariableAction>();
   params.addParam<std::string>("name",
-                               "",
                                "The name of this reaction list. If multiple reaction blocks are "
                                "written, use this to supply a unique name to each one.");
   params.addParam<bool>(
@@ -148,10 +147,16 @@ ChemicalReactionsBase::ChemicalReactionsBase(InputParameters params)
     _use_bolsig(getParam<bool>("use_bolsig")),
     _lumped_species(getParam<std::vector<std::string>>("lumped")),
     _use_ad(getParam<bool>("use_ad")),
-    _name(getParam<std::string>("name")),
+    //_name(getParam<std::string>("name")),
     _mole_factor(getParam<bool>("convert_to_moles")),
     _rate_factor(getParam<Real>("convert_to_meters"))
 {
+  if (isParamValid("name"))
+  {
+    _name += "_";
+  }
+  else
+    _name = "";
   // Multiplies rate constants (constant and parsed function based only!) by N_A to convert to mole
   // rates
   if (_mole_factor)
@@ -313,7 +318,7 @@ ChemicalReactionsBase::ChemicalReactionsBase(InputParameters params)
       _threshold_energy[i] = std::stod(threshold_energy_string[i]);
     }
     _aux_var_name[i] =
-        _name + "_rate_constant" + std::to_string(i); // Stores name of rate coefficients
+        _name + "rate_constant" + std::to_string(i); // Stores name of rate coefficients
     _reaction_coefficient_name[i] = "rate_constant" + std::to_string(i);
     if (rate_coefficient_string[i] == std::string("EEDF"))
     {


### PR DESCRIPTION
A recent PR that allowed multiple blocks of reactions to exist caused tests to fail due to variable names being slightly different ("rate_constant0" became "_rate_constant0"). This PR fixes the issue. 