### PR TITLE
Fixing AuxScalarVariable naming bug

### DIFF
--- a/include/actions/AddScalarReactions.h
+++ b/include/actions/AddScalarReactions.h
@@ -20,4 +20,5 @@ public:
   virtual void act();
 
 //protected:
+  std::vector<std::string> _aux_scalar_var_name;
 };


### PR DESCRIPTION
Addresses a minor variable name error that caused test failure. Note that this had no effect on the results of any simulations; the names of the auxiliary variables storing the rate coefficient data were simply different between new output files and the older test output files. The numbers were correct, but the tests failed because they were trying to compare variables with different names.

Closes issue #63. 