### PR TITLE
Update for API changes 

### DIFF
--- a/include/auxkernels/ParsedAuxScalar.h
+++ b/include/auxkernels/ParsedAuxScalar.h
@@ -12,7 +12,7 @@ InputParameters validParams<ParsedAuxScalar>();
 /**
  * AuxKernel that evaluates a parsed function expression
  */
-class ParsedAuxScalar : public AuxScalarKernel, public FunctionParserUtils
+class ParsedAuxScalar : public AuxScalarKernel, public FunctionParserUtils<false>
 {
 public:
   ParsedAuxScalar(const InputParameters & parameters);
@@ -28,5 +28,5 @@ protected:
   std::vector<const VariableValue *> _args;
 
   /// function parser object for the resudual and on-diagonal Jacobian
-  ADFunctionPtr _func_F;
+  SymFunctionPtr _func_F;
 };

--- a/include/auxkernels/ParsedScalarRateCoefficient.h
+++ b/include/auxkernels/ParsedScalarRateCoefficient.h
@@ -27,7 +27,7 @@ InputParameters validParams<ParsedScalarRateCoefficient>();
 /**
  * Constant auxiliary value
  */
-class ParsedScalarRateCoefficient : public AuxScalarKernel, public FunctionParserUtils
+class ParsedScalarRateCoefficient : public AuxScalarKernel, public FunctionParserUtils<false>
 {
 public:
   ParsedScalarRateCoefficient(const InputParameters & parameters);
@@ -51,5 +51,5 @@ protected:
   std::vector<std::string> _constant_expressions;
   // const ValueProvider & _data;
 
-  ADFunctionPtr _func_F;
+  SymFunctionPtr _func_F;
 };

--- a/src/auxkernels/ParsedScalarRateCoefficient.C
+++ b/src/auxkernels/ParsedScalarRateCoefficient.C
@@ -21,7 +21,7 @@ InputParameters
 validParams<ParsedScalarRateCoefficient>()
 {
   InputParameters params = validParams<AuxScalarKernel>();
-  params += validParams<FunctionParserUtils>();
+  params += validParams<FunctionParserUtils<false>>();
   params.addClassDescription("Parsed function AuxKernel.");
 
   params.addRequiredCustomTypeParam<std::string>(
@@ -44,7 +44,7 @@ validParams<ParsedScalarRateCoefficient>()
 
 ParsedScalarRateCoefficient::ParsedScalarRateCoefficient(const InputParameters & parameters)
   : AuxScalarKernel(parameters),
-    FunctionParserUtils(parameters),
+    FunctionParserUtils<false>(parameters),
     _function(getParam<std::string>("function")),
     _nargs(coupledScalarComponents("args")),
     _args(_nargs),
@@ -64,7 +64,7 @@ ParsedScalarRateCoefficient::ParsedScalarRateCoefficient(const InputParameters &
   }
 
   // base function object
-  _func_F = ADFunctionPtr(std::make_shared<ADFunction>());
+  _func_F = SymFunctionPtr(std::make_shared<SymFunction>());
 
   // set FParser interneal feature flags
   setParserFeatureFlags(_func_F);


### PR DESCRIPTION
I renamed `ADFunction` to `SymFunction` to avoid confusion with upcoming AD'ified function objects. `FunctionParserUtils` is now a template that takes a bool parameter, choosing between a regular and a dual number version (forward mode AD).

This should probably get merged after https://github.com/idaholab/moose/pull/15331 is in

Closes #57