### PR TITLE
Use std::make_unique in InterpolatedCoefficientLinear

### DIFF
--- a/src/materials/InterpolatedCoefficientLinear.C
+++ b/src/materials/InterpolatedCoefficientLinear.C
@@ -70,7 +70,7 @@ InterpolatedCoefficientLinear::InterpolatedCoefficientLinear(const InputParamete
     mooseError("Unable to open file");
 
   _coefficient_interpolation =
-      libmesh_make_unique<LinearInterpolation>(val_x, rate_coefficient, true);
+      std::make_unique<LinearInterpolation>(val_x, rate_coefficient, true);
 }
 
 void


### PR DESCRIPTION
MOOSE/libMesh use C++17 now, so libmesh_make_unique is deprecated.