### PR TITLE
Add new templates in support of Zapdos AD conversion

### DIFF
--- a/include/kernels/ReactionSecondOrderLog.h
+++ b/include/kernels/ReactionSecondOrderLog.h
@@ -1,45 +1,33 @@
-/****************************************************************/
-/*               DO NOT MODIFY THIS HEADER                      */
-/* MOOSE - Multiphysics Object Oriented Simulation Environment  */
-/*                                                              */
-/*           (c) 2010 Battelle Energy Alliance, LLC             */
-/*                   ALL RIGHTS RESERVED                        */
-/*                                                              */
-/*          Prepared by Battelle Energy Alliance, LLC           */
-/*            Under Contract No. DE-AC07-05ID14517              */
-/*            With the U. S. Department of Energy               */
-/*                                                              */
-/*            See COPYRIGHT for full restrictions               */
-/****************************************************************/
-
 #pragma once
 
-#include "Kernel.h"
+#include "GenericKernel.h"
 
-// Forward Declaration
-class ReactionSecondOrderLog;
-
-template <>
-InputParameters validParams<ReactionSecondOrderLog>();
-
-class ReactionSecondOrderLog : public Kernel
+template <bool is_ad>
+class ReactionSecondOrderLogTempl : public GenericKernel<is_ad>
 {
 public:
-  ReactionSecondOrderLog(const InputParameters & parameters);
+  ReactionSecondOrderLogTempl(const InputParameters & parameters);
+
+  static InputParameters validParams();
 
 protected:
-  virtual Real computeQpResidual();
+  virtual GenericReal<is_ad> computeQpResidual();
   virtual Real computeQpJacobian();
   virtual Real computeQpOffDiagJacobian(unsigned int jvar);
 
-  const VariableValue & _v;
-  const VariableValue & _w;
+  const GenericVariableValue<is_ad> & _v;
+  const GenericVariableValue<is_ad> & _w;
   unsigned int _v_id;
   unsigned int _w_id;
 
   // The reaction coefficient
-  const MaterialProperty<Real> & _reaction_coeff;
+  const GenericMaterialProperty<Real, is_ad> & _reaction_coeff;
   Real _stoichiometric_coeff;
   bool _v_eq_u;
   bool _w_eq_u;
+
+  usingGenericKernelMembers;
 };
+
+typedef ReactionSecondOrderLogTempl<false> ReactionSecondOrderLog;
+typedef ReactionSecondOrderLogTempl<true> ADReactionSecondOrderLog;

--- a/include/kernels/ReactionThirdOrderLog.h
+++ b/include/kernels/ReactionThirdOrderLog.h
@@ -1,40 +1,23 @@
-/****************************************************************/
-/*               DO NOT MODIFY THIS HEADER                      */
-/* MOOSE - Multiphysics Object Oriented Simulation Environment  */
-/*                                                              */
-/*           (c) 2010 Battelle Energy Alliance, LLC             */
-/*                   ALL RIGHTS RESERVED                        */
-/*                                                              */
-/*          Prepared by Battelle Energy Alliance, LLC           */
-/*            Under Contract No. DE-AC07-05ID14517              */
-/*            With the U. S. Department of Energy               */
-/*                                                              */
-/*            See COPYRIGHT for full restrictions               */
-/****************************************************************/
-
 #pragma once
 
-#include "Kernel.h"
+#include "GenericKernel.h"
 
-// Forward Declaration
-class ReactionThirdOrderLog;
-
-template <>
-InputParameters validParams<ReactionThirdOrderLog>();
-
-class ReactionThirdOrderLog : public Kernel
+template <bool is_ad>
+class ReactionThirdOrderLogTempl : public GenericKernel<is_ad>
 {
 public:
-  ReactionThirdOrderLog(const InputParameters & parameters);
+  ReactionThirdOrderLogTempl(const InputParameters & parameters);
+
+  static InputParameters validParams();
 
 protected:
-  virtual Real computeQpResidual();
+  virtual GenericReal<is_ad> computeQpResidual();
   virtual Real computeQpJacobian();
   virtual Real computeQpOffDiagJacobian(unsigned int jvar);
 
-  const VariableValue & _v;
-  const VariableValue & _w;
-  const VariableValue & _x;
+  const GenericVariableValue<is_ad> & _v;
+  const GenericVariableValue<is_ad> & _w;
+  const GenericVariableValue<is_ad> & _x;
   unsigned int _v_id;
   unsigned int _w_id;
   unsigned int _x_id;
@@ -42,6 +25,11 @@ protected:
   bool _w_eq_u;
   bool _x_eq_u;
 
-  const MaterialProperty<Real> & _reaction_coeff;
+  const GenericMaterialProperty<Real, is_ad> & _reaction_coeff;
   Real _stoichiometric_coeff;
+
+  usingGenericKernelMembers;
 };
+
+typedef ReactionThirdOrderLogTempl<false> ReactionThirdOrderLog;
+typedef ReactionThirdOrderLogTempl<true> ADReactionThirdOrderLog;

--- a/include/materials/GenericRateConstant.h
+++ b/include/materials/GenericRateConstant.h
@@ -1,36 +1,24 @@
-/****************************************************************/
-/*                      DO NOT MODIFY THIS HEADER               */
-/* MOOSE - Multiphysics Object Oriented Simulation Environment  */
-/*                                                              */
-/*              (c) 2010 Battelle Energy Alliance, LLC          */
-/*                      ALL RIGHTS RESERVED                     */
-/*                                                              */
-/*              Prepared by Battelle Energy Alliance, LLC       */
-/*              Under Contract No. DE-AC07-05ID14517            */
-/*              With the U. S. Department of Energy             */
-/*                                                              */
-/*              See COPYRIGHT for full restrictions             */
-/****************************************************************/
 #pragma once
 
 #include "Material.h"
 
-class GenericRateConstant;
-
-template <>
-InputParameters validParams<GenericRateConstant>();
-
-class GenericRateConstant : public Material
+template <bool is_ad>
+class GenericRateConstantTempl : public Material
 {
 public:
-  GenericRateConstant(const InputParameters & parameters);
+  GenericRateConstantTempl(const InputParameters & parameters);
+
+  static InputParameters validParams();
 
 protected:
-  virtual void computeQpProperties();
+  virtual void computeQpProperties() override;
 
-  MaterialProperty<Real> & _reaction_rate;
+  GenericMaterialProperty<Real, is_ad> & _reaction_rate;
   MaterialProperty<Real> & _d_k_d_en;
 
   Real _rate_value;
 
 };
+
+typedef GenericRateConstantTempl<false> GenericRateConstant;
+typedef GenericRateConstantTempl<true> ADGenericRateConstant;

--- a/src/materials/GenericRateConstant.C
+++ b/src/materials/GenericRateConstant.C
@@ -1,16 +1,13 @@
 #include "GenericRateConstant.h"
-#include "MooseUtils.h"
-
-// MOOSE includes
-#include "MooseVariable.h"
 
 registerMooseObject("CraneApp", GenericRateConstant);
+registerMooseObject("CraneApp", ADGenericRateConstant);
 
-template <>
+template <bool is_ad>
 InputParameters
-validParams<GenericRateConstant>()
+GenericRateConstantTempl<is_ad>::validParams()
 {
-  InputParameters params = validParams<Material>();
+  InputParameters params = Material::validParams();
   params.addRequiredParam<std::string>("reaction", "The full reaction equation.");
   params.addRequiredParam<Real>("reaction_rate_value",
                                 "The value of the reaction rate (constant).");
@@ -24,19 +21,32 @@ validParams<GenericRateConstant>()
   return params;
 }
 
-GenericRateConstant::GenericRateConstant(const InputParameters & parameters)
+template <bool is_ad>
+GenericRateConstantTempl<is_ad>::GenericRateConstantTempl(const InputParameters & parameters)
   : Material(parameters),
-    _reaction_rate(declareProperty<Real>("k" + getParam<std::string>("number") + "_" +
-                                         getParam<std::string>("reaction"))),
+    _reaction_rate(declareGenericProperty<Real, is_ad>("k" + getParam<std::string>("number") + "_" +
+                                                       getParam<std::string>("reaction"))),
     _d_k_d_en(declareProperty<Real>("d_k" + getParam<std::string>("number") + "_d_en_" +
                                     getParam<std::string>("reaction"))),
     _rate_value(getParam<Real>("reaction_rate_value"))
 {
 }
 
+template <>
 void
-GenericRateConstant::computeQpProperties()
+GenericRateConstantTempl<false>::computeQpProperties()
 {
   _reaction_rate[_qp] = _rate_value;
   _d_k_d_en[_qp] = 0.0;
 }
+
+template <>
+void
+GenericRateConstantTempl<true>::computeQpProperties()
+{
+  _reaction_rate[_qp].value() = _rate_value;
+  _reaction_rate[_qp].derivatives() = 0.0;
+}
+
+template class GenericRateConstantTempl<false>;
+template class GenericRateConstantTempl<true>;


### PR DESCRIPTION
Updates the following classes to AD templates and cleans extraneous code and comment cruft:

- ReactionSecondOrderLog
- ReactionThirdOrderLog
- GenericRateConstant

@keniley1 This change is in support of converting Zapdos to AD (specifically, to fixup the shooting method acceleration tests). Refs shannon-lab/zapdos#80