### PR TITLE
Linear interpolations

### DIFF
--- a/include/actions/AddScalarReactions.h
+++ b/include/actions/AddScalarReactions.h
@@ -14,6 +14,7 @@ class AddScalarReactions : public ChemicalReactionsBase
 {
 public:
   AddScalarReactions(InputParameters params);
+  const std::string _interpolation_type;
   // AddScalarReactions(InputParameters params) : ChemicalReactionsBase(params) {};
 
   virtual void act();

--- a/include/auxkernels/ScalarLinearInterpolation.h
+++ b/include/auxkernels/ScalarLinearInterpolation.h
@@ -1,0 +1,39 @@
+/****************************************************************/
+/*               DO NOT MODIFY THIS HEADER                      */
+/* MOOSE - Multiphysics Object Oriented Simulation Environment  */
+/*                                                              */
+/*           (c) 2010 Battelle Energy Alliance, LLC             */
+/*                   ALL RIGHTS RESERVED                        */
+/*                                                              */
+/*          Prepared by Battelle Energy Alliance, LLC           */
+/*            Under Contract No. DE-AC07-05ID14517              */
+/*            With the U. S. Department of Energy               */
+/*                                                              */
+/*            See COPYRIGHT for full restrictions               */
+/****************************************************************/
+
+#pragma once
+
+#include "AuxScalarKernel.h"
+#include "LinearInterpolation.h"
+
+class ScalarLinearInterpolation;
+
+template <>
+InputParameters validParams<ScalarLinearInterpolation>();
+
+class ScalarLinearInterpolation : public AuxScalarKernel
+{
+public:
+  ScalarLinearInterpolation(const InputParameters & parameters);
+
+protected:
+  virtual Real computeValue();
+  LinearInterpolation _coefficient_interpolation;
+  const VariableValue & _sampler_var;
+  Real _sampler_const;
+  std::string _sampling_format;
+  bool _use_time;
+  bool _use_log;
+  Real _scale_factor;
+};

--- a/include/auxkernels/ScalarSplineInterpolation.h
+++ b/include/auxkernels/ScalarSplineInterpolation.h
@@ -16,26 +16,25 @@
 
 #include "AuxScalarKernel.h"
 #include "SplineInterpolation.h"
-#include "LinearInterpolation.h"
 
-class DataReadScalar;
+class ScalarSplineInterpolation;
 
 template <>
-InputParameters validParams<DataReadScalar>();
+InputParameters validParams<ScalarSplineInterpolation>();
 
-class DataReadScalar : public AuxScalarKernel
+class ScalarSplineInterpolation : public AuxScalarKernel
 {
 public:
-  DataReadScalar(const InputParameters & parameters);
+  ScalarSplineInterpolation(const InputParameters & parameters);
 
 protected:
   virtual Real computeValue();
   SplineInterpolation _coefficient_interpolation;
-  // LinearInterpolation _coefficient_interpolation_linear;
   const VariableValue & _sampler_var;
   Real _sampler_const;
   std::string _sampling_format;
   bool _use_time;
   bool _use_log;
+  std::string _interpolation_type;
   Real _scale_factor;
 };

--- a/src/auxkernels/ScalarLinearInterpolation.C
+++ b/src/auxkernels/ScalarLinearInterpolation.C
@@ -12,29 +12,36 @@
 /*            See COPYRIGHT for full restrictions               */
 /****************************************************************/
 
-#include "DataReadScalar.h"
+#include "ScalarLinearInterpolation.h"
 
-registerMooseObject("CraneApp", DataReadScalar);
+registerMooseObject("CraneApp", ScalarLinearInterpolation);
 
 template <>
 InputParameters
-validParams<DataReadScalar>()
+validParams<ScalarLinearInterpolation>()
 {
   InputParameters params = validParams<AuxScalarKernel>();
   params.addCoupledVar("sampler", 0, "The variable with which the data will be sampled.");
   params.addParam<bool>("use_time", false, "Whether or not to sample with time.");
-  params.addParam<bool>("use_log", false, "Whether or not to return the natural logarithm of the sampled data.");
-  params.addParam<Real>("scale_factor", 1.0, "Multiplies the sampled output by a given factor. Convert from m^3 to cm^3, for example.(Optional)");
+  params.addParam<bool>(
+      "use_log", false, "Whether or not to return the natural logarithm of the sampled data.");
+  params.addParam<Real>("scale_factor",
+                        1.0,
+                        "Multiplies the sampled output by a given factor. Convert from m^3 to "
+                        "cm^3, for example.(Optional)");
   params.addParam<Real>("const_sampler", 0, "The value with which the data will be sampled.");
-  params.addParam<FileName>("property_file", "",
-      "The file containing interpolation tables for material properties.");
-  params.addParam<std::string>("file_location", "", "The name of the file that stores the reaction rate tables.");
-  params.addParam<std::string>("sampling_format", "reduced_field",
-    "The format that the rate constant files are in. Options: reduced_field and electron_energy.");
+  params.addParam<FileName>(
+      "property_file", "", "The file containing interpolation tables for material properties.");
+  params.addParam<std::string>(
+      "file_location", "", "The name of the file that stores the reaction rate tables.");
+  params.addParam<std::string>("sampling_format",
+                               "reduced_field",
+                               "The format that the rate constant files are in. Options: "
+                               "reduced_field and electron_energy.");
   return params;
 }
 
-DataReadScalar::DataReadScalar(const InputParameters & parameters)
+ScalarLinearInterpolation::ScalarLinearInterpolation(const InputParameters & parameters)
   : AuxScalarKernel(parameters),
     _sampler_var(coupledScalarValue("sampler")),
     _sampler_const(getParam<Real>("const_sampler")),
@@ -45,7 +52,8 @@ DataReadScalar::DataReadScalar(const InputParameters & parameters)
 {
   std::vector<Real> x_val;
   std::vector<Real> y_val;
-  std::string file_name = getParam<std::string>("file_location") + "/" + getParam<FileName>("property_file");
+  std::string file_name =
+      getParam<std::string>("file_location") + "/" + getParam<FileName>("property_file");
   MooseUtils::checkFileReadable(file_name);
   const char * charPath = file_name.c_str();
   std::ifstream myfile(charPath);
@@ -65,31 +73,38 @@ DataReadScalar::DataReadScalar(const InputParameters & parameters)
     mooseError("Unable to open file");
 
   _coefficient_interpolation.setData(x_val, y_val);
-  // _coefficient_interpolation_linear.setData(x_val, y_val);
 }
 
 Real
-DataReadScalar::computeValue()
+ScalarLinearInterpolation::computeValue()
 {
-  Real val;
-  if (isCoupledScalar("sampler"))
-    val = _coefficient_interpolation.sample(_sampler_var[_i]);
-  else if (!isCoupledScalar("sampler") && _use_time)
-    // val = _coefficient_interpolation_linear.sample(_t);
-    val = _coefficient_interpolation.sample(_t);
-  else
-    val = _coefficient_interpolation.sample(_sampler_const);
+  Real val = 0;
 
-  // Ensure positivity
-  if (val < 0.0)
+  try
   {
-    val = 0.0;
-  }
-  val = val * _scale_factor;
+    if (isCoupledScalar("sampler"))
+      val = _coefficient_interpolation.sample(_sampler_var[_i]);
+    else if (!isCoupledScalar("sampler") && _use_time)
+      // val = _coefficient_interpolation_linear.sample(_t);
+      val = _coefficient_interpolation.sample(_t);
+    else
+      val = _coefficient_interpolation.sample(_sampler_const);
 
-  if (_use_log && val>0)
+    // Ensure positivity
+    if (val < 0.0)
+    {
+      val = 0.0;
+    }
+    val = val * _scale_factor;
+  }
+  catch (const std::exception & err)
+  {
+    MooseException("Linear interpolation out of range! Cutting the timestep...");
+  }
+
+  if (_use_log && val > 0)
     return log(val);
-  else if (_use_log && val<=0)
+  else if (_use_log && val <= 0)
     return 1e-4;
   else
     return val;

--- a/src/auxkernels/ScalarSplineInterpolation.C
+++ b/src/auxkernels/ScalarSplineInterpolation.C
@@ -1,0 +1,103 @@
+/****************************************************************/
+/*               DO NOT MODIFY THIS HEADER                      */
+/* MOOSE - Multiphysics Object Oriented Simulation Environment  */
+/*                                                              */
+/*           (c) 2010 Battelle Energy Alliance, LLC             */
+/*                   ALL RIGHTS RESERVED                        */
+/*                                                              */
+/*          Prepared by Battelle Energy Alliance, LLC           */
+/*            Under Contract No. DE-AC07-05ID14517              */
+/*            With the U. S. Department of Energy               */
+/*                                                              */
+/*            See COPYRIGHT for full restrictions               */
+/****************************************************************/
+
+#include "ScalarSplineInterpolation.h"
+
+registerMooseObject("CraneApp", ScalarSplineInterpolation);
+
+template <>
+InputParameters
+validParams<ScalarSplineInterpolation>()
+{
+  InputParameters params = validParams<AuxScalarKernel>();
+  params.addCoupledVar("sampler", 0, "The variable with which the data will be sampled.");
+  params.addParam<bool>("use_time", false, "Whether or not to sample with time.");
+  params.addParam<bool>(
+      "use_log", false, "Whether or not to return the natural logarithm of the sampled data.");
+  params.addParam<Real>("scale_factor",
+                        1.0,
+                        "Multiplies the sampled output by a given factor. Convert from m^3 to "
+                        "cm^3, for example.(Optional)");
+  params.addParam<Real>("const_sampler", 0, "The value with which the data will be sampled.");
+  params.addParam<FileName>(
+      "property_file", "", "The file containing interpolation tables for material properties.");
+  params.addParam<std::string>(
+      "file_location", "", "The name of the file that stores the reaction rate tables.");
+  params.addParam<std::string>("sampling_format",
+                               "reduced_field",
+                               "The format that the rate constant files are in. Options: "
+                               "reduced_field and electron_energy.");
+  return params;
+}
+
+ScalarSplineInterpolation::ScalarSplineInterpolation(const InputParameters & parameters)
+  : AuxScalarKernel(parameters),
+    _sampler_var(coupledScalarValue("sampler")),
+    _sampler_const(getParam<Real>("const_sampler")),
+    _sampling_format(getParam<std::string>("sampling_format")),
+    _use_time(getParam<bool>("use_time")),
+    _use_log(getParam<bool>("use_log")),
+    _scale_factor(getParam<Real>("scale_factor"))
+{
+  std::vector<Real> x_val;
+  std::vector<Real> y_val;
+  std::string file_name =
+      getParam<std::string>("file_location") + "/" + getParam<FileName>("property_file");
+  MooseUtils::checkFileReadable(file_name);
+  const char * charPath = file_name.c_str();
+  std::ifstream myfile(charPath);
+  Real value;
+
+  if (myfile.is_open())
+  {
+    while (myfile >> value)
+    {
+      x_val.push_back(value);
+      myfile >> value;
+      y_val.push_back(value);
+    }
+    myfile.close();
+  }
+  else
+    mooseError("Unable to open file");
+
+  _coefficient_interpolation.setData(x_val, y_val);
+}
+
+Real
+ScalarSplineInterpolation::computeValue()
+{
+  Real val;
+  if (isCoupledScalar("sampler"))
+    val = _coefficient_interpolation.sample(_sampler_var[_i]);
+  else if (!isCoupledScalar("sampler") && _use_time)
+    // val = _coefficient_interpolation_linear.sample(_t);
+    val = _coefficient_interpolation.sample(_t);
+  else
+    val = _coefficient_interpolation.sample(_sampler_const);
+
+  // Ensure positivity
+  if (val < 0.0)
+  {
+    val = 0.0;
+  }
+  val = val * _scale_factor;
+
+  if (_use_log && val > 0)
+    return log(val);
+  else if (_use_log && val <= 0)
+    return 1e-4;
+  else
+    return val;
+}

--- a/tests/scalar_network/zdplaskin_ex1.i
+++ b/tests/scalar_network/zdplaskin_ex1.i
@@ -48,6 +48,7 @@
   [./ScalarNetwork]
     species = 'e Ar+ Ar'
     file_location = 'Example1'
+    interpolation_type = 'spline'
     reactions = 'e + Ar -> e + e + Ar+          : EEDF
                  e + Ar+ + Ar -> Ar + Ar       : 1e-25'
 
@@ -61,7 +62,6 @@
     initial_condition = 51e-21
   [../]
 []
-
 
 [Executioner]
   type = Transient

--- a/tests/scalar_network/zdplaskin_ex2.i
+++ b/tests/scalar_network/zdplaskin_ex2.i
@@ -67,12 +67,12 @@
   [../]
 []
 
-
 [ChemicalReactions]
   [./ScalarNetwork]
     species = 'e Ar* Ar+ Ar Ar2+'
     reaction_coefficient_format = 'rate'
     file_location = 'Example2'
+    interpolation_type = 'spline'
 
     # These are parameters required equation-based rate coefficients
     equation_constants = 'Tgas J pi'
@@ -96,7 +96,6 @@
                  Ar2+ -> W                      : {1.52*(760/100)*(Tgas/273.16)*(Te/1.5)*((J/0.4)^2 + (pi/0.4)^2)}'
   [../]
 []
-
 
 [AuxVariables]
   [./all_neutral]
@@ -159,7 +158,7 @@
   [../]
 
   [./mobility_calculation]
-    type = DataReadScalar
+    type = ScalarSplineInterpolation
     variable = mobility
     sampler = reduced_field
     property_file = 'Example2/electron_mobility.txt'
@@ -167,7 +166,7 @@
   [../]
 
   [./temperature_calculation]
-    type = DataReadScalar
+    type = ScalarSplineInterpolation
     variable = Te
     sampler = reduced_field
     property_file = 'Example2/electron_temperature.txt'

--- a/tests/scalar_network/zdplaskin_ex3.i
+++ b/tests/scalar_network/zdplaskin_ex3.i
@@ -121,12 +121,12 @@
   [../]
 []
 
-
 [ChemicalReactions]
   [./ScalarNetwork]
     species = 'N N2 N2A N2B N2a1 N2C N+ N2+ N3+ N4+'
     aux_species = 'e'
     file_location = 'Example3'
+    interpolation_type = 'spline'
 
     # These are parameters required equation-based rate coefficients
     equation_variables = 'Te Teff'
@@ -170,7 +170,6 @@
   [../]
 []
 
-
 [AuxVariables]
   [./reduced_field]
     order = FIRST
@@ -195,7 +194,7 @@
 
 [AuxScalarKernels]
   [./field_calculation]
-    type = DataReadScalar
+    type = ScalarSplineInterpolation
     variable = reduced_field
     use_time = true
     property_file = 'Example3/reduced_field.txt'
@@ -203,7 +202,7 @@
   [../]
 
   [./temperature_calculation]
-    type = DataReadScalar
+    type = ScalarSplineInterpolation
     variable = Te
     scale_factor = 1.5e-1
     sampler = reduced_field
@@ -212,7 +211,7 @@
   [../]
 
   [./density_calculation]
-    type = DataReadScalar
+    type = ScalarSplineInterpolation
     variable = e
     use_time = true
     property_file = 'Example3/electron_density.txt'


### PR DESCRIPTION
Replaces the DataReadScalar AuxKernel with two classes: 

1. ScalarLinearInterpolation
2. ScalarSplineInterpolation

so the user may now select which type of interpolation they want. This also required modifying the action to point to the appropriate AuxKernel. An input parameter called "interpolation_type" was added to the action, with accepted inputs of "linear" and "spline". The default option is now set to 'linear'.  

All three tests needed to be modified as well since the "gold" output files were created using splines. (The solutions using linear interpolations vs splines were only different by a factor of 1e-4, but this was enough to throw a test failure.) 

Note that this PR only affects scalar problems. 1D-3D problems  still default to splines.

EDIT: spelling and grammar. That's what I get for typing quickly. 