### PR TITLE
Replacing deprecated kernel names in AddReactions

### DIFF
--- a/include/actions/AddReactions.h
+++ b/include/actions/AddReactions.h
@@ -18,6 +18,19 @@ public:
   virtual void act();
 
 protected:
-  std::string _coefficient_format;
+  virtual void addConstantCoefficient(const unsigned & reaction_num);
+  virtual void addFunctionCoefficient(const unsigned & reaction_num);
+  virtual void addFunctionReaction(const unsigned & reaction_num,
+                                 const unsigned & species_num,
+                                 const std::string & kernel_name);
+  virtual void addConstantReaction(const unsigned & reaction_num,
+                                 const unsigned & species_num,
+                                 const std::string & kernel_name);
+  virtual std::string getReactionKernelName(const unsigned & num_reactants, const bool & is_aux);
+  virtual void addAuxRate(const std::string & aux_kernel_name,
+                          const unsigned & reaction_num);
 
+  std::string _coefficient_format;
+  std::string _log_append;
+  std::vector<std::string> _reactant_names;
 };

--- a/include/auxkernels/ReactionRateFirstOrder.h
+++ b/include/auxkernels/ReactionRateFirstOrder.h
@@ -1,0 +1,37 @@
+/****************************************************************/
+/*               DO NOT MODIFY THIS HEADER                      */
+/* MOOSE - Multiphysics Object Oriented Simulation Environment  */
+/*                                                              */
+/*           (c) 2010 Battelle Energy Alliance, LLC             */
+/*                   ALL RIGHTS RESERVED                        */
+/*                                                              */
+/*          Prepared by Battelle Energy Alliance, LLC           */
+/*            Under Contract No. DE-AC07-05ID14517              */
+/*            With the U. S. Department of Energy               */
+/*                                                              */
+/*            See COPYRIGHT for full restrictions               */
+/****************************************************************/
+
+#pragma once
+
+#include "AuxKernel.h"
+
+class ReactionRateFirstOrder;
+
+template <>
+InputParameters validParams<ReactionRateFirstOrder>();
+
+class ReactionRateFirstOrder : public AuxKernel
+{
+public:
+  ReactionRateFirstOrder(const InputParameters & parameters);
+
+  virtual ~ReactionRateFirstOrder() {}
+  virtual Real computeValue();
+
+protected:
+
+
+  const VariableValue & _v;
+  const MaterialProperty<Real> & _reaction_coeff;
+};

--- a/include/auxkernels/ReactionRateSecondOrder.h
+++ b/include/auxkernels/ReactionRateSecondOrder.h
@@ -1,0 +1,37 @@
+/****************************************************************/
+/*               DO NOT MODIFY THIS HEADER                      */
+/* MOOSE - Multiphysics Object Oriented Simulation Environment  */
+/*                                                              */
+/*           (c) 2010 Battelle Energy Alliance, LLC             */
+/*                   ALL RIGHTS RESERVED                        */
+/*                                                              */
+/*          Prepared by Battelle Energy Alliance, LLC           */
+/*            Under Contract No. DE-AC07-05ID14517              */
+/*            With the U. S. Department of Energy               */
+/*                                                              */
+/*            See COPYRIGHT for full restrictions               */
+/****************************************************************/
+
+#pragma once
+
+#include "AuxKernel.h"
+
+class ReactionRateSecondOrder;
+
+template <>
+InputParameters validParams<ReactionRateSecondOrder>();
+
+class ReactionRateSecondOrder : public AuxKernel
+{
+public:
+  ReactionRateSecondOrder(const InputParameters & parameters);
+
+  virtual ~ReactionRateSecondOrder() {}
+  virtual Real computeValue();
+
+protected:
+  const VariableValue & _v;
+  const VariableValue & _w;
+  const MaterialProperty<Real> & _reaction_coeff;
+};
+

--- a/include/auxkernels/ReactionRateThirdOrder.h
+++ b/include/auxkernels/ReactionRateThirdOrder.h
@@ -1,0 +1,38 @@
+/****************************************************************/
+/*               DO NOT MODIFY THIS HEADER                      */
+/* MOOSE - Multiphysics Object Oriented Simulation Environment  */
+/*                                                              */
+/*           (c) 2010 Battelle Energy Alliance, LLC             */
+/*                   ALL RIGHTS RESERVED                        */
+/*                                                              */
+/*          Prepared by Battelle Energy Alliance, LLC           */
+/*            Under Contract No. DE-AC07-05ID14517              */
+/*            With the U. S. Department of Energy               */
+/*                                                              */
+/*            See COPYRIGHT for full restrictions               */
+/****************************************************************/
+
+#pragma once
+
+#include "AuxKernel.h"
+
+class ReactionRateThirdOrder;
+
+template <>
+InputParameters validParams<ReactionRateThirdOrder>();
+
+class ReactionRateThirdOrder : public AuxKernel
+{
+public:
+  ReactionRateThirdOrder(const InputParameters & parameters);
+
+  virtual ~ReactionRateThirdOrder() {}
+  virtual Real computeValue();
+
+protected:
+  const VariableValue & _v;
+  const VariableValue & _w;
+  const VariableValue & _x;
+  const MaterialProperty<Real> & _reaction_coeff;
+};
+

--- a/src/actions/AddReactions.C
+++ b/src/actions/AddReactions.C
@@ -40,10 +40,8 @@ validParams<AddReactions>()
   MooseEnum orders(AddVariableAction::getNonlinearVariableOrders());
 
   InputParameters params = validParams<ChemicalReactionsBase>();
-  params.addParam<std::string>(
-      "reaction_coefficient_format",
-      "rate",
-      "The format of the reaction coefficient. Options: rate or townsend.");
+  params.addParam<std::vector<SubdomainName>>("block",
+                                              "The subdomain that this action applies to.");
   params.addClassDescription(
       "This Action automatically adds the necessary kernels and materials for a reaction network.");
 
@@ -70,20 +68,19 @@ trim(std::string & s)
   return ltrim(rtrim(s));
 }
 
-AddReactions::AddReactions(InputParameters params)
-  : ChemicalReactionsBase(params),
-    _coefficient_format(getParam<std::string>("reaction_coefficient_format"))
+AddReactions::AddReactions(InputParameters params) : ChemicalReactionsBase(params)
 {
-  if (_coefficient_format == "townsend" && !isParamValid("electron_density"))
-    mooseError(
-        "Coefficient format type 'townsend' requires an input parameter 'electron_density'!");
+  if (_use_log)
+    _log_append = "Log";
+  else
+    _log_append = "";
 
-  if (_coefficient_format == "townsend" && !isParamValid("electron_energy"))
-    mooseError("Coefficient format type 'townsend' requires an input parameter 'electron_energy'!");
-  // for (unsigned int i=0; i<_num_reactions; ++i)
-  // {
-  //   if (_)
-  // }
+  // Define reactant names for kernels
+  // (In kernels, coupled variables are typically referred to as "v", "w", "x", etc...)
+  _reactant_names.resize(3);
+  _reactant_names[0] = "v";
+  _reactant_names[1] = "w";
+  _reactant_names[2] = "x";
 }
 
 void
@@ -114,7 +111,35 @@ AddReactions::act()
   {
     for (unsigned int i = 0; i < _num_reactions; ++i)
     {
-      _problem->addAuxVariable(_aux_var_name[i], FIRST);
+      auto var_params = _factory.getValidParams("MooseVariableConstMonomial");
+      //_problem->addAuxVariable(_aux_var_name[i], FIRST);
+      _problem->addAuxVariable("MooseVariableConstMonomial", _aux_var_name[i], var_params);
+    }
+  }
+
+  if (_current_task == "add_aux_kernel")
+  {
+    // This boolean is only for EEDF reactions. It is always set to false for every other reaction
+    // type.
+    if (_track_rates)
+    {
+      std::string kernel_name;
+
+      // For AuxKernels function and constant-based reactions are identical.
+      // They are added separately just by convention.
+      // getKernelName(_num_reactants, is_energy, is_aux)
+      for (unsigned int i = 0; i < _num_function_reactions; ++i)
+      {
+        kernel_name = getReactionKernelName(_reactants[_function_reaction_number[i]].size(), true);
+        addAuxRate(kernel_name, _function_reaction_number[i]);
+      }
+
+      for (unsigned int i = 0; i < _num_constant_reactions; ++i)
+      {
+        kernel_name =
+            getReactionKernelName(_reactants[_constant_reaction_number[i]].size(), true);
+        addAuxRate(kernel_name, _constant_reaction_number[i]);
+      }
     }
   }
 
@@ -122,146 +147,24 @@ AddReactions::act()
   {
     for (unsigned int i = 0; i < _num_reactions; ++i)
     {
-      _reaction_coefficient_name[i] = "alpha_" + _reaction[i];
-      if (_rate_type[i] == "EEDF" && _coefficient_format == "townsend")
+      if (_rate_type[i] == "Constant")
       {
-        // BOLOS and BOLSIG+ both get stored as NAN in _rate_coefficient, as to
-        // rate constants based on an equation (_rate_equation).
-        // Superelastic reactions need to have their constants calculated separately.
-        // Coefficient format chooses which specific material to apply.
-        Real position_units = getParam<Real>("position_units");
-        InputParameters params = _factory.getValidParams("EEDFRateConstantTownsend");
-        params.set<std::string>("reaction") = _reaction[i];
-        params.set<std::string>("file_location") = getParam<std::string>("file_location");
-        params.set<Real>("position_units") = position_units;
-        params.set<std::vector<VariableName>>("em") = {_reactants[i][_electron_index[i]]};
-        params.set<std::vector<VariableName>>("mean_en") =
-            getParam<std::vector<VariableName>>("electron_energy");
-        params.set<std::string>("reaction_coefficient_format") = _coefficient_format;
-        params.set<std::string>("sampling_format") = _sampling_variable;
-
-        // This section determines if the target species is a tracked variable.
-        // If it isn't, the target is assumed to be the background gas (_n_gas).
-        // (This cannot handle gas mixtures yet.)
-        bool target_species_tracked = false;
-        for (unsigned int j = 0; j < _species.size(); ++j)
-        {
-          // Checking for the target species in electron-impact reactions, so
-          // electrons are ignored.
-          // if (getParam<bool>("include_electrons") == true)
-          // {
-          if (_species[j] == getParam<std::string>("electron_density"))
-          {
-            continue;
-          }
-          // }
-
-          for (unsigned int k = 0; k < _reactants[i].size(); ++k)
-          {
-            if (_reactants[i][k] == _species[j])
-            {
-              target_species_tracked = true;
-              target = k;
-              break;
-            }
-          }
-
-          if (target_species_tracked)
-            break;
-        }
-        if (target_species_tracked)
-        {
-          params.set<std::vector<VariableName>>("target_species") = {_reactants[i][target]};
-        }
-        params.set<bool>("elastic_collision") = {_elastic_collision[i]};
-        params.set<FileName>("property_file") = "reaction_" + _reaction[i] + ".txt";
-
-        _problem->addMaterial("EEDFRateConstantTownsend", "reaction_" + std::to_string(i), params);
-      }
-      else if (_rate_type[i] == "EEDF" && _coefficient_format == "rate")
-      {
-        Real position_units = getParam<Real>("position_units");
-        InputParameters params = _factory.getValidParams("EEDFRateConstant");
-        params.set<std::string>("reaction") = _reaction[i];
-        params.set<std::string>("file_location") = getParam<std::string>("file_location");
-        params.set<Real>("position_units") = position_units;
-        params.set<std::vector<VariableName>>("sampler") = {_sampling_variable};
-        params.set<FileName>("property_file") = "reaction_" + _reaction[i] + ".txt";
-        params.set<bool>("elastic_collision") = {_elastic_collision[i]};
-        params.set<std::vector<VariableName>>("em") = {_reactants[i][_electron_index[i]]};
-        _problem->addMaterial("EEDFRateConstant", "reaction_" + std::to_string(i), params);
-      }
-      else if (_rate_type[i] == "Constant")
-      {
-        InputParameters params = _factory.getValidParams("GenericRateConstant");
-        params.set<std::string>("reaction") = _reaction[i];
-        params.set<Real>("reaction_rate_value") = _rate_coefficient[i];
-        _problem->addMaterial("GenericRateConstant", "reaction_" + std::to_string(i), params);
+        addConstantCoefficient(i);
       }
       else if (_rate_type[i] == "Equation")
       {
-        InputParameters params = _factory.getValidParams("DerivativeParsedMaterial");
-        // params.set<std::string>("f_name") = _reaction_coefficient_name[i];
-        params.set<std::string>("f_name") = "k_" + _reaction[i];
-        params.set<std::vector<VariableName>>("args") =
-            getParam<std::vector<VariableName>>("equation_variables");
-        params.set<std::vector<std::string>>("constant_names") =
-            getParam<std::vector<std::string>>("equation_constants");
-        params.set<std::vector<std::string>>("constant_expressions") =
-            getParam<std::vector<std::string>>("equation_values");
-        params.set<std::string>("function") = _rate_equation_string[i];
-        params.set<unsigned int>("derivative_order") = 2;
-        _problem->addMaterial("DerivativeParsedMaterial",
-                              "reaction_" + std::to_string(i) + std::to_string(i),
-                              params);
-        // std::cout << "WARNING: CRANE cannot yet handle equation-based equations." << std::endl;
-        // This should be a mooseError...but I'm using it for testing purposes.
+        /*
+         * THIS WILL NEED TO BE MODIFIED.
+         * ADD COUPLED NONLINEAR VARIABLES THAT NEED
+         * DERIVATIVES. NO AD CAPABILITY YET SO THIS
+         * WILL NEED TO BE DONE MANUALLY.
+         */
+        addFunctionCoefficient(i);
       }
       else if (_superelastic_reaction[i] == true)
       {
-        // first we need to figure out which participants exist, and pass only
-        // those stoichiometric coefficients and names.
-        std::vector<std::string> active_participants;
-
-        for (unsigned int k = 0; k < _reactants[i].size(); ++k)
-        {
-          active_participants.push_back(_reactants[i][k]);
-        }
-        for (unsigned int k = 0; k < _products[i].size(); ++k)
-        {
-          active_participants.push_back(_products[i][k]);
-        }
-        sort(active_participants.begin(), active_participants.end());
-        std::vector<std::string>::iterator it;
-        it = std::unique(active_participants.begin(), active_participants.end());
-        active_participants.resize(std::distance(active_participants.begin(), it));
-
-        // Now we find the correct index to obtain the necessary stoichiometric values
-        std::vector<std::string>::iterator iter;
-        std::vector<Real> active_constants;
-        for (unsigned int k = 0; k < active_participants.size(); ++k)
-        {
-          iter =
-              std::find(_all_participants.begin(), _all_participants.end(), active_participants[k]);
-          active_constants.push_back(
-              _stoichiometric_coeff[i][std::distance(_all_participants.begin(), iter)]);
-        }
-
-        InputParameters params = _factory.getValidParams("SuperelasticReactionRate");
-        params.set<std::string>("reaction") = _reaction[i];
-        params.set<std::string>("original_reaction") = _reaction[_superelastic_index[i]];
-        params.set<std::vector<Real>>("stoichiometric_coeff") = active_constants;
-        params.set<std::vector<std::string>>("participants") = active_participants;
-        params.set<std::string>("file_location") = "PolynomialCoefficients";
-        _problem->addMaterial("SuperelasticReactionRate", "reaction_" + std::to_string(i), params);
-      }
-
-      // Now we check for reactions that include a change of energy.
-      // Will this require  its own material?
-      if (_energy_change[i] == true)
-      {
-        // Gas temperature is almost in place, but not finished yet.
-        std::cout << "WARNING: energy dependence is not yet implemented." << std::endl;
+        mooseError("Superelastic reactions not supported yet!");
+        // addSuperelasticCoefficient(i);
       }
     }
   }
@@ -269,314 +172,197 @@ AddReactions::act()
   // Add appropriate kernels to each reactant and product.
   if (_current_task == "add_kernel")
   {
-    int non_electron_index;
-    int index; // stores index of species in the reactant/product arrays
-    std::vector<std::string>::iterator iter;
-    for (unsigned int i = 0; i < _num_reactions; ++i)
+    // Initialize the kernel name
+    std::string kernel_name;
+
+    /*
+     *
+     * FUNCTION REACTIONS
+     *
+     * (Note that functions will be added as normal kernels, not AD.
+     * No AD functionality exists for parsed materials.)
+     */
+    for (unsigned int i = 0; i < _num_function_reactions; ++i)
     {
-      energy_kernel_name = "EnergyTerm";
-      if (_elastic_collision[i])
-        energy_kernel_name += "Elastic";
-      if (_coefficient_format == "townsend" && _rate_type[i] == "EEDF")
+      for (unsigned int j = 0; j < _species.size(); ++j)
       {
-        energy_kernel_name += "Townsend";
-        product_kernel_name = "ElectronImpactReactionProduct";
-        reactant_kernel_name = "ElectronImpactReactionReactant";
-        if (getParam<bool>("track_electron_energy") == true)
+        kernel_name = getReactionKernelName(_reactants[_function_reaction_number[i]].size(), false);
+        if (_species_count[_function_reaction_number[i]][j] != 0)
         {
-          if (_coefficient_format == "townsend")
-          {
-            product_kernel_name = "ElectronImpactReactionProduct";
-            reactant_kernel_name = "ElectronImpactReactionReactant";
-          }
-        }
-      }
-      // else if (_coefficient_format == "rate")
-      else
-      {
-        energy_kernel_name += "Rate";
-        if (_reactants[i].size() == 1)
-        {
-          product_kernel_name = "ProductFirstOrder";
-          reactant_kernel_name = "ReactantFirstOrder";
-        }
-        else if (_reactants[i].size() == 2)
-        {
-          product_kernel_name = "ProductSecondOrder";
-          reactant_kernel_name = "ReactantSecondOrder";
+          addFunctionReaction(_function_reaction_number[i], j, kernel_name);
         }
         else
-        {
-          product_kernel_name = "ProductThirdOrder";
-          reactant_kernel_name = "ReactantThirdOrder";
-        }
-        if (_use_log)
-        {
-          product_kernel_name += "Log";
-          reactant_kernel_name += "Log";
-        }
+          continue;
       }
+    }
 
-      // if (_energy_change[i] && _rate_type[i] == "EEDF")
-      // {
-      if (_energy_change[i])
+    /*
+     *
+     * CONSTANT REACTIONS
+     *
+     */
+    for (unsigned int i = 0; i < _num_constant_reactions; ++i)
+    {
+      for (unsigned int j = 0; j < _species.size(); ++j)
       {
-        Real energy_sign;
-        for (unsigned int t = 0; t < _energy_variable.size(); ++t)
+        kernel_name = getReactionKernelName(_reactants[_constant_reaction_number[i]].size(), false);
+        if (_species_count[_constant_reaction_number[i]][j] != 0)
         {
-          if (_rate_type[i] == "EEDF")
-          {
-            if (_electron_energy_term[t])
-              energy_sign = 1.0;
-            else
-              energy_sign = -1.0;
-
-            for (unsigned int k = 0; k < _reactants[i].size(); ++k)
-            {
-              if (_reactants[i][k] == getParam<std::string>("electron_density"))
-                continue;
-              else
-                non_electron_index = k;
-            }
-            // Check if value is tracked, and if so, add as coupled variable.
-            find_other =
-                std::find(_species.begin(), _species.end(), _reactants[i][non_electron_index]) !=
-                _species.end();
-            find_aux = std::find(_aux_species.begin(),
-                                 _aux_species.end(),
-                                 _reactants[i][non_electron_index]) != _aux_species.end();
-            if (_elastic_collision[i])
-            {
-              // First we find the correct target species to add (need species mass for elastic
-              // energy change calculation)
-              InputParameters params = _factory.getValidParams(energy_kernel_name);
-              // params.set<NonlinearVariableName>("variable") = _electron_energy[0];
-              params.set<NonlinearVariableName>("variable") = _energy_variable[t];
-              params.set<std::string>("reaction") = _reaction[i];
-              if (_coefficient_format == "townsend")
-                params.set<std::vector<VariableName>>("potential") =
-                    getParam<std::vector<VariableName>>("potential");
-              params.set<std::vector<VariableName>>("electron_species") = {
-                  getParam<std::string>("electron_density")};
-              if (find_other || find_aux)
-                params.set<std::vector<VariableName>>("target_species") = {
-                    _reactants[i][non_electron_index]};
-              params.set<Real>("position_units") = _r_units;
-              params.set<std::vector<SubdomainName>>("block") =
-                  getParam<std::vector<SubdomainName>>("block");
-              _problem->addKernel(energy_kernel_name,
-                                  "elastic_kernel" + std::to_string(i) + "_" + _reaction[i],
-                                  params);
-            }
-            else
-            {
-              InputParameters params = _factory.getValidParams(energy_kernel_name);
-              // params.set<NonlinearVariableName>("variable") = _electron_energy[0];
-              params.set<NonlinearVariableName>("variable") = _energy_variable[t];
-              params.set<std::vector<VariableName>>("em") = {
-                  getParam<std::string>("electron_density")};
-              if (_coefficient_format == "townsend")
-                params.set<std::vector<VariableName>>("potential") =
-                    getParam<std::vector<VariableName>>("potential");
-              // params.set<std::vector<VariableName>>("v") = {"Ar"};
-              params.set<std::string>("reaction") = _reaction[i];
-              params.set<Real>("threshold_energy") = energy_sign * _threshold_energy[i];
-              params.set<Real>("position_units") = _r_units;
-              params.set<std::vector<SubdomainName>>("block") =
-                  getParam<std::vector<SubdomainName>>("block");
-              _problem->addKernel(energy_kernel_name,
-                                  "energy_kernel" + std::to_string(i) + "_" + _reaction[i],
-                                  params);
-            }
-          }
-          else if (_rate_type[i] != "EEDF")
-          {
-            // for (unsigned int m=0; m<_energy_variable.size(); ++m)
-            // {
-            // find_other = std::find(_species.begin(), _species.end(), _reactants[i][v_index]) !=
-            // _species.end(); Coupled variable must be generalized to allow for 3 reactants
-            InputParameters params = _factory.getValidParams(energy_kernel_name);
-            params.set<NonlinearVariableName>("variable") = _energy_variable[t];
-            params.set<Real>("threshold_energy") = energy_sign * _threshold_energy[i];
-            // if (_electron_energy_term[m])
-            //   params.set<Real>("threshold_energy") = _threshold_energy[i];
-            // else
-            //   params.set<Real>("threshold_energy") = -_threshold_energy[i];
-            // Check if each reactant is a tracked species, and add the necessary variable(s)
-            // reactant 1
-            if (std::find(_species.begin(), _species.end(), _reactants[i][0]) != _species.end())
-              params.set<std::vector<VariableName>>("v") = {_reactants[i][0]};
-            // reactant 2
-            if (std::find(_species.begin(), _species.end(), _reactants[i][1]) != _species.end())
-              params.set<std::vector<VariableName>>("w") = {_reactants[i][1]};
-            // params.set<std::vector<VariableName>>("em") = {_reactants[i][0]};
-            // // Find the non-electron reactant
-            // for (unsigned int k=0; k<_reactants[i].size(); ++k)
-            // {
-            //   if (_reactants[i][k] == "em")
-            //     continue;
-            //   else
-            //     non_electron_index = k;
-            // }
-            // // Check if value is tracked, and if so, add as coupled variable.
-            // find_other = std::find(_species.begin(), _species.end(),
-            // _reactants[i][non_electron_index]) != _species.end(); find_aux =
-            // std::find(_aux_species.begin(), _aux_species.end(),
-            // _reactants[i][non_electron_index]) != _aux_species.end(); if (find_other || find_aux)
-            //   params.set<std::vector<VariableName>>("v") = {_reactants[i][non_electron_index]};
-
-            // params.set<std::vector<VariableName>>("v") = {"Ar*"};
-            params.set<std::string>("reaction") = _reaction[i];
-            params.set<Real>("position_units") = _r_units;
-            params.set<std::vector<SubdomainName>>("block") =
-                getParam<std::vector<SubdomainName>>("block");
-            _problem->addKernel(energy_kernel_name,
-                                "energy_kernel" + std::to_string(i) + std::to_string(t),
-                                params);
-            // }
-          }
+          addConstantReaction(_constant_reaction_number[i], j, kernel_name);
         }
+        else
+          continue;
       }
-      for (MooseIndex(_species) j = 0; j < _species.size(); ++j)
-      {
-        iter = std::find(_reactants[i].begin(), _reactants[i].end(), _species[j]);
-        index = std::distance(_reactants[i].begin(), iter);
-
-        if (iter != _reactants[i].end())
-        {
-          // Now we see if the second reactant is a tracked species.
-          // We only treat two-body reactions now. This will need to be changed for three-body
-          // reactions. e.g. 1) find size of reactants array 2) use find() to search other values
-          // inside that size that are not == index 3) same result!
-          reactant_indices.resize(_reactants[i].size());
-          for (unsigned int k = 0; k < _reactants[i].size(); ++k)
-            reactant_indices[k] = k;
-          reactant_indices.erase(reactant_indices.begin() + index);
-          for (unsigned int k = 0; k < reactant_indices.size(); ++k)
-          {
-            find_other =
-                std::find(_species.begin(), _species.end(), _reactants[i][reactant_indices[k]]) !=
-                _species.end();
-
-            find_aux = std::find(_aux_species.begin(),
-                                 _aux_species.end(),
-                                 _reactants[i][reactant_indices[k]]) != _aux_species.end();
-            if (find_other)
-              continue;
-            else
-              reactant_indices.erase(reactant_indices.begin() + k);
-          }
-          v_index = std::abs(index - 1);
-          find_other =
-              std::find(_species.begin(), _species.end(), _reactants[i][v_index]) != _species.end();
-
-          if (_species_count[i][j] < 0)
-          {
-            if (_coefficient_format == "townsend")
-            {
-              InputParameters params = _factory.getValidParams(reactant_kernel_name);
-              // params.set<NonlinearVariableName>("variable") = _reactants[i][index];
-              params.set<NonlinearVariableName>("variable") = _species[j];
-              params.set<std::vector<VariableName>>("mean_en") =
-                  getParam<std::vector<VariableName>>("electron_energy");
-              params.set<std::vector<VariableName>>("potential") =
-                  getParam<std::vector<VariableName>>("potential");
-              params.set<std::vector<VariableName>>("em") = {
-                  getParam<std::string>("electron_density")};
-              params.set<Real>("position_units") = _r_units;
-              params.set<std::string>("reaction") = _reaction[i];
-              // params.set<std::string>("reaction_coefficient_name") =
-              // _reaction_coefficient_name[i];
-              _problem->addKernel(
-                  reactant_kernel_name, "kernel" + std::to_string(j) + "_" + _reaction[i], params);
-            }
-            else if (_coefficient_format == "rate")
-            {
-              InputParameters params = _factory.getValidParams(reactant_kernel_name);
-              params.set<NonlinearVariableName>("variable") = _species[j];
-              params.set<Real>("coefficient") = _species_count[i][j];
-              params.set<std::string>("reaction") = _reaction[i];
-
-              if (find_other)
-              {
-                for (unsigned int k = 0; k < reactant_indices.size(); ++k)
-                  params.set<std::vector<VariableName>>(other_variables[k]) = {
-                      _reactants[i][reactant_indices[k]]};
-                // params.set<std::vector<VariableName>>("v") = {_reactants[i][v_index]};
-              }
-              _problem->addKernel(
-                  reactant_kernel_name, "kernel" + std::to_string(j) + "_" + _reaction[i], params);
-            }
-          }
-        }
-
-        // Now we do the same thing for the products side of the reaction
-        iter = std::find(_products[i].begin(), _products[i].end(), _species[j]);
-        // index = std::distance(_products[i].begin(), iter);
-        // species_v = std::find(_species.begin(), _species.end(), _reactants[i][0]) !=
-        // _species.end(); species_w = std::find(_species.begin(), _species.end(), _reactants[i][1])
-        // != _species.end();
-        include_species.resize(_reactants[i].size());
-        for (unsigned int k = 0; k < _reactants[i].size(); ++k)
-        {
-          include_species[k] =
-              std::find(_species.begin(), _species.end(), _reactants[i][k]) != _species.end();
-          if (!include_species[k])
-            include_species[k] =
-                std::find(_aux_species.begin(), _aux_species.end(), _reactants[i][k]) !=
-                _aux_species.end();
-        }
-        if (iter != _products[i].end())
-        {
-
-          if (_species_count[i][j] > 0)
-          {
-            if (_coefficient_format == "townsend")
-            {
-              InputParameters params = _factory.getValidParams(product_kernel_name);
-              params.set<NonlinearVariableName>("variable") = _species[j];
-              params.set<std::vector<VariableName>>("mean_en") =
-                  getParam<std::vector<VariableName>>("electron_energy");
-              if (_coefficient_format == "townsend")
-                params.set<std::vector<VariableName>>("potential") =
-                    getParam<std::vector<VariableName>>("potential");
-              params.set<std::vector<VariableName>>("em") = {
-                  getParam<std::string>("electron_density")};
-              params.set<Real>("position_units") = _r_units;
-              params.set<std::string>("reaction") = _reaction[i];
-              params.set<std::string>("reaction_coefficient_name") = _reaction_coefficient_name[i];
-              _problem->addKernel(product_kernel_name,
-                                  "kernel_prod" + std::to_string(j) + "_" + _reaction[i],
-                                  params);
-            }
-            else if (_coefficient_format == "rate")
-            {
-              InputParameters params = _factory.getValidParams(product_kernel_name);
-              params.set<NonlinearVariableName>("variable") = _species[j];
-              params.set<std::string>("reaction") = _reaction[i];
-              // This loop includes reactants as long as they are tracked species.
-              // If a species is not tracked, it is treated as a background gas.
-              for (unsigned int k = 0; k < _reactants[i].size(); ++k)
-              {
-                if (include_species[k])
-                {
-                  params.set<std::vector<VariableName>>(other_variables[k]) = {_reactants[i][k]};
-                  if (_species[j] == _reactants[i][k])
-                  {
-                    params.set<bool>("_" + other_variables[k] + "_eq_u") = true;
-                  }
-                }
-              }
-              params.set<Real>("coefficient") = _species_count[i][j];
-              _problem->addKernel(product_kernel_name,
-                                  "kernel_prod" + std::to_string(j) + "_" + _reaction[i],
-                                  params);
-            }
-          }
-        }
-      }
-
-      // To do: add energy kernels here
     }
   }
+}
+
+void
+AddReactions::addConstantCoefficient(const unsigned & reaction_num)
+{
+  InputParameters params = _factory.getValidParams("GenericRateConstant");
+  params.set<std::string>("reaction") = _reaction[reaction_num];
+  params.set<Real>("reaction_rate_value") = _rate_coefficient[reaction_num];
+  params.set<std::vector<SubdomainName>>("block") = getParam<std::vector<SubdomainName>>("block");
+  params.set<std::string>("number") = Moose::stringify(reaction_num);
+  _problem->addMaterial("GenericRateConstant",
+                        "reaction_" + getParam<std::vector<SubdomainName>>("block")[0] + "_" +
+                            std::to_string(reaction_num) + "_" + _name,
+                        params);
+}
+
+void
+AddReactions::addFunctionCoefficient(const unsigned & reaction_num)
+{
+  InputParameters params = _factory.getValidParams("DerivativeParsedMaterial");
+  params.set<std::string>("f_name") =
+      "k" + Moose::stringify(reaction_num) + "_" + _reaction[reaction_num];
+  params.set<std::vector<VariableName>>("args") =
+      getParam<std::vector<VariableName>>("equation_variables");
+  params.set<std::vector<std::string>>("constant_names") =
+      getParam<std::vector<std::string>>("equation_constants");
+  params.set<std::vector<std::string>>("constant_expressions") =
+      getParam<std::vector<std::string>>("equation_values");
+  params.set<std::string>("function") = _rate_equation_string[reaction_num];
+  params.set<unsigned int>("derivative_order") = 1;
+  params.set<std::vector<SubdomainName>>("block") = getParam<std::vector<SubdomainName>>("block");
+  _problem->addMaterial("DerivativeParsedMaterial",
+                        "reaction_" + getParam<std::vector<SubdomainName>>("block")[0] + "_" +
+                            std::to_string(reaction_num) + "_" + _name,
+                        params);
+}
+
+void
+AddReactions::addConstantReaction(const unsigned & reaction_num,
+                                  const unsigned & species_num,
+                                  const std::string & kernel_name)
+{
+  std::string kernel_identifier;
+
+  InputParameters params = _factory.getValidParams(kernel_name);
+  params.set<std::string>("reaction") = _reaction[reaction_num];
+  params.set<std::string>("number") = Moose::stringify(reaction_num);
+  params.set<std::vector<SubdomainName>>("block") = getParam<std::vector<SubdomainName>>("block");
+
+  params.set<NonlinearVariableName>("variable") = _species[species_num];
+  for (unsigned int k = 0; k < _reactants[reaction_num].size(); ++k)
+  {
+    params.set<std::vector<VariableName>>(_reactant_names[k]) = {_reactants[reaction_num][k]};
+    if (_species[species_num] == _reactants[reaction_num][k])
+    {
+      params.set<bool>("_" + _reactant_names[k] + "_eq_u") = true;
+    }
+  }
+  params.set<Real>("coefficient") = _species_count[reaction_num][species_num];
+  kernel_identifier = "kernel_constant_" + getParam<std::vector<SubdomainName>>("block")[0] +
+                      std::to_string(reaction_num) + "_" + std::to_string(species_num);
+
+  params.set<std::vector<SubdomainName>>("block") = getParam<std::vector<SubdomainName>>("block");
+  _problem->addKernel(kernel_name, kernel_identifier + "_" + _name, params);
+}
+
+void
+AddReactions::addFunctionReaction(const unsigned & reaction_num,
+                                  const unsigned & species_num,
+                                  const std::string & kernel_name)
+{
+  // Source and sink terms that are dictated by a parsed function rate coefficient are little tricky
+  // to handle, so they require a separate kernel function. As of the writing of this code no
+  // automatic differentiation capabilities exist for parsed materials, so the jacobians need to be
+  // included manually. Luckily parsed rate coefficients almost always only exist in terms of
+  // electron or gas temperature, but in its current form this still requires computing the jacobian
+  // of the parsed function with respect to AT LEAST electrons and _mean_en.
+  std::string kernel_identifier;
+
+  InputParameters params = _factory.getValidParams(kernel_name);
+  params.set<std::string>("reaction") = _reaction[reaction_num];
+  params.set<std::string>("number") = Moose::stringify(reaction_num);
+  params.set<std::vector<SubdomainName>>("block") = getParam<std::vector<SubdomainName>>("block");
+
+  // define the coupled variables in the function to compute jacobian contribution
+  // params.set<std::vector<VariableName>>("args") =
+  //    getParam<std::vector<VariableName>>("equation_variables");
+
+  // TO DO: (1) INCLUDE VARIABLES FOR JACOBIAN CONTRIBUTION OF RATE COEFFICIENT
+  //        (2) ALLOW FOR BOTH ELECTRON AND GAS TEMPERATURE
+
+  params.set<NonlinearVariableName>("variable") = _species[species_num];
+  for (unsigned int k = 0; k < _reactants[reaction_num].size(); ++k)
+  {
+    params.set<std::vector<VariableName>>(_reactant_names[k]) = {_reactants[reaction_num][k]};
+    if (_species[species_num] == _reactants[reaction_num][k])
+    {
+      params.set<bool>("_" + _reactant_names[k] + "_eq_u") = true;
+    }
+  }
+  params.set<Real>("coefficient") = _species_count[reaction_num][species_num];
+  kernel_identifier = "kernel_function_" + getParam<std::vector<SubdomainName>>("block")[0] +
+                      std::to_string(reaction_num) + "_" + std::to_string(species_num);
+
+  _problem->addKernel(kernel_name, kernel_identifier + "_" + _name, params);
+}
+
+std::string
+AddReactions::getReactionKernelName(const unsigned & num_reactants, const bool & is_aux)
+{
+  /*
+   * This function only gets kernel names for non-eedf kernels.
+   * There are three types of kernels (First-, Second-, and Third-order reactions)
+   * Each has variants for (a) log formulation (b) linear formulation.
+   */
+  std::string name = "Reaction";
+  if (is_aux)
+    name += "Rate";
+
+  if (num_reactants == 1)
+    name += "FirstOrder";
+  if (num_reactants == 2)
+    name += "SecondOrder";
+  if (num_reactants == 3)
+    name += "ThirdOrder";
+
+  return (name + _log_append);
+}
+
+void
+AddReactions::addAuxRate(const std::string & aux_kernel_name,
+                               const unsigned & reaction_num)
+{
+
+  auto params = _factory.getValidParams(aux_kernel_name);
+
+  // Add the reactants. _reactant_names = ["v", "w", "x"], just like for regular kernels
+  for (unsigned int k = 0; k < _reactants[reaction_num].size(); ++k)
+  {
+    params.set<std::vector<VariableName>>(_reactant_names[k]) = {_reactants[reaction_num][k]};
+  }
+  params.set<std::string>("number") = Moose::stringify(reaction_num);
+
+  params.set<std::string>("reaction") = _reaction[reaction_num];
+  //params.set<AuxVariableName>("variable") = {"rate" + std::to_string(reaction_num) + "_" + _name};
+  params.set<AuxVariableName>("variable") = {_aux_var_name[reaction_num]};
+  params.set<std::vector<SubdomainName>>("block") = getParam<std::vector<SubdomainName>>("block");
+  params.set<ExecFlagEnum>("execute_on") = "TIMESTEP_END";
+  _problem->addAuxKernel(
+      aux_kernel_name, "Calc_Reaction_Rate" + std::to_string(reaction_num) + "_" + _name, params);
 }

--- a/src/actions/ChemicalReactionsBase.C
+++ b/src/actions/ChemicalReactionsBase.C
@@ -318,7 +318,7 @@ ChemicalReactionsBase::ChemicalReactionsBase(InputParameters params)
       _threshold_energy[i] = std::stod(threshold_energy_string[i]);
     }
     _aux_var_name[i] =
-        _name + "rate_constant" + std::to_string(i); // Stores name of rate coefficients
+        _name + "reaction_rate" + std::to_string(i); // Stores name of rate coefficients
     _reaction_coefficient_name[i] = "rate_constant" + std::to_string(i);
     if (rate_coefficient_string[i] == std::string("EEDF"))
     {

--- a/src/auxkernels/ReactionRateFirstOrder.C
+++ b/src/auxkernels/ReactionRateFirstOrder.C
@@ -1,0 +1,55 @@
+/****************************************************************/
+/*               DO NOT MODIFY THIS HEADER                      */
+/* MOOSE - Multiphysics Object Oriented Simulation Environment  */
+/*                                                              */
+/*           (c) 2010 Battelle Energy Alliance, LLC             */
+/*                   ALL RIGHTS RESERVED                        */
+/*                                                              */
+/*          Prepared by Battelle Energy Alliance, LLC           */
+/*            Under Contract No. DE-AC07-05ID14517              */
+/*            With the U. S. Department of Energy               */
+/*                                                              */
+/*            See COPYRIGHT for full restrictions               */
+/****************************************************************/
+
+#include "ReactionRateFirstOrder.h"
+
+registerMooseObject("CraneApp", ReactionRateFirstOrder);
+
+template <>
+InputParameters
+validParams<ReactionRateFirstOrder>()
+{
+  InputParameters params = validParams<AuxKernel>();
+
+  params.addCoupledVar("v", "The first variable that is reacting to create u.");
+  params.addRequiredParam<std::string>("reaction", "The full reaction equation.");
+  params.addParam<std::string>(
+      "number",
+      "",
+      "The reaction number. Optional, just for material property naming purposes. If a single "
+      "reaction has multiple different rate coefficients (frequently the case when multiple "
+      "species are lumped together to simplify a reaction network), this will prevent the same "
+      "material property from being declared multiple times.");
+  params.addClassDescription(
+      "Reaction rate for one body collisions. User can pass choice of elastic, excitation, or "
+      "ionization reaction rate coefficients. Automatically added if track_rates set to true in "
+      "the [Reactions] action.");
+
+  return params;
+}
+
+ReactionRateFirstOrder::ReactionRateFirstOrder(const InputParameters & parameters)
+  : AuxKernel(parameters),
+    _v(coupledValue("v")),
+    _reaction_coeff(getMaterialProperty<Real>("k" + getParam<std::string>("number") + "_" +
+                                              getParam<std::string>("reaction")))
+{
+}
+
+Real
+ReactionRateFirstOrder::computeValue()
+{
+
+  return 6.02e23 * _reaction_coeff[_qp] * _v[_qp];
+}

--- a/src/auxkernels/ReactionRateSecondOrder.C
+++ b/src/auxkernels/ReactionRateSecondOrder.C
@@ -1,0 +1,56 @@
+/****************************************************************/
+/*               DO NOT MODIFY THIS HEADER                      */
+/* MOOSE - Multiphysics Object Oriented Simulation Environment  */
+/*                                                              */
+/*           (c) 2010 Battelle Energy Alliance, LLC             */
+/*                   ALL RIGHTS RESERVED                        */
+/*                                                              */
+/*          Prepared by Battelle Energy Alliance, LLC           */
+/*            Under Contract No. DE-AC07-05ID14517              */
+/*            With the U. S. Department of Energy               */
+/*                                                              */
+/*            See COPYRIGHT for full restrictions               */
+/****************************************************************/
+
+#include "ReactionRateSecondOrder.h"
+
+registerMooseObject("CraneApp", ReactionRateSecondOrder);
+
+template <>
+InputParameters
+validParams<ReactionRateSecondOrder>()
+{
+  InputParameters params = validParams<AuxKernel>();
+
+  params.addCoupledVar("v", "The first variable that is reacting to create u.");
+  params.addCoupledVar("w", "The second variable that is reacting to create u.");
+  params.addRequiredParam<std::string>("reaction", "The full reaction equation.");
+  params.addParam<std::string>(
+      "number",
+      "",
+      "The reaction number. Optional, just for material property naming purposes. If a single "
+      "reaction has multiple different rate coefficients (frequently the case when multiple "
+      "species are lumped together to simplify a reaction network), this will prevent the same "
+      "material property from being declared multiple times.");
+  params.addClassDescription(
+      "Reaction rate for two body collisions. User can pass choice of elastic, excitation, or "
+      "ionization reaction rate coefficients. Automatically added if track_rates set to true in "
+      "the [Reactions] action.");
+
+  return params;
+}
+
+ReactionRateSecondOrder::ReactionRateSecondOrder(const InputParameters & parameters)
+  : AuxKernel(parameters),
+    _v(coupledValue("v")),
+    _w(coupledValue("w")),
+    _reaction_coeff(getMaterialProperty<Real>("k" + getParam<std::string>("number") + "_" +
+                                              getParam<std::string>("reaction")))
+{
+}
+
+Real
+ReactionRateSecondOrder::computeValue()
+{
+  return 6.02e23 * _reaction_coeff[_qp] * _v[_qp] * _w[_qp];
+}

--- a/src/auxkernels/ReactionRateThirdOrder.C
+++ b/src/auxkernels/ReactionRateThirdOrder.C
@@ -1,0 +1,59 @@
+/****************************************************************/
+/*               DO NOT MODIFY THIS HEADER                      */
+/* MOOSE - Multiphysics Object Oriented Simulation Environment  */
+/*                                                              */
+/*           (c) 2010 Battelle Energy Alliance, LLC             */
+/*                   ALL RIGHTS RESERVED                        */
+/*                                                              */
+/*          Prepared by Battelle Energy Alliance, LLC           */
+/*            Under Contract No. DE-AC07-05ID14517              */
+/*            With the U. S. Department of Energy               */
+/*                                                              */
+/*            See COPYRIGHT for full restrictions               */
+/****************************************************************/
+
+#include "ReactionRateThirdOrder.h"
+
+registerMooseObject("CraneApp", ReactionRateThirdOrder);
+
+template <>
+InputParameters
+validParams<ReactionRateThirdOrder>()
+{
+  InputParameters params = validParams<AuxKernel>();
+
+  params.addCoupledVar("v", "The first reactant.");
+  params.addCoupledVar("w", "The second reactant.");
+  params.addCoupledVar("x", "The third reactant.");
+  params.addRequiredParam<std::string>("reaction", "The full reaction equation.");
+  params.addParam<std::string>(
+      "number",
+      "",
+      "The reaction number. Optional, just for material property naming purposes. If a single "
+      "reaction has multiple different rate coefficients (frequently the case when multiple "
+      "species are lumped together to simplify a reaction network), this will prevent the same "
+      "material property from being declared multiple times.");
+  params.addClassDescription(
+      "Reaction rate for three body collisions. User can pass choice of elastic, excitation, or "
+      "ionization reaction rate coefficients. Automatically added if track_rates set to true in "
+      "the [Reactions] action.");
+  return params;
+}
+
+ReactionRateThirdOrder::ReactionRateThirdOrder(const InputParameters & parameters)
+  : AuxKernel(parameters),
+
+    _v(coupledValue("v")),
+    _w(coupledValue("w")),
+    _x(coupledValue("x")),
+    _reaction_coeff(getMaterialProperty<Real>("k" + getParam<std::string>("number") + "_" +
+                                              getParam<std::string>("reaction")))
+{
+}
+
+Real
+ReactionRateThirdOrder::computeValue()
+{
+
+  return 6.02e23 * _reaction_coeff[_qp] * _v[_qp] * _w[_qp] * _x[_qp];
+}


### PR DESCRIPTION
This PR fixes a few deprecated kernel names for spatial reaction networks in the AddReactions class. (Note that this only affects reaction networks that are used with Crane itself, not Zapdos.) Also updates the AddReactions class to be more similar to the AddZapdosReactions version. 