### PR TITLE
Restore positivity constraint in ADZapdosEEDFRateConstant and Convert TimeDerivativeLog to AD

### DIFF
--- a/include/kernels/TimeDerivativeLog.h
+++ b/include/kernels/TimeDerivativeLog.h
@@ -1,38 +1,14 @@
-/****************************************************************/
-/*               DO NOT MODIFY THIS HEADER                      */
-/* MOOSE - Multiphysics Object Oriented Simulation Environment  */
-/*                                                              */
-/*           (c) 2010 Battelle Energy Alliance, LLC             */
-/*                   ALL RIGHTS RESERVED                        */
-/*                                                              */
-/*          Prepared by Battelle Energy Alliance, LLC           */
-/*            Under Contract No. DE-AC07-05ID14517              */
-/*            With the U. S. Department of Energy               */
-/*                                                              */
-/*            See COPYRIGHT for full restrictions               */
-/****************************************************************/
-
 #pragma once
 
-#include "TimeKernel.h"
+#include "ADTimeDerivative.h"
 
-// Forward Declaration
-class TimeDerivativeLog;
-
-template <>
-InputParameters validParams<TimeDerivativeLog>();
-
-class TimeDerivativeLog : public TimeKernel
+class TimeDerivativeLog : public ADTimeDerivative
 {
 public:
+  static InputParameters validParams();
+
   TimeDerivativeLog(const InputParameters & parameters);
 
-  /* virtual void computeJacobian(); */
-
 protected:
-  virtual Real computeQpResidual();
-  virtual Real computeQpJacobian();
-  /* virtual Real computeQpOffDiagJacobian(unsigned int jvar); */
-
-  bool _lumping;
+  virtual ADReal precomputeQpResidual() override;
 };

--- a/src/kernels/TimeDerivativeLog.C
+++ b/src/kernels/TimeDerivativeLog.C
@@ -2,30 +2,20 @@
 
 registerMooseObject("CraneApp", TimeDerivativeLog);
 
-template <>
 InputParameters
-validParams<TimeDerivativeLog>()
+TimeDerivativeLog::validParams()
 {
-  InputParameters params = validParams<TimeKernel>();
-  params.addParam<bool>("lumping", false, "True for mass matrix lumping, false otherwise");
+  InputParameters params = ADTimeDerivative::validParams();
   return params;
 }
 
 TimeDerivativeLog::TimeDerivativeLog(const InputParameters & parameters)
-  : TimeKernel(parameters), _lumping(getParam<bool>("lumping"))
-
+  : ADTimeDerivative(parameters)
 {
 }
 
-Real
-TimeDerivativeLog::computeQpResidual()
+ADReal
+TimeDerivativeLog::precomputeQpResidual()
 {
-  return _test[_i][_qp] * std::exp(_u[_qp]) * _u_dot[_qp];
-}
-
-Real
-TimeDerivativeLog::computeQpJacobian()
-{
-  return _test[_i][_qp] * (std::exp(_u[_qp]) * _phi[_j][_qp] * _u_dot[_qp] +
-                           std::exp(_u[_qp]) * _du_dot_du[_qp] * _phi[_j][_qp]);
+  return std::exp(_u[_qp]) * ADTimeDerivative::precomputeQpResidual();
 }

--- a/src/materials/ADZapdosEEDFRateConstant.C
+++ b/src/materials/ADZapdosEEDFRateConstant.C
@@ -68,4 +68,10 @@ ADZapdosEEDFRateConstant::computeQpProperties()
                                              std::exp(_mean_en[_qp].value() - _em[_qp].value())) *
                                          std::exp(_mean_en[_qp].value() - _em[_qp].value()) *
                                          (_mean_en[_qp].derivatives() - _em[_qp].derivatives());
+
+  if (_rate_coefficient[_qp].value() < 0.0)
+  {
+    _rate_coefficient[_qp].value() = 0.0;
+    _rate_coefficient[_qp].derivatives() = 0.0;
+  }
 }


### PR DESCRIPTION
The recent removal of the positivity constraint in ADZapdosEEDFRateConstant in #71 caused a failure in the shooting method test in shannon-lab/zapdos#80. This PR restores that constraint. 

This PR also converts TimeDerivativeLog to AD (so that ADTimeDerivativeLog in Zapdos can just be removed). Tested as working against current CRANE tests on MacOS with Big Sur 11.2.1