### PR TITLE
Converting linear interpolation to splines

### DIFF
--- a/include/materials/ADEEDFRateConstantTownsend.h
+++ b/include/materials/ADEEDFRateConstantTownsend.h
@@ -15,8 +15,8 @@
 
 #include "ADMaterial.h"
 /* #include "LinearInterpolation.h" */
-//#include "SplineInterpolation.h"
-#include "LinearInterpolation.h"
+#include "SplineInterpolation.h"
+//#include "LinearInterpolation.h"
 
 class ADEEDFRateConstantTownsend : public ADMaterial
 {
@@ -27,7 +27,7 @@ public:
 protected:
   virtual void computeQpProperties();
 
-  std::unique_ptr<LinearInterpolation> _coefficient_interpolation;
+  SplineInterpolation _coefficient_interpolation;
   
   std::string _coefficient_format;
   ADMaterialProperty<Real> & _townsend_coefficient;

--- a/include/materials/ADZapdosEEDFRateConstant.h
+++ b/include/materials/ADZapdosEEDFRateConstant.h
@@ -15,8 +15,8 @@
 
 #include "ADMaterial.h"
 /* #include "LinearInterpolation.h" */
-//#include "SplineInterpolation.h"
-#include "LinearInterpolation.h"
+#include "SplineInterpolation.h"
+//#include "LinearInterpolation.h"
 
 class ADZapdosEEDFRateConstant : public ADMaterial
 {
@@ -27,7 +27,8 @@ public:
 protected:
   virtual void computeQpProperties();
 
-  std::unique_ptr<LinearInterpolation> _coefficient_interpolation;
+  //std::unique_ptr<LinearInterpolation> _coefficient_interpolation;
+  SplineInterpolation _coefficient_interpolation;
 
   Real _r_units;
   ADMaterialProperty<Real> & _rate_coefficient;

--- a/src/kernels/ADEEDFElasticTownsendLog.C
+++ b/src/kernels/ADEEDFElasticTownsendLog.C
@@ -27,8 +27,7 @@ ADEEDFElasticTownsendLog::validParams()
   return params;
 }
 
-ADEEDFElasticTownsendLog::ADEEDFElasticTownsendLog(
-    const InputParameters & parameters)
+ADEEDFElasticTownsendLog::ADEEDFElasticTownsendLog(const InputParameters & parameters)
   : ADKernel(parameters),
     _r_units(1. / getParam<Real>("position_units")),
     _diffem(getADMaterialProperty<Real>("diffem")),
@@ -47,8 +46,8 @@ ADEEDFElasticTownsendLog::ADEEDFElasticTownsendLog(
 ADReal
 ADEEDFElasticTownsendLog::computeQpResidual()
 {
-  ADReal electron_flux_mag = (-_muem[_qp] * -_grad_potential[_qp] * _r_units * std::exp(_em[_qp]) -
-                              _diffem[_qp] * std::exp(_em[_qp]) * _grad_em[_qp] * _r_units)
+  ADReal electron_flux_mag = (std::exp(_em[_qp]) * (-_muem[_qp] * -_grad_potential[_qp] * _r_units -
+                                                    _diffem[_qp] * _grad_em[_qp] * _r_units))
                                  .norm();
   ADReal Eel = -3.0 * _massem / _massGas[_qp] * 2.0 / 3. * std::exp(_u[_qp] - _em[_qp]);
   ADReal el_term = _alpha[_qp] * std::exp(_target[_qp]) * electron_flux_mag * Eel;

--- a/src/kernels/ADEEDFEnergyTownsendLog.C
+++ b/src/kernels/ADEEDFEnergyTownsendLog.C
@@ -47,8 +47,8 @@ ADEEDFEnergyTownsendLog::ADEEDFEnergyTownsendLog(const InputParameters & paramet
 ADReal
 ADEEDFEnergyTownsendLog::computeQpResidual()
 {
-  _electron_flux_mag = (-_muem[_qp] * -_grad_potential[_qp] * _r_units * std::exp(_em[_qp]) -
-                        _diffem[_qp] * std::exp(_em[_qp]) * _grad_em[_qp] * _r_units)
+  _electron_flux_mag = (std::exp(_em[_qp]) * (-_muem[_qp] * -_grad_potential[_qp] * _r_units -
+                                              _diffem[_qp] * _grad_em[_qp] * _r_units))
                            .norm();
 
   return -_test[_i][_qp] * _alpha[_qp] * std::exp(_target[_qp]) * _electron_flux_mag *

--- a/src/kernels/ADEEDFReactionTownsend.C
+++ b/src/kernels/ADEEDFReactionTownsend.C
@@ -30,8 +30,7 @@ ADEEDFReactionTownsendLog::validParams()
   return params;
 }
 
-ADEEDFReactionTownsendLog::ADEEDFReactionTownsendLog(
-    const InputParameters & parameters)
+ADEEDFReactionTownsendLog::ADEEDFReactionTownsendLog(const InputParameters & parameters)
   : ADKernel(parameters),
     _r_units(1. / getParam<Real>("position_units")),
     _diffem(getADMaterialProperty<Real>("diffem")),
@@ -52,8 +51,8 @@ ADReal
 ADEEDFReactionTownsendLog::computeQpResidual()
 {
   return -_test[_i][_qp] * _alpha[_qp] * std::exp(_target[_qp]) *
-         (-_muem[_qp] * -_grad_potential[_qp] * _r_units * std::exp(_em[_qp]) -
-          _diffem[_qp] * std::exp(_em[_qp]) * _grad_em[_qp] * _r_units)
+         (std::exp(_em[_qp]) * (-_muem[_qp] * -_grad_potential[_qp] * _r_units -
+                                _diffem[_qp] * _grad_em[_qp] * _r_units))
              .norm() *
          _coefficient;
 }

--- a/src/materials/ADEEDFRateConstantTownsend.C
+++ b/src/materials/ADEEDFRateConstantTownsend.C
@@ -68,7 +68,7 @@ ADEEDFRateConstantTownsend::ADEEDFRateConstantTownsend(const InputParameters & p
   else
     mooseError("Unable to open file");
 
-  _coefficient_interpolation = libmesh_make_unique<LinearInterpolation>(val_x, rate_coefficient);
+  _coefficient_interpolation.setData(val_x, rate_coefficient);
 }
 
 void
@@ -76,8 +76,8 @@ ADEEDFRateConstantTownsend::computeQpProperties()
 {
 
   _townsend_coefficient[_qp].value() =
-      _coefficient_interpolation->sample(std::exp(_mean_en[_qp].value() - _em[_qp].value()));
-  _townsend_coefficient[_qp].derivatives() = _coefficient_interpolation->sampleDerivative(std::exp(
+      _coefficient_interpolation.sample(std::exp(_mean_en[_qp].value() - _em[_qp].value()));
+  _townsend_coefficient[_qp].derivatives() = _coefficient_interpolation.sampleDerivative(std::exp(
                                                  _mean_en[_qp].value() - _em[_qp].value())) *
                                              std::exp(_mean_en[_qp].value() - _em[_qp].value()) *
                                              (_mean_en[_qp].derivatives() - _em[_qp].derivatives());

--- a/src/materials/ADZapdosEEDFRateConstant.C
+++ b/src/materials/ADZapdosEEDFRateConstant.C
@@ -56,16 +56,16 @@ ADZapdosEEDFRateConstant::ADZapdosEEDFRateConstant(const InputParameters & param
   else
     mooseError("Unable to open file");
 
-  _coefficient_interpolation = libmesh_make_unique<LinearInterpolation>(val_x, rate_coefficient);
+  _coefficient_interpolation.setData(val_x, rate_coefficient);
 }
 
 void
 ADZapdosEEDFRateConstant::computeQpProperties()
 {
   _rate_coefficient[_qp].value() =
-      _coefficient_interpolation->sample(std::exp(_mean_en[_qp].value() - _em[_qp].value()));
+      _coefficient_interpolation.sample(std::exp(_mean_en[_qp].value() - _em[_qp].value()));
   _rate_coefficient[_qp].derivatives() =
-      _coefficient_interpolation->sample(std::exp(_mean_en[_qp].value() - _em[_qp].value())) *
+      _coefficient_interpolation.sample(std::exp(_mean_en[_qp].value() - _em[_qp].value())) *
       std::exp(_mean_en[_qp].value() - _em[_qp].value()) *
       (_mean_en[_qp].derivatives() - _em[_qp].derivatives());
 


### PR DESCRIPTION
Converts linear interpolation to spline interpolation for automatic differentiation rate coefficients. 

Splines have better convergence properties and smooth derivatives. In addition, linear interpolations will throw a standard library error if the sample is out of range. Standard library errors are not caught by MOOSE and will terminate the program rather than simply cutting the timestep.  