### PR TITLE
Performance update

### DIFF
--- a/src/actions/ChemicalReactionsBase.C
+++ b/src/actions/ChemicalReactionsBase.C
@@ -453,17 +453,16 @@ ChemicalReactionsBase::ChemicalReactionsBase(InputParameters params)
     }
     // Here we check to see if the rate coefficients need to be modified in any way
     // (Options: convert to moles, convert to m^3/s or m^6/s)
+    Real exp_factor;
+    exp_factor = _reactants[i].size() - 1;
     if (_rate_type[i] == "Equation")
     {
       _rate_equation_string[i] +=
-          "*" +
-          Moose::stringify(
-              N_A * std::pow(_rate_factor, (3 * (_reactants[i].size() - 1))));
+          "*" + Moose::stringify(std::pow(N_A, exp_factor) * std::pow(_rate_factor, (3 * exp_factor)));
     }
     else if (_rate_type[i] == "Constant")
     {
-      _rate_coefficient[i] *=
-          N_A * std::pow(_rate_factor, (3 * (_reactants[i].size() - 1)));
+      _rate_coefficient[i] *= std::pow(N_A, exp_factor) * std::pow(_rate_factor, (3 * exp_factor));
     }
 
     // _reaction_lumped is used as a flag in the add_kernel (or add_scalar_kernel) stage. All lumped

--- a/src/kernels/EEDFEnergyTownsendLog.C
+++ b/src/kernels/EEDFEnergyTownsendLog.C
@@ -56,8 +56,8 @@ EEDFEnergyTownsendLog::~EEDFEnergyTownsendLog() {}
 Real
 EEDFEnergyTownsendLog::computeQpResidual()
 {
-  Real electron_flux_mag = (-_muem[_qp] * -_grad_potential[_qp] * _r_units * std::exp(_em[_qp]) -
-                            _diffem[_qp] * std::exp(_em[_qp]) * _grad_em[_qp] * _r_units)
+  Real electron_flux_mag = (std::exp(_em[_qp]) * (-_muem[_qp] * -_grad_potential[_qp] * _r_units -
+                                                  _diffem[_qp] * _grad_em[_qp] * _r_units))
                                .norm();
   Real iz_term = _alpha[_qp] * std::exp(_target[_qp]) * electron_flux_mag;
 
@@ -73,11 +73,11 @@ EEDFEnergyTownsendLog::computeQpJacobian()
   Real d_diffem_d_mean_en = _d_diffem_d_actual_mean_en[_qp] * d_actual_mean_en_d_mean_en;
 
   RealVectorValue electron_flux =
-      -_muem[_qp] * -_grad_potential[_qp] * _r_units * std::exp(_em[_qp]) -
-      _diffem[_qp] * std::exp(_em[_qp]) * _grad_em[_qp] * _r_units;
+      std::exp(_em[_qp]) *
+      (-_muem[_qp] * -_grad_potential[_qp] * _r_units - _diffem[_qp] * _grad_em[_qp] * _r_units);
   RealVectorValue d_electron_flux_d_mean_en =
-      -d_muem_d_mean_en * -_grad_potential[_qp] * _r_units * std::exp(_em[_qp]) -
-      d_diffem_d_mean_en * std::exp(_em[_qp]) * _grad_em[_qp] * _r_units;
+      std::exp(_em[_qp]) * (-d_muem_d_mean_en * -_grad_potential[_qp] * _r_units -
+                            d_diffem_d_mean_en * _grad_em[_qp] * _r_units);
   Real electron_flux_mag = electron_flux.norm();
   Real d_electron_flux_mag_d_mean_en = electron_flux * d_electron_flux_d_mean_en /
                                        (electron_flux_mag + std::numeric_limits<double>::epsilon());
@@ -96,16 +96,16 @@ EEDFEnergyTownsendLog::computeQpOffDiagJacobian(unsigned int jvar)
   Real d_diffem_d_em = _d_diffem_d_actual_mean_en[_qp] * d_actual_mean_en_d_em;
 
   RealVectorValue electron_flux =
-      -_muem[_qp] * -_grad_potential[_qp] * _r_units * std::exp(_em[_qp]) -
-      _diffem[_qp] * std::exp(_em[_qp]) * _grad_em[_qp] * _r_units;
+      std::exp(_em[_qp]) *
+      (-_muem[_qp] * -_grad_potential[_qp] * _r_units - _diffem[_qp] * _grad_em[_qp] * _r_units);
   RealVectorValue d_electron_flux_d_potential =
       -_muem[_qp] * -_grad_phi[_j][_qp] * _r_units * std::exp(_em[_qp]);
   RealVectorValue d_electron_flux_d_em =
-      -d_muem_d_em * -_grad_potential[_qp] * _r_units * std::exp(_em[_qp]) -
-      _muem[_qp] * -_grad_potential[_qp] * _r_units * std::exp(_em[_qp]) * _phi[_j][_qp] -
-      d_diffem_d_em * std::exp(_em[_qp]) * _grad_em[_qp] * _r_units -
-      _diffem[_qp] * std::exp(_em[_qp]) * _phi[_j][_qp] * _grad_em[_qp] * _r_units -
-      _diffem[_qp] * std::exp(_em[_qp]) * _grad_phi[_j][_qp] * _r_units;
+      std::exp(_em[_qp]) * (-d_muem_d_em * -_grad_potential[_qp] * _r_units -
+                            _muem[_qp] * -_grad_potential[_qp] * _r_units * _phi[_j][_qp] -
+                            d_diffem_d_em * _grad_em[_qp] * _r_units -
+                            _diffem[_qp] * _phi[_j][_qp] * _grad_em[_qp] * _r_units -
+                            _diffem[_qp] * _grad_phi[_j][_qp] * _r_units);
   Real electron_flux_mag = electron_flux.norm();
   Real d_electron_flux_mag_d_potential =
       electron_flux * d_electron_flux_d_potential /

--- a/src/kernels/EEDFReactionTownsendLog.C
+++ b/src/kernels/EEDFReactionTownsendLog.C
@@ -59,8 +59,8 @@ EEDFReactionTownsendLog::~EEDFReactionTownsendLog() {}
 Real
 EEDFReactionTownsendLog::computeQpResidual()
 {
-  Real electron_flux_mag = (-_muem[_qp] * -_grad_potential[_qp] * _r_units * std::exp(_em[_qp]) -
-                            _diffem[_qp] * std::exp(_em[_qp]) * _grad_em[_qp] * _r_units)
+  Real electron_flux_mag = (std::exp(_em[_qp]) * (-_muem[_qp] * -_grad_potential[_qp] * _r_units -
+                                                  _diffem[_qp] * _grad_em[_qp] * _r_units))
                                .norm();
 
   return -_test[_i][_qp] * _alpha[_qp] * std::exp(_target[_qp]) * electron_flux_mag * _coefficient;
@@ -78,14 +78,14 @@ EEDFReactionTownsendLog::computeQpJacobian()
     Real d_diffem_d_em = _d_diffem_d_actual_mean_en[_qp] * actual_mean_en * -_phi[_j][_qp];
 
     RealVectorValue electron_flux =
-        -_muem[_qp] * -_grad_potential[_qp] * _r_units * std::exp(_em[_qp]) -
-        _diffem[_qp] * std::exp(_em[_qp]) * _grad_em[_qp] * _r_units;
+        std::exp(_em[_qp]) *
+        (-_muem[_qp] * -_grad_potential[_qp] * _r_units - _diffem[_qp] * _grad_em[_qp] * _r_units);
     RealVectorValue d_electron_flux_d_em =
-        -d_muem_d_em * -_grad_potential[_qp] * _r_units * std::exp(_em[_qp]) -
-        _muem[_qp] * -_grad_potential[_qp] * _r_units * std::exp(_em[_qp]) * _phi[_j][_qp] -
-        d_diffem_d_em * std::exp(_em[_qp]) * _grad_em[_qp] * _r_units -
-        _diffem[_qp] * std::exp(_em[_qp]) * _phi[_j][_qp] * _grad_em[_qp] * _r_units -
-        _diffem[_qp] * std::exp(_em[_qp]) * _grad_phi[_j][_qp] * _r_units;
+        std::exp(_em[_qp]) * (-d_muem_d_em * -_grad_potential[_qp] * _r_units -
+                              _muem[_qp] * -_grad_potential[_qp] * _r_units * _phi[_j][_qp] -
+                              d_diffem_d_em * _grad_em[_qp] * _r_units -
+                              _diffem[_qp] * _phi[_j][_qp] * _grad_em[_qp] * _r_units -
+                              _diffem[_qp] * _grad_phi[_j][_qp] * _r_units);
     Real electron_flux_mag = electron_flux.norm();
     Real d_electron_flux_mag_d_em = electron_flux * d_electron_flux_d_em /
                                     (electron_flux_mag + std::numeric_limits<double>::epsilon());
@@ -120,19 +120,19 @@ EEDFReactionTownsendLog::computeQpOffDiagJacobian(unsigned int jvar)
   Real d_diffem_d_em = _d_diffem_d_actual_mean_en[_qp] * actual_mean_en * -_phi[_j][_qp];
 
   RealVectorValue electron_flux =
-      -_muem[_qp] * -_grad_potential[_qp] * _r_units * std::exp(_em[_qp]) -
-      _diffem[_qp] * std::exp(_em[_qp]) * _grad_em[_qp] * _r_units;
+      std::exp(_em[_qp]) *
+      (-_muem[_qp] * -_grad_potential[_qp] * _r_units - _diffem[_qp] * _grad_em[_qp] * _r_units);
   RealVectorValue d_electron_flux_d_potential =
       -_muem[_qp] * -_grad_phi[_j][_qp] * _r_units * std::exp(_em[_qp]);
   RealVectorValue d_electron_flux_d_mean_en =
       -d_muem_d_mean_en * -_grad_potential[_qp] * _r_units * std::exp(_em[_qp]) -
       d_diffem_d_mean_en * std::exp(_em[_qp]) * _grad_em[_qp] * _r_units;
   RealVectorValue d_electron_flux_d_em =
-      -d_muem_d_em * -_grad_potential[_qp] * _r_units * std::exp(_em[_qp]) -
-      _muem[_qp] * -_grad_potential[_qp] * _r_units * std::exp(_em[_qp]) * _phi[_j][_qp] -
-      d_diffem_d_em * std::exp(_em[_qp]) * _grad_em[_qp] * _r_units -
-      _diffem[_qp] * std::exp(_em[_qp]) * _phi[_j][_qp] * _grad_em[_qp] * _r_units -
-      _diffem[_qp] * std::exp(_em[_qp]) * _grad_phi[_j][_qp] * _r_units;
+      std::exp(_em[_qp]) * (-d_muem_d_em * -_grad_potential[_qp] * _r_units -
+                            _muem[_qp] * -_grad_potential[_qp] * _r_units * _phi[_j][_qp] -
+                            d_diffem_d_em * _grad_em[_qp] * _r_units -
+                            _diffem[_qp] * _phi[_j][_qp] * _grad_em[_qp] * _r_units -
+                            _diffem[_qp] * _grad_phi[_j][_qp] * _r_units);
   Real electron_flux_mag = electron_flux.norm();
   Real d_electron_flux_mag_d_potential =
       electron_flux * d_electron_flux_d_potential /

--- a/src/kernels/ReactionSecondOrderEnergyLog.C
+++ b/src/kernels/ReactionSecondOrderEnergyLog.C
@@ -14,7 +14,8 @@ validParams<ReactionSecondOrderEnergyLog>()
   params.addRequiredCoupledVar("w", "The second variable that is reacting to create u.");
   params.addRequiredParam<std::string>("reaction", "The full reaction equation.");
   params.addRequiredParam<Real>("coefficient", "The stoichiometric coeffient.");
-  params.addRequiredParam<Real>("threshold_energy", "The change in enthalpy associated with this reaction.");
+  params.addRequiredParam<Real>("threshold_energy",
+                                "The change in enthalpy associated with this reaction.");
   params.addParam<bool>("_v_eq_u", false, "If v == u.");
   params.addParam<bool>("_w_eq_u", false, "If w == u.");
   params.addParam<std::string>(
@@ -45,34 +46,14 @@ ReactionSecondOrderEnergyLog::ReactionSecondOrderEnergyLog(const InputParameters
 Real
 ReactionSecondOrderEnergyLog::computeQpResidual()
 {
-  return -_test[_i][_qp] * _stoichiometric_coeff * _reaction_coeff[_qp] * std::exp(_v[_qp]) *
-         std::exp(_w[_qp]) * _threshold_energy;
+  return -_test[_i][_qp] * _stoichiometric_coeff * _reaction_coeff[_qp] *
+         std::exp(_v[_qp] + _w[_qp]) * _threshold_energy;
 }
 
 Real
 ReactionSecondOrderEnergyLog::computeQpJacobian()
 {
   return 0.0;
-  /*
-  Real power;
-  power = 0.0;
-
-  if (_v_eq_u)
-    power += 1.0;
-
-  if (_w_eq_u)
-    power += 1.0;
-
-  if (!_v_eq_u && !_w_eq_u)
-  {
-    return 0.0;
-  }
-  else
-  {
-    return -_test[_i][_qp] * _stoichiometric_coeff * power * _reaction_coeff[_qp] *
-           std::exp(_v[_qp]) * std::exp(_w[_qp]) * _phi[_j][_qp];
-  }
-  */
 }
 
 Real
@@ -87,6 +68,6 @@ ReactionSecondOrderEnergyLog::computeQpOffDiagJacobian(unsigned int jvar)
   if (!_w_eq_u && jvar == _w_id)
     power += 1;
 
-  return -_test[_i][_qp] * _stoichiometric_coeff * _reaction_coeff[_qp] * std::exp(_v[_qp]) *
-         std::exp(_w[_qp]) * power * _phi[_j][_qp] * _threshold_energy;
+  return -_test[_i][_qp] * _stoichiometric_coeff * _reaction_coeff[_qp] *
+         std::exp(_v[_qp] + _w[_qp]) * power * _phi[_j][_qp] * _threshold_energy;
 }

--- a/src/kernels/ReactionSecondOrderLog.C
+++ b/src/kernels/ReactionSecondOrderLog.C
@@ -43,8 +43,8 @@ ReactionSecondOrderLog::ReactionSecondOrderLog(const InputParameters & parameter
 Real
 ReactionSecondOrderLog::computeQpResidual()
 {
-  return -_test[_i][_qp] * _stoichiometric_coeff * _reaction_coeff[_qp] * std::exp(_v[_qp]) *
-         std::exp(_w[_qp]);
+  return -_test[_i][_qp] * _stoichiometric_coeff * _reaction_coeff[_qp] *
+         std::exp(_v[_qp] + _w[_qp]);
 }
 
 Real
@@ -66,7 +66,7 @@ ReactionSecondOrderLog::computeQpJacobian()
   else
   {
     return -_test[_i][_qp] * _stoichiometric_coeff * power * _reaction_coeff[_qp] *
-           std::exp(_v[_qp]) * std::exp(_w[_qp]) * _phi[_j][_qp];
+           std::exp(_v[_qp] + _w[_qp]) * _phi[_j][_qp];
   }
 }
 
@@ -82,6 +82,6 @@ ReactionSecondOrderLog::computeQpOffDiagJacobian(unsigned int jvar)
   if (!_w_eq_u && jvar == _w_id)
     power += 1;
 
-  return -_test[_i][_qp] * _stoichiometric_coeff * _reaction_coeff[_qp] * std::exp(_v[_qp]) *
-         std::exp(_w[_qp]) * power * _phi[_j][_qp];
+  return -_test[_i][_qp] * _stoichiometric_coeff * _reaction_coeff[_qp] *
+         std::exp(_v[_qp] + _w[_qp]) * power * _phi[_j][_qp];
 }

--- a/src/kernels/ReactionThirdOrderEnergyLog.C
+++ b/src/kernels/ReactionThirdOrderEnergyLog.C
@@ -15,7 +15,8 @@ validParams<ReactionThirdOrderEnergyLog>()
   params.addRequiredCoupledVar("x", "The third variable that is reacting.");
   params.addRequiredParam<std::string>("reaction", "The full reaction equation.");
   params.addRequiredParam<Real>("coefficient", "The stoichiometric coeffient.");
-  params.addRequiredParam<Real>("threshold_energy", "The change in enthalpy associated with this reaction.");
+  params.addRequiredParam<Real>("threshold_energy",
+                                "The change in enthalpy associated with this reaction.");
   params.addParam<bool>("_v_eq_u", false, "If coupled v == u.");
   params.addParam<bool>("_w_eq_u", false, "If coupled w == u.");
   params.addParam<bool>("_x_eq_u", false, "If coupled x == u.");
@@ -50,28 +51,14 @@ ReactionThirdOrderEnergyLog::ReactionThirdOrderEnergyLog(const InputParameters &
 Real
 ReactionThirdOrderEnergyLog::computeQpResidual()
 {
-  return -_test[_i][_qp] * _stoichiometric_coeff * _reaction_coeff[_qp] * std::exp(_v[_qp]) *
-         std::exp(_w[_qp]) * std::exp(_x[_qp]) * _threshold_energy;
+  return -_test[_i][_qp] * _stoichiometric_coeff * _reaction_coeff[_qp] *
+         std::exp(_v[_qp] + _w[_qp] + _x[_qp]) * _threshold_energy;
 }
 
 Real
 ReactionThirdOrderEnergyLog::computeQpJacobian()
 {
   return 0.0;
-  /*
-  Real power;
-
-  power = 0;
-  if (_v_eq_u)
-    power += 1;
-  if (_w_eq_u)
-    power += 1;
-  if (_x_eq_u)
-    power += 1;
-
-  return -_test[_i][_qp] * _stoichiometric_coeff * _reaction_coeff[_qp] * power *
-         std::exp(_v[_qp]) * std::exp(_w[_qp]) * std::exp(_x[_qp]) * _phi[_j][_qp];
-  */
 }
 
 Real
@@ -89,6 +76,6 @@ ReactionThirdOrderEnergyLog::computeQpOffDiagJacobian(unsigned int jvar)
   if (!_x_eq_u && jvar == _x_id)
     power += 1;
 
-  return -_test[_i][_qp] * _stoichiometric_coeff * _reaction_coeff[_qp] * std::exp(_v[_qp]) *
-         std::exp(_w[_qp]) * std::exp(_x[_qp]) * power * _phi[_j][_qp] * _threshold_energy;
+  return -_test[_i][_qp] * _stoichiometric_coeff * _reaction_coeff[_qp] *
+         std::exp(_v[_qp] + _w[_qp] + _x[_qp]) * power * _phi[_j][_qp] * _threshold_energy;
 }

--- a/src/kernels/ReactionThirdOrderLog.C
+++ b/src/kernels/ReactionThirdOrderLog.C
@@ -48,8 +48,8 @@ ReactionThirdOrderLog::ReactionThirdOrderLog(const InputParameters & parameters)
 Real
 ReactionThirdOrderLog::computeQpResidual()
 {
-  return -_test[_i][_qp] * _stoichiometric_coeff * _reaction_coeff[_qp] * std::exp(_v[_qp]) *
-         std::exp(_w[_qp]) * std::exp(_x[_qp]);
+  return -_test[_i][_qp] * _stoichiometric_coeff * _reaction_coeff[_qp] *
+         std::exp(_v[_qp] + _w[_qp] + _x[_qp]);
 }
 
 Real
@@ -66,7 +66,7 @@ ReactionThirdOrderLog::computeQpJacobian()
     power += 1;
 
   return -_test[_i][_qp] * _stoichiometric_coeff * _reaction_coeff[_qp] * power *
-         std::exp(_v[_qp]) * std::exp(_w[_qp]) * std::exp(_x[_qp]) * _phi[_j][_qp];
+         std::exp(_v[_qp] + _w[_qp] + _x[_qp]) * _phi[_j][_qp];
 }
 
 Real
@@ -84,6 +84,6 @@ ReactionThirdOrderLog::computeQpOffDiagJacobian(unsigned int jvar)
   if (!_x_eq_u && jvar == _x_id)
     power += 1;
 
-  return -_test[_i][_qp] * _stoichiometric_coeff * _reaction_coeff[_qp] * std::exp(_v[_qp]) *
-         std::exp(_w[_qp]) * std::exp(_x[_qp]) * power * _phi[_j][_qp];
+  return -_test[_i][_qp] * _stoichiometric_coeff * _reaction_coeff[_qp] *
+         std::exp(_v[_qp] + _w[_qp] + _x[_qp]) * power * _phi[_j][_qp];
 }


### PR DESCRIPTION
Changes include the following: 

1. Reduces number of std::exp() calls in reaction kernels: exp(var1) * exp(var2) becomes exp(var1 + var2). Has a small but noticeable effect on computational time - with a 10 reaction test, 10 timesteps took 64 seconds prior to this change and 60.6 seconds after. This becomes significant when a large number of reactions are considered.

2. Addresses unit conversion bug in Action. Constant and Function rate coefficients may have their units converted automatically from the input file with the "convert_to_moles" and "convert_to_meters"  options, but three body reactions were not converted to molar units properly. This PR fixes the bug.