### PR TITLE
Make scalar variable values const-correct

### DIFF
--- a/include/userobjects/BoltzmannSolverScalar.h
+++ b/include/userobjects/BoltzmannSolverScalar.h
@@ -44,7 +44,7 @@ public:
 protected:
   std::string _file_name;
   std::size_t _nargs;
-  std::vector<VariableValue *> _args;
+  std::vector<const VariableValue *> _args;
   std::vector<std::stringstream> _fractions_string;
   std::string _cross_sections;
   const VariableValue & _reduced_field;


### PR DESCRIPTION
This is required for the passing of Zapdos after the merge of https://github.com/idaholab/moose/pull/17380