### PR TITLE
Get CRANE docs building again

### DIFF
--- a/doc/config.yml
+++ b/doc/config.yml
@@ -1,26 +1,14 @@
 Content:
-    Crane:
-        root_dir: ${ROOT_DIR}/doc/content
-    moose:
-        root_dir: ${MOOSE_DIR}/framework/doc/content
-        content:
-            - js/*
-            - css/*
-            - contrib/**
-            - media/**
-            - templates/stubs/*
+    - ${ROOT_DIR}/doc/content
+    - ${MOOSE_DIR}/framework/doc/content
 
 Renderer:
     type: MooseDocs.base.MaterializeRenderer
-    #name: CRANE
-    #home: https://lcpp-org.github.io/crane
-    #repo: https://github.com/lcpp-org/crane
     #extra-css: # if you wanted to add extra CSS (like changing the default coloring), uncomment and add it here
             #- css/zapdos.css  # example - location relative to your "doc/content" directory
 Extensions:
     MooseDocs.extensions.navigation:
-        name: 'CRANE'
-        home: https://lcpp-org.github.io/crane
+        name: CRANE
         repo: https://github.com/lcpp-org/crane
         menu:
             Getting Started:
@@ -33,7 +21,7 @@ Extensions:
                 #Help:
                 #FAQ: help/faq.md
                 #Contact: help/contact_us.md
-            Examples: 
+            Examples:
                 Global Examples: examples/crane_examples.md
                 Zapdos Examples: examples/zapdos_examples.md
     MooseDocs.extensions.template:
@@ -42,3 +30,14 @@ Extensions:
         executable: ${ROOT_DIR}
         includes:
             - include
+        unregister:
+            framework: !include ${MOOSE_DIR}/framework/doc/unregister.yml
+        remove:
+            framework: !include ${MOOSE_DIR}/framework/doc/remove.yml
+    MooseDocs.extensions.common:
+        shortcuts:
+            framework: !include ${MOOSE_DIR}/framework/doc/globals.yml
+            crane:
+                Reactions: /syntax/Reactions/index.md
+    MooseDocs.extensions.acronym:
+        acronyms: !include ${MOOSE_DIR}/framework/doc/acronyms.yml

--- a/doc/content/bib/crane.bib
+++ b/doc/content/bib/crane.bib
@@ -1,0 +1,23 @@
+@inproceedings{zdplaskin2008,
+        author = {{Pancheshnyi}, Sergey and {Eismann}, Benjamin and {Hagelaar}, Gerjan and {Pitchford}, Leanne},
+         title = {{ZDPlasKin}: a new tool for plasmachemical simulations},
+         month = {September},
+          year = {2008},
+     booktitle = {The Eleventh International Symposium on High Pressure, Low Temperature Plasma Chemistry (HAKONE XI)},
+       address = {Oleron Island, France}
+}
+
+@online{nitrogen_example,
+        author = {{Pancheshnyi}, Sergey and {Eismann}, Benjamin and {Hagelaar}, Gerjan and {Pitchford}, Leanne},
+         title = {External profiles of electron density and electric field},
+           url = {http://www.zdplaskin.laplace.univ-tlse.fr/index.html@p=332.html},
+          year = {2015},
+   institution = {{University of Toulouse, LAPLACE, CNRS-UPS-INP}}
+}
+
+@book{capitelli2000,
+        author = {{Capitelli}, Mario and {Ferreira}, Carlos M and {Gordiets}, Boris F and {Osipov}, Alexey I},
+         title = {Plasma Kinetics in Atmospheric Gases},
+     publisher = {Springer},
+          year = {2000}
+}

--- a/doc/content/examples/global/argon_microdischarge.md
+++ b/doc/content/examples/global/argon_microdischarge.md
@@ -1,6 +1,6 @@
 # Argon Microdischarge
 
-This example is based on a [ZDPlasKin example of an argon microdischarge at atmospheric pressure](http://www.zdplaskin.laplace.univ-tlse.fr/index.html@p=310.html). The model includes five species: Ar, Ar$^*$, Ar$^+$, Ar$_2^+$, and electrons. The number density versus time is shown in the plot below, with ZDPlasKin's results for comparison.
+This example is based on a [ZDPlasKin example of an argon microdischarge at atmospheric pressure](http://www.zdplaskin.laplace.univ-tlse.fr/index.html@p=310.html) [!citep](zdplaskin2008). The model includes five species: Ar, Ar$^*$, Ar$^+$, Ar$_2^+$, and electrons. The number density versus time is shown in the plot below, with ZDPlasKin's results for comparison.
 
 The reactions are included in the input file as shown below:
 
@@ -41,10 +41,6 @@ Rate coefficients are separated from the reaction notation by a colon character.
 !media media/examples/argon.png style=width:80%;margin-left:50px;float:center;id=fig:argon_example caption=Argon species and electrons versus time. Solid lines are computed by CRANE, dotted lines by ZDPlasKin.
 
 !alert note title=Plot Differences
-The profiles are not identical. The main difference between ZDPlasKin and CRANE is that a Boltzmann solver is not dynamically coupled to CRANE, but [BOLSIG+](http://www.bolsig.laplace.univ-tlse.fr/) is coupled and run with ZDPlasKin. Instead, electron-impact rate coefficients are tabulated prior to runtime.  
+The profiles are not identical. The main difference between ZDPlasKin and CRANE is that a Boltzmann solver is not dynamically coupled to CRANE, but [BOLSIG+](http://www.bolsig.laplace.univ-tlse.fr/) is coupled and run with ZDPlasKin. Instead, electron-impact rate coefficients are tabulated prior to runtime.
 
-
-
-## Citations:
-
-[1] Pancheshnyi S., Eismannn B., Hagelaar G. and Pitchford L. "ZDPLASKIN: A NEW TOOL FOR PLASMACHEMICAL SIMULATIONS", The Eleventh International Symposium on High Pressure, Low Temperature Plasma Chemistry (HAKONE XI), September 2008, Oleron Island, France.
+!bibtex bibliography

--- a/doc/content/examples/global/nitrogen.md
+++ b/doc/content/examples/global/nitrogen.md
@@ -1,6 +1,6 @@
 # Nitrogen Example
 
-This example is based on a [ZDPlasKin example of a pure nitrogen discharge at atmospheric pressure](http://www.zdplaskin.laplace.univ-tlse.fr/index.html@p=332.html). The model includes 36 reactions between 10 species. 
+This example is based on a [ZDPlasKin example of a pure nitrogen discharge at atmospheric pressure](http://www.zdplaskin.laplace.univ-tlse.fr/index.html@p=332.html) [!citep](nitrogen_example, capitelli2000). The model includes 36 reactions between 10 species.
 
 ```
 [ChemicalReactions]
@@ -52,9 +52,9 @@ This example is based on a [ZDPlasKin example of a pure nitrogen discharge at at
 []
 ```
 
-In this example, the reduced electric field (`reduced_field`), electron temperature (`Te`), and electron density (`e`) are read into auxiliary variables with tabualted experimental data. The effective ion collision temperature `Teff` is also an auxiliary variable, but it is added as a parsed function. These variables are shown below. The `[AuxVariables]` block names the auxiliary variables, specifies their order, and denotes the family they belong to. (Since CRANE is being run alone in this example, all variables must be scalar.) 
+In this example, the reduced electric field (`reduced_field`), electron temperature (`Te`), and electron density (`e`) are read into auxiliary variables with tabualted experimental data. The effective ion collision temperature `Teff` is also an auxiliary variable, but it is added as a parsed function. These variables are shown below. The `[AuxVariables]` block names the auxiliary variables, specifies their order, and denotes the family they belong to. (Since CRANE is being run alone in this example, all variables must be scalar.)
 
-Values are supplied to the auxiliary variables with the `[AuxScalarKernels]` block. the `DataReadScalar` kernel will accept a csv or txt file as input, with the location denoted by `property_file`. The `scale_factor` parameter may be used to multiply each value by some factor; for example, if the csv file is tabulated in units of m$^{-3}$ s$^{-1}$ but the rest of the variables require units of cm$^{-3}$ s$^{-1}$, `scale_factor = 1e6` will convert the values appropriately.  
+Values are supplied to the auxiliary variables with the `[AuxScalarKernels]` block. the `DataReadScalar` kernel will accept a csv or txt file as input, with the location denoted by `property_file`. The `scale_factor` parameter may be used to multiply each value by some factor; for example, if the csv file is tabulated in units of m$^{-3}$ s$^{-1}$ but the rest of the variables require units of cm$^{-3}$ s$^{-1}$, `scale_factor = 1e6` will convert the values appropriately.
 
 ```
 [AuxVariables]
@@ -123,8 +123,4 @@ Values are supplied to the auxiliary variables with the `[AuxScalarKernels]` blo
 
 !media media/examples/nitrogen.png style=width:80%;margin-left:50px;float:center;id=fig:argon_example caption=Nitrogen species and electrons versus time. Solid lines are computed by CRANE, dotted lines by ZDPlasKin.
 
-## Citations
-
-[1] ZDPlasKin: http://www.zdplaskin.laplace.univ-tlse.fr/index.html@p=332.html
-
-[2] M Capitelli, C M Ferreira, B F Gordiets, and A I Osipov, *Plasma Kinetics in Atmospheric Gases*, Springer (2000).
+!bibtex bibliography

--- a/doc/content/index.md
+++ b/doc/content/index.md
@@ -1,6 +1,6 @@
 !config navigation breadcrumbs=False scrollspy=False
 
-!media logo.png style=width:30%;margin:auto;
+!media logo.png style=width:30%;display:block;margin:auto;
 
 # CRANE: Chemical ReAction NEtwork class=center light style=font-size:300%
 
@@ -11,7 +11,7 @@
 !col! small=12 medium=4 large=4 icon=check_box
 ### 'Human Readable' class=center style=font-weight:200;
 
-CRANE was developed with readability in mind. Chemical reactions may be added 
+CRANE was developed with readability in mind. Chemical reactions may be added
 exactly as they would be written by hand, and the program will parse the reactions
 into the appropriate source terms automatically.
 !col-end!
@@ -19,15 +19,15 @@ into the appropriate source terms automatically.
 !col! small=12 medium=4 large=4 icon=check_box
 ### MOOSE-based application class=center style=font-weight:200;
 
-CRANE is built on the MOOSE framework, and as such may be used effectively on both workstations and 
-high-performance computers. It may be used by itself as a global chemical kinetics solver, or it can 
+CRANE is built on the MOOSE framework, and as such may be used effectively on both workstations and
+high-performance computers. It may be used by itself as a global chemical kinetics solver, or it can
 be coupled into other MOOSE applications.
 !col-end!
 
 !col! small=12 medium=4 large=4 icon=check_box
 ### Coupled to Zapdos class=center style=font-weight:200;
 
-CRANE has been natively coupled to [Zapdos](https://github.com/shannon-lab/zapdos) and has been used 
+CRANE has been natively coupled to [Zapdos](https://github.com/shannon-lab/zapdos) and has been used
 to study multidimensional plasma discharges with complex chemical reaction networks.
 !col-end!
 !row-end!

--- a/doc/content/source/actions/AddReactions.md
+++ b/doc/content/source/actions/AddReactions.md
@@ -1,1 +1,21 @@
-!template load file=stubs/moose_action.md.template name=AddReactions syntax=/ChemicalReactions/Network/AddReactions
+# AddReactions
+
+!alert construction title=Undocumented Action Class
+The AddReactions has not been documented. The content listed below should be used as a starting point for
+documenting the class, which includes the typical automatic documentation associated with an Action;
+however, what is contained is ultimately determined by what is necessary to make the documentation
+clear for users.
+
+!syntax description /ChemicalReactions/Network/AddReactions
+
+## Overview
+
+!! Replace these lines with information regarding the AddReactions action.
+
+## Example Input File Syntax
+
+!! Describe and include an example of how to use the AddReactions action.
+
+!syntax description /ChemicalReactions/Network/AddReactions
+
+!syntax parameters /ChemicalReactions/Network/AddReactions

--- a/doc/content/source/actions/AddScalarReactions.md
+++ b/doc/content/source/actions/AddScalarReactions.md
@@ -1,1 +1,21 @@
-!template load file=stubs/moose_action.md.template name=AddScalarReactions syntax=/ChemicalReactions/ScalarNetwork/AddScalarReactions
+# AddScalarReactions
+
+!alert construction title=Undocumented Action Class
+The AddScalarReactions has not been documented. The content listed below should be used as a starting point for
+documenting the class, which includes the typical automatic documentation associated with an Action;
+however, what is contained is ultimately determined by what is necessary to make the documentation
+clear for users.
+
+!syntax description /ChemicalReactions/ScalarNetwork/AddScalarReactions
+
+## Overview
+
+!! Replace these lines with information regarding the AddScalarReactions action.
+
+## Example Input File Syntax
+
+!! Describe and include an example of how to use the AddScalarReactions action.
+
+!syntax description /ChemicalReactions/ScalarNetwork/AddScalarReactions
+
+!syntax parameters /ChemicalReactions/ScalarNetwork/AddScalarReactions

--- a/doc/content/source/actions/AddSpecies.md
+++ b/doc/content/source/actions/AddSpecies.md
@@ -1,1 +1,21 @@
-!template load file=stubs/moose_action.md.template name=AddSpecies syntax=/ChemicalSpecies/AddSpecies
+# AddSpecies
+
+!alert construction title=Undocumented Action Class
+The AddSpecies has not been documented. The content listed below should be used as a starting point for
+documenting the class, which includes the typical automatic documentation associated with an Action;
+however, what is contained is ultimately determined by what is necessary to make the documentation
+clear for users.
+
+!syntax description /ChemicalSpecies/AddSpecies
+
+## Overview
+
+!! Replace these lines with information regarding the AddSpecies action.
+
+## Example Input File Syntax
+
+!! Describe and include an example of how to use the AddSpecies action.
+
+!syntax description /ChemicalSpecies/AddSpecies
+
+!syntax parameters /ChemicalSpecies/AddSpecies

--- a/doc/content/source/actions/AddZapdosReactions.md
+++ b/doc/content/source/actions/AddZapdosReactions.md
@@ -1,1 +1,21 @@
-!template load file=stubs/moose_action.md.template name=AddZapdosReactions syntax=/ChemicalReactions/ZapdosNetwork/AddZapdosReactions
+# AddZapdosReactions
+
+!alert construction title=Undocumented Action Class
+The AddZapdosReactions has not been documented. The content listed below should be used as a starting point for
+documenting the class, which includes the typical automatic documentation associated with an Action;
+however, what is contained is ultimately determined by what is necessary to make the documentation
+clear for users.
+
+!syntax description /ChemicalReactions/ZapdosNetwork/AddZapdosReactions
+
+## Overview
+
+!! Replace these lines with information regarding the AddZapdosReactions action.
+
+## Example Input File Syntax
+
+!! Describe and include an example of how to use the AddZapdosReactions action.
+
+!syntax description /ChemicalReactions/ZapdosNetwork/AddZapdosReactions
+
+!syntax parameters /ChemicalReactions/ZapdosNetwork/AddZapdosReactions

--- a/doc/content/source/actions/ChemicalReactions.md
+++ b/doc/content/source/actions/ChemicalReactions.md
@@ -1,1 +1,21 @@
-!template load file=stubs/moose_action.md.template name=ChemicalReactions syntax=/ChemicalReactionsSolo/ChemicalReactions
+# ChemicalReactions
+
+!alert construction title=Undocumented Action Class
+The ChemicalReactions has not been documented. The content listed below should be used as a starting point for
+documenting the class, which includes the typical automatic documentation associated with an Action;
+however, what is contained is ultimately determined by what is necessary to make the documentation
+clear for users.
+
+!syntax description /ChemicalReactionsSolo/ChemicalReactions
+
+## Overview
+
+!! Replace these lines with information regarding the ChemicalReactions action.
+
+## Example Input File Syntax
+
+!! Describe and include an example of how to use the ChemicalReactions action.
+
+!syntax description /ChemicalReactionsSolo/ChemicalReactions
+
+!syntax parameters /ChemicalReactionsSolo/ChemicalReactions

--- a/doc/content/source/actions/ChemicalReactionsBase.md
+++ b/doc/content/source/actions/ChemicalReactionsBase.md
@@ -1,1 +1,21 @@
-!template load file=stubs/moose_action.md.template name=ChemicalReactionsBase syntax=/ChemicalReactions/Network/ChemicalReactionsBase
+# ChemicalReactionsBase
+
+!alert construction title=Undocumented Action Class
+The ChemicalReactionsBase has not been documented. The content listed below should be used as a starting point for
+documenting the class, which includes the typical automatic documentation associated with an Action;
+however, what is contained is ultimately determined by what is necessary to make the documentation
+clear for users.
+
+!syntax description /ChemicalReactions/ScalarNetwork/ChemicalReactionsBase
+
+## Overview
+
+!! Replace these lines with information regarding the ChemicalReactionsBase action.
+
+## Example Input File Syntax
+
+!! Describe and include an example of how to use the ChemicalReactionsBase action.
+
+!syntax description /ChemicalReactions/ScalarNetwork/ChemicalReactionsBase
+
+!syntax parameters /ChemicalReactions/ScalarNetwork/ChemicalReactionsBase

--- a/doc/content/source/auxkernels/AuxInitialConditionScalar.md
+++ b/doc/content/source/auxkernels/AuxInitialConditionScalar.md
@@ -1,1 +1,23 @@
-!template load file=stubs/moose_object.md.template name=AuxInitialConditionScalar syntax=/AuxScalarKernels/AuxInitialConditionScalar
+# AuxInitialConditionScalar
+
+!alert construction title=Undocumented Class
+The AuxInitialConditionScalar has not been documented. The content listed below should be used as a starting point for
+documenting the class, which includes the typical automatic documentation associated with a
+MooseObject; however, what is contained is ultimately determined by what is necessary to make the
+documentation clear for users.
+
+!syntax description /AuxScalarKernels/AuxInitialConditionScalar
+
+## Overview
+
+!! Replace these lines with information regarding the AuxInitialConditionScalar object.
+
+## Example Input File Syntax
+
+!! Describe and include an example of how to use the AuxInitialConditionScalar object.
+
+!syntax parameters /AuxScalarKernels/AuxInitialConditionScalar
+
+!syntax inputs /AuxScalarKernels/AuxInitialConditionScalar
+
+!syntax children /AuxScalarKernels/AuxInitialConditionScalar

--- a/doc/content/source/auxkernels/BolsigValueScalar.md
+++ b/doc/content/source/auxkernels/BolsigValueScalar.md
@@ -1,1 +1,23 @@
-!template load file=stubs/moose_object.md.template name=BolsigValueScalar syntax=/AuxScalarKernels/BolsigValueScalar
+# BolsigValueScalar
+
+!alert construction title=Undocumented Class
+The BolsigValueScalar has not been documented. The content listed below should be used as a starting point for
+documenting the class, which includes the typical automatic documentation associated with a
+MooseObject; however, what is contained is ultimately determined by what is necessary to make the
+documentation clear for users.
+
+!syntax description /AuxScalarKernels/BolsigValueScalar
+
+## Overview
+
+!! Replace these lines with information regarding the BolsigValueScalar object.
+
+## Example Input File Syntax
+
+!! Describe and include an example of how to use the BolsigValueScalar object.
+
+!syntax parameters /AuxScalarKernels/BolsigValueScalar
+
+!syntax inputs /AuxScalarKernels/BolsigValueScalar
+
+!syntax children /AuxScalarKernels/BolsigValueScalar

--- a/doc/content/source/auxkernels/DataRead.md
+++ b/doc/content/source/auxkernels/DataRead.md
@@ -1,1 +1,23 @@
-!template load file=stubs/moose_object.md.template name=DataRead syntax=/AuxKernels/DataRead
+# DataRead
+
+!alert construction title=Undocumented Class
+The DataRead has not been documented. The content listed below should be used as a starting point for
+documenting the class, which includes the typical automatic documentation associated with a
+MooseObject; however, what is contained is ultimately determined by what is necessary to make the
+documentation clear for users.
+
+!syntax description /AuxKernels/DataRead
+
+## Overview
+
+!! Replace these lines with information regarding the DataRead object.
+
+## Example Input File Syntax
+
+!! Describe and include an example of how to use the DataRead object.
+
+!syntax parameters /AuxKernels/DataRead
+
+!syntax inputs /AuxKernels/DataRead
+
+!syntax children /AuxKernels/DataRead

--- a/doc/content/source/auxkernels/DataReadScalar.md
+++ b/doc/content/source/auxkernels/DataReadScalar.md
@@ -1,1 +1,0 @@
-!template load file=stubs/moose_object.md.template name=DataReadScalar syntax=/AuxScalarKernels/DataReadScalar

--- a/doc/content/source/auxkernels/DensityLogConvert.md
+++ b/doc/content/source/auxkernels/DensityLogConvert.md
@@ -1,1 +1,23 @@
-!template load file=stubs/moose_object.md.template name=DensityLogConvert syntax=/AuxKernels/DensityLogConvert
+# DensityLogConvert
+
+!alert construction title=Undocumented Class
+The DensityLogConvert has not been documented. The content listed below should be used as a starting point for
+documenting the class, which includes the typical automatic documentation associated with a
+MooseObject; however, what is contained is ultimately determined by what is necessary to make the
+documentation clear for users.
+
+!syntax description /AuxKernels/DensityLogConvert
+
+## Overview
+
+!! Replace these lines with information regarding the DensityLogConvert object.
+
+## Example Input File Syntax
+
+!! Describe and include an example of how to use the DensityLogConvert object.
+
+!syntax parameters /AuxKernels/DensityLogConvert
+
+!syntax inputs /AuxKernels/DensityLogConvert
+
+!syntax children /AuxKernels/DensityLogConvert

--- a/doc/content/source/auxkernels/DensityLogConvertScalar.md
+++ b/doc/content/source/auxkernels/DensityLogConvertScalar.md
@@ -1,1 +1,23 @@
-!template load file=stubs/moose_object.md.template name=DensityLogConvertScalar syntax=/AuxScalarKernels/DensityLogConvertScalar
+# DensityLogConvertScalar
+
+!alert construction title=Undocumented Class
+The DensityLogConvertScalar has not been documented. The content listed below should be used as a starting point for
+documenting the class, which includes the typical automatic documentation associated with a
+MooseObject; however, what is contained is ultimately determined by what is necessary to make the
+documentation clear for users.
+
+!syntax description /AuxScalarKernels/DensityLogConvertScalar
+
+## Overview
+
+!! Replace these lines with information regarding the DensityLogConvertScalar object.
+
+## Example Input File Syntax
+
+!! Describe and include an example of how to use the DensityLogConvertScalar object.
+
+!syntax parameters /AuxScalarKernels/DensityLogConvertScalar
+
+!syntax inputs /AuxScalarKernels/DensityLogConvertScalar
+
+!syntax children /AuxScalarKernels/DensityLogConvertScalar

--- a/doc/content/source/auxkernels/EEDFRateCoefficientScalar.md
+++ b/doc/content/source/auxkernels/EEDFRateCoefficientScalar.md
@@ -1,1 +1,23 @@
-!template load file=stubs/moose_object.md.template name=EEDFRateCoefficientScalar syntax=/AuxScalarKernels/EEDFRateCoefficientScalar
+# EEDFRateCoefficientScalar
+
+!alert construction title=Undocumented Class
+The EEDFRateCoefficientScalar has not been documented. The content listed below should be used as a starting point for
+documenting the class, which includes the typical automatic documentation associated with a
+MooseObject; however, what is contained is ultimately determined by what is necessary to make the
+documentation clear for users.
+
+!syntax description /AuxScalarKernels/EEDFRateCoefficientScalar
+
+## Overview
+
+!! Replace these lines with information regarding the EEDFRateCoefficientScalar object.
+
+## Example Input File Syntax
+
+!! Describe and include an example of how to use the EEDFRateCoefficientScalar object.
+
+!syntax parameters /AuxScalarKernels/EEDFRateCoefficientScalar
+
+!syntax inputs /AuxScalarKernels/EEDFRateCoefficientScalar
+
+!syntax children /AuxScalarKernels/EEDFRateCoefficientScalar

--- a/doc/content/source/auxkernels/ElectronMobility.md
+++ b/doc/content/source/auxkernels/ElectronMobility.md
@@ -1,1 +1,23 @@
-!template load file=stubs/moose_object.md.template name=ElectronMobility syntax=/AuxScalarKernels/ElectronMobility
+# ElectronMobility
+
+!alert construction title=Undocumented Class
+The ElectronMobility has not been documented. The content listed below should be used as a starting point for
+documenting the class, which includes the typical automatic documentation associated with a
+MooseObject; however, what is contained is ultimately determined by what is necessary to make the
+documentation clear for users.
+
+!syntax description /AuxScalarKernels/ElectronMobility
+
+## Overview
+
+!! Replace these lines with information regarding the ElectronMobility object.
+
+## Example Input File Syntax
+
+!! Describe and include an example of how to use the ElectronMobility object.
+
+!syntax parameters /AuxScalarKernels/ElectronMobility
+
+!syntax inputs /AuxScalarKernels/ElectronMobility
+
+!syntax children /AuxScalarKernels/ElectronMobility

--- a/doc/content/source/auxkernels/MoleFraction.md
+++ b/doc/content/source/auxkernels/MoleFraction.md
@@ -1,1 +1,23 @@
-!template load file=stubs/moose_object.md.template name=MoleFraction syntax=/AuxScalarKernels/MoleFraction
+# MoleFraction
+
+!alert construction title=Undocumented Class
+The MoleFraction has not been documented. The content listed below should be used as a starting point for
+documenting the class, which includes the typical automatic documentation associated with a
+MooseObject; however, what is contained is ultimately determined by what is necessary to make the
+documentation clear for users.
+
+!syntax description /AuxScalarKernels/MoleFraction
+
+## Overview
+
+!! Replace these lines with information regarding the MoleFraction object.
+
+## Example Input File Syntax
+
+!! Describe and include an example of how to use the MoleFraction object.
+
+!syntax parameters /AuxScalarKernels/MoleFraction
+
+!syntax inputs /AuxScalarKernels/MoleFraction
+
+!syntax children /AuxScalarKernels/MoleFraction

--- a/doc/content/source/auxkernels/ParsedAuxScalar.md
+++ b/doc/content/source/auxkernels/ParsedAuxScalar.md
@@ -1,1 +1,23 @@
-!template load file=stubs/moose_object.md.template name=ParsedAuxScalar syntax=/AuxScalarKernels/ParsedAuxScalar
+# ParsedAuxScalar
+
+!alert construction title=Undocumented Class
+The ParsedAuxScalar has not been documented. The content listed below should be used as a starting point for
+documenting the class, which includes the typical automatic documentation associated with a
+MooseObject; however, what is contained is ultimately determined by what is necessary to make the
+documentation clear for users.
+
+!syntax description /AuxScalarKernels/ParsedAuxScalar
+
+## Overview
+
+!! Replace these lines with information regarding the ParsedAuxScalar object.
+
+## Example Input File Syntax
+
+!! Describe and include an example of how to use the ParsedAuxScalar object.
+
+!syntax parameters /AuxScalarKernels/ParsedAuxScalar
+
+!syntax inputs /AuxScalarKernels/ParsedAuxScalar
+
+!syntax children /AuxScalarKernels/ParsedAuxScalar

--- a/doc/content/source/auxkernels/ParsedScalarRateCoefficient.md
+++ b/doc/content/source/auxkernels/ParsedScalarRateCoefficient.md
@@ -1,1 +1,23 @@
-!template load file=stubs/moose_object.md.template name=ParsedScalarRateCoefficient syntax=/AuxScalarKernels/ParsedScalarRateCoefficient
+# ParsedScalarRateCoefficient
+
+!alert construction title=Undocumented Class
+The ParsedScalarRateCoefficient has not been documented. The content listed below should be used as a starting point for
+documenting the class, which includes the typical automatic documentation associated with a
+MooseObject; however, what is contained is ultimately determined by what is necessary to make the
+documentation clear for users.
+
+!syntax description /AuxScalarKernels/ParsedScalarRateCoefficient
+
+## Overview
+
+!! Replace these lines with information regarding the ParsedScalarRateCoefficient object.
+
+## Example Input File Syntax
+
+!! Describe and include an example of how to use the ParsedScalarRateCoefficient object.
+
+!syntax parameters /AuxScalarKernels/ParsedScalarRateCoefficient
+
+!syntax inputs /AuxScalarKernels/ParsedScalarRateCoefficient
+
+!syntax children /AuxScalarKernels/ParsedScalarRateCoefficient

--- a/doc/content/source/auxkernels/ReactionRateEEDFTownsendLog.md
+++ b/doc/content/source/auxkernels/ReactionRateEEDFTownsendLog.md
@@ -1,0 +1,23 @@
+# ReactionRateEEDFTownsendLog
+
+!alert construction title=Undocumented Class
+The ReactionRateEEDFTownsendLog has not been documented. The content listed below should be used as a starting point for
+documenting the class, which includes the typical automatic documentation associated with a
+MooseObject; however, what is contained is ultimately determined by what is necessary to make the
+documentation clear for users.
+
+!syntax description /AuxKernels/ReactionRateEEDFTownsendLog
+
+## Overview
+
+!! Replace these lines with information regarding the ReactionRateEEDFTownsendLog object.
+
+## Example Input File Syntax
+
+!! Describe and include an example of how to use the ReactionRateEEDFTownsendLog object.
+
+!syntax parameters /AuxKernels/ReactionRateEEDFTownsendLog
+
+!syntax inputs /AuxKernels/ReactionRateEEDFTownsendLog
+
+!syntax children /AuxKernels/ReactionRateEEDFTownsendLog

--- a/doc/content/source/auxkernels/ReactionRateFirstOrder.md
+++ b/doc/content/source/auxkernels/ReactionRateFirstOrder.md
@@ -1,0 +1,23 @@
+# ReactionRateFirstOrder
+
+!alert construction title=Undocumented Class
+The ReactionRateFirstOrder has not been documented. The content listed below should be used as a starting point for
+documenting the class, which includes the typical automatic documentation associated with a
+MooseObject; however, what is contained is ultimately determined by what is necessary to make the
+documentation clear for users.
+
+!syntax description /AuxKernels/ReactionRateFirstOrder
+
+## Overview
+
+!! Replace these lines with information regarding the ReactionRateFirstOrder object.
+
+## Example Input File Syntax
+
+!! Describe and include an example of how to use the ReactionRateFirstOrder object.
+
+!syntax parameters /AuxKernels/ReactionRateFirstOrder
+
+!syntax inputs /AuxKernels/ReactionRateFirstOrder
+
+!syntax children /AuxKernels/ReactionRateFirstOrder

--- a/doc/content/source/auxkernels/ReactionRateFirstOrderLog.md
+++ b/doc/content/source/auxkernels/ReactionRateFirstOrderLog.md
@@ -1,0 +1,23 @@
+# ReactionRateFirstOrderLog
+
+!alert construction title=Undocumented Class
+The ReactionRateFirstOrderLog has not been documented. The content listed below should be used as a starting point for
+documenting the class, which includes the typical automatic documentation associated with a
+MooseObject; however, what is contained is ultimately determined by what is necessary to make the
+documentation clear for users.
+
+!syntax description /AuxKernels/ReactionRateFirstOrderLog
+
+## Overview
+
+!! Replace these lines with information regarding the ReactionRateFirstOrderLog object.
+
+## Example Input File Syntax
+
+!! Describe and include an example of how to use the ReactionRateFirstOrderLog object.
+
+!syntax parameters /AuxKernels/ReactionRateFirstOrderLog
+
+!syntax inputs /AuxKernels/ReactionRateFirstOrderLog
+
+!syntax children /AuxKernels/ReactionRateFirstOrderLog

--- a/doc/content/source/auxkernels/ReactionRateOneBodyScalar.md
+++ b/doc/content/source/auxkernels/ReactionRateOneBodyScalar.md
@@ -1,0 +1,23 @@
+# ReactionRateOneBodyScalar
+
+!alert construction title=Undocumented Class
+The ReactionRateOneBodyScalar has not been documented. The content listed below should be used as a starting point for
+documenting the class, which includes the typical automatic documentation associated with a
+MooseObject; however, what is contained is ultimately determined by what is necessary to make the
+documentation clear for users.
+
+!syntax description /AuxScalarKernels/ReactionRateOneBodyScalar
+
+## Overview
+
+!! Replace these lines with information regarding the ReactionRateOneBodyScalar object.
+
+## Example Input File Syntax
+
+!! Describe and include an example of how to use the ReactionRateOneBodyScalar object.
+
+!syntax parameters /AuxScalarKernels/ReactionRateOneBodyScalar
+
+!syntax inputs /AuxScalarKernels/ReactionRateOneBodyScalar
+
+!syntax children /AuxScalarKernels/ReactionRateOneBodyScalar

--- a/doc/content/source/auxkernels/ReactionRateSecondOrder.md
+++ b/doc/content/source/auxkernels/ReactionRateSecondOrder.md
@@ -1,0 +1,23 @@
+# ReactionRateSecondOrder
+
+!alert construction title=Undocumented Class
+The ReactionRateSecondOrder has not been documented. The content listed below should be used as a starting point for
+documenting the class, which includes the typical automatic documentation associated with a
+MooseObject; however, what is contained is ultimately determined by what is necessary to make the
+documentation clear for users.
+
+!syntax description /AuxKernels/ReactionRateSecondOrder
+
+## Overview
+
+!! Replace these lines with information regarding the ReactionRateSecondOrder object.
+
+## Example Input File Syntax
+
+!! Describe and include an example of how to use the ReactionRateSecondOrder object.
+
+!syntax parameters /AuxKernels/ReactionRateSecondOrder
+
+!syntax inputs /AuxKernels/ReactionRateSecondOrder
+
+!syntax children /AuxKernels/ReactionRateSecondOrder

--- a/doc/content/source/auxkernels/ReactionRateSecondOrderLog.md
+++ b/doc/content/source/auxkernels/ReactionRateSecondOrderLog.md
@@ -1,0 +1,23 @@
+# ReactionRateSecondOrderLog
+
+!alert construction title=Undocumented Class
+The ReactionRateSecondOrderLog has not been documented. The content listed below should be used as a starting point for
+documenting the class, which includes the typical automatic documentation associated with a
+MooseObject; however, what is contained is ultimately determined by what is necessary to make the
+documentation clear for users.
+
+!syntax description /AuxKernels/ReactionRateSecondOrderLog
+
+## Overview
+
+!! Replace these lines with information regarding the ReactionRateSecondOrderLog object.
+
+## Example Input File Syntax
+
+!! Describe and include an example of how to use the ReactionRateSecondOrderLog object.
+
+!syntax parameters /AuxKernels/ReactionRateSecondOrderLog
+
+!syntax inputs /AuxKernels/ReactionRateSecondOrderLog
+
+!syntax children /AuxKernels/ReactionRateSecondOrderLog

--- a/doc/content/source/auxkernels/ReactionRateThirdOrder.md
+++ b/doc/content/source/auxkernels/ReactionRateThirdOrder.md
@@ -1,0 +1,23 @@
+# ReactionRateThirdOrder
+
+!alert construction title=Undocumented Class
+The ReactionRateThirdOrder has not been documented. The content listed below should be used as a starting point for
+documenting the class, which includes the typical automatic documentation associated with a
+MooseObject; however, what is contained is ultimately determined by what is necessary to make the
+documentation clear for users.
+
+!syntax description /AuxKernels/ReactionRateThirdOrder
+
+## Overview
+
+!! Replace these lines with information regarding the ReactionRateThirdOrder object.
+
+## Example Input File Syntax
+
+!! Describe and include an example of how to use the ReactionRateThirdOrder object.
+
+!syntax parameters /AuxKernels/ReactionRateThirdOrder
+
+!syntax inputs /AuxKernels/ReactionRateThirdOrder
+
+!syntax children /AuxKernels/ReactionRateThirdOrder

--- a/doc/content/source/auxkernels/ReactionRateThirdOrderLog.md
+++ b/doc/content/source/auxkernels/ReactionRateThirdOrderLog.md
@@ -1,0 +1,23 @@
+# ReactionRateThirdOrderLog
+
+!alert construction title=Undocumented Class
+The ReactionRateThirdOrderLog has not been documented. The content listed below should be used as a starting point for
+documenting the class, which includes the typical automatic documentation associated with a
+MooseObject; however, what is contained is ultimately determined by what is necessary to make the
+documentation clear for users.
+
+!syntax description /AuxKernels/ReactionRateThirdOrderLog
+
+## Overview
+
+!! Replace these lines with information regarding the ReactionRateThirdOrderLog object.
+
+## Example Input File Syntax
+
+!! Describe and include an example of how to use the ReactionRateThirdOrderLog object.
+
+!syntax parameters /AuxKernels/ReactionRateThirdOrderLog
+
+!syntax inputs /AuxKernels/ReactionRateThirdOrderLog
+
+!syntax children /AuxKernels/ReactionRateThirdOrderLog

--- a/doc/content/source/auxkernels/ReactionRateThreeBodyScalar.md
+++ b/doc/content/source/auxkernels/ReactionRateThreeBodyScalar.md
@@ -1,0 +1,23 @@
+# ReactionRateThreeBodyScalar
+
+!alert construction title=Undocumented Class
+The ReactionRateThreeBodyScalar has not been documented. The content listed below should be used as a starting point for
+documenting the class, which includes the typical automatic documentation associated with a
+MooseObject; however, what is contained is ultimately determined by what is necessary to make the
+documentation clear for users.
+
+!syntax description /AuxScalarKernels/ReactionRateThreeBodyScalar
+
+## Overview
+
+!! Replace these lines with information regarding the ReactionRateThreeBodyScalar object.
+
+## Example Input File Syntax
+
+!! Describe and include an example of how to use the ReactionRateThreeBodyScalar object.
+
+!syntax parameters /AuxScalarKernels/ReactionRateThreeBodyScalar
+
+!syntax inputs /AuxScalarKernels/ReactionRateThreeBodyScalar
+
+!syntax children /AuxScalarKernels/ReactionRateThreeBodyScalar

--- a/doc/content/source/auxkernels/ReactionRateTwoBodyScalar.md
+++ b/doc/content/source/auxkernels/ReactionRateTwoBodyScalar.md
@@ -1,0 +1,23 @@
+# ReactionRateTwoBodyScalar
+
+!alert construction title=Undocumented Class
+The ReactionRateTwoBodyScalar has not been documented. The content listed below should be used as a starting point for
+documenting the class, which includes the typical automatic documentation associated with a
+MooseObject; however, what is contained is ultimately determined by what is necessary to make the
+documentation clear for users.
+
+!syntax description /AuxScalarKernels/ReactionRateTwoBodyScalar
+
+## Overview
+
+!! Replace these lines with information regarding the ReactionRateTwoBodyScalar object.
+
+## Example Input File Syntax
+
+!! Describe and include an example of how to use the ReactionRateTwoBodyScalar object.
+
+!syntax parameters /AuxScalarKernels/ReactionRateTwoBodyScalar
+
+!syntax inputs /AuxScalarKernels/ReactionRateTwoBodyScalar
+
+!syntax children /AuxScalarKernels/ReactionRateTwoBodyScalar

--- a/doc/content/source/auxkernels/ReducedField.md
+++ b/doc/content/source/auxkernels/ReducedField.md
@@ -1,1 +1,23 @@
-!template load file=stubs/moose_object.md.template name=ReducedField syntax=/AuxScalarKernels/ReducedField
+# ReducedField
+
+!alert construction title=Undocumented Class
+The ReducedField has not been documented. The content listed below should be used as a starting point for
+documenting the class, which includes the typical automatic documentation associated with a
+MooseObject; however, what is contained is ultimately determined by what is necessary to make the
+documentation clear for users.
+
+!syntax description /AuxScalarKernels/ReducedField
+
+## Overview
+
+!! Replace these lines with information regarding the ReducedField object.
+
+## Example Input File Syntax
+
+!! Describe and include an example of how to use the ReducedField object.
+
+!syntax parameters /AuxScalarKernels/ReducedField
+
+!syntax inputs /AuxScalarKernels/ReducedField
+
+!syntax children /AuxScalarKernels/ReducedField

--- a/doc/content/source/auxkernels/ReducedFieldScalar.md
+++ b/doc/content/source/auxkernels/ReducedFieldScalar.md
@@ -1,1 +1,23 @@
-!template load file=stubs/moose_object.md.template name=ReducedFieldScalar syntax=/AuxScalarKernels/ReducedFieldScalar
+# ReducedFieldScalar
+
+!alert construction title=Undocumented Class
+The ReducedFieldScalar has not been documented. The content listed below should be used as a starting point for
+documenting the class, which includes the typical automatic documentation associated with a
+MooseObject; however, what is contained is ultimately determined by what is necessary to make the
+documentation clear for users.
+
+!syntax description /AuxScalarKernels/ReducedFieldScalar
+
+## Overview
+
+!! Replace these lines with information regarding the ReducedFieldScalar object.
+
+## Example Input File Syntax
+
+!! Describe and include an example of how to use the ReducedFieldScalar object.
+
+!syntax parameters /AuxScalarKernels/ReducedFieldScalar
+
+!syntax inputs /AuxScalarKernels/ReducedFieldScalar
+
+!syntax children /AuxScalarKernels/ReducedFieldScalar

--- a/doc/content/source/auxkernels/ScalarLinearInterpolation.md
+++ b/doc/content/source/auxkernels/ScalarLinearInterpolation.md
@@ -1,0 +1,23 @@
+# ScalarLinearInterpolation
+
+!alert construction title=Undocumented Class
+The ScalarLinearInterpolation has not been documented. The content listed below should be used as a starting point for
+documenting the class, which includes the typical automatic documentation associated with a
+MooseObject; however, what is contained is ultimately determined by what is necessary to make the
+documentation clear for users.
+
+!syntax description /AuxScalarKernels/ScalarLinearInterpolation
+
+## Overview
+
+!! Replace these lines with information regarding the ScalarLinearInterpolation object.
+
+## Example Input File Syntax
+
+!! Describe and include an example of how to use the ScalarLinearInterpolation object.
+
+!syntax parameters /AuxScalarKernels/ScalarLinearInterpolation
+
+!syntax inputs /AuxScalarKernels/ScalarLinearInterpolation
+
+!syntax children /AuxScalarKernels/ScalarLinearInterpolation

--- a/doc/content/source/auxkernels/ScalarSplineInterpolation.md
+++ b/doc/content/source/auxkernels/ScalarSplineInterpolation.md
@@ -1,0 +1,23 @@
+# ScalarSplineInterpolation
+
+!alert construction title=Undocumented Class
+The ScalarSplineInterpolation has not been documented. The content listed below should be used as a starting point for
+documenting the class, which includes the typical automatic documentation associated with a
+MooseObject; however, what is contained is ultimately determined by what is necessary to make the
+documentation clear for users.
+
+!syntax description /AuxScalarKernels/ScalarSplineInterpolation
+
+## Overview
+
+!! Replace these lines with information regarding the ScalarSplineInterpolation object.
+
+## Example Input File Syntax
+
+!! Describe and include an example of how to use the ScalarSplineInterpolation object.
+
+!syntax parameters /AuxScalarKernels/ScalarSplineInterpolation
+
+!syntax inputs /AuxScalarKernels/ScalarSplineInterpolation
+
+!syntax children /AuxScalarKernels/ScalarSplineInterpolation

--- a/doc/content/source/auxkernels/SuperelasticRateCoefficientScalar.md
+++ b/doc/content/source/auxkernels/SuperelasticRateCoefficientScalar.md
@@ -1,1 +1,23 @@
-!template load file=stubs/moose_object.md.template name=SuperelasticRateCoefficientScalar syntax=/AuxScalarKernels/SuperelasticRateCoefficientScalar
+# SuperelasticRateCoefficientScalar
+
+!alert construction title=Undocumented Class
+The SuperelasticRateCoefficientScalar has not been documented. The content listed below should be used as a starting point for
+documenting the class, which includes the typical automatic documentation associated with a
+MooseObject; however, what is contained is ultimately determined by what is necessary to make the
+documentation clear for users.
+
+!syntax description /AuxScalarKernels/SuperelasticRateCoefficientScalar
+
+## Overview
+
+!! Replace these lines with information regarding the SuperelasticRateCoefficientScalar object.
+
+## Example Input File Syntax
+
+!! Describe and include an example of how to use the SuperelasticRateCoefficientScalar object.
+
+!syntax parameters /AuxScalarKernels/SuperelasticRateCoefficientScalar
+
+!syntax inputs /AuxScalarKernels/SuperelasticRateCoefficientScalar
+
+!syntax children /AuxScalarKernels/SuperelasticRateCoefficientScalar

--- a/doc/content/source/auxkernels/VariableSum.md
+++ b/doc/content/source/auxkernels/VariableSum.md
@@ -1,1 +1,23 @@
-!template load file=stubs/moose_object.md.template name=VariableSum syntax=/AuxScalarKernels/VariableSum
+# VariableSum
+
+!alert construction title=Undocumented Class
+The VariableSum has not been documented. The content listed below should be used as a starting point for
+documenting the class, which includes the typical automatic documentation associated with a
+MooseObject; however, what is contained is ultimately determined by what is necessary to make the
+documentation clear for users.
+
+!syntax description /AuxScalarKernels/VariableSum
+
+## Overview
+
+!! Replace these lines with information regarding the VariableSum object.
+
+## Example Input File Syntax
+
+!! Describe and include an example of how to use the VariableSum object.
+
+!syntax parameters /AuxScalarKernels/VariableSum
+
+!syntax inputs /AuxScalarKernels/VariableSum
+
+!syntax children /AuxScalarKernels/VariableSum

--- a/doc/content/source/auxkernels/VariableSumLog.md
+++ b/doc/content/source/auxkernels/VariableSumLog.md
@@ -1,0 +1,23 @@
+# VariableSumLog
+
+!alert construction title=Undocumented Class
+The VariableSumLog has not been documented. The content listed below should be used as a starting point for
+documenting the class, which includes the typical automatic documentation associated with a
+MooseObject; however, what is contained is ultimately determined by what is necessary to make the
+documentation clear for users.
+
+!syntax description /AuxScalarKernels/VariableSumLog
+
+## Overview
+
+!! Replace these lines with information regarding the VariableSumLog object.
+
+## Example Input File Syntax
+
+!! Describe and include an example of how to use the VariableSumLog object.
+
+!syntax parameters /AuxScalarKernels/VariableSumLog
+
+!syntax inputs /AuxScalarKernels/VariableSumLog
+
+!syntax children /AuxScalarKernels/VariableSumLog

--- a/doc/content/source/kernels/ADEEDFElasticLog.md
+++ b/doc/content/source/kernels/ADEEDFElasticLog.md
@@ -1,0 +1,23 @@
+# ADEEDFElasticLog
+
+!alert construction title=Undocumented Class
+The ADEEDFElasticLog has not been documented. The content listed below should be used as a starting point for
+documenting the class, which includes the typical automatic documentation associated with a
+MooseObject; however, what is contained is ultimately determined by what is necessary to make the
+documentation clear for users.
+
+!syntax description /Kernels/ADEEDFElasticLog
+
+## Overview
+
+!! Replace these lines with information regarding the ADEEDFElasticLog object.
+
+## Example Input File Syntax
+
+!! Describe and include an example of how to use the ADEEDFElasticLog object.
+
+!syntax parameters /Kernels/ADEEDFElasticLog
+
+!syntax inputs /Kernels/ADEEDFElasticLog
+
+!syntax children /Kernels/ADEEDFElasticLog

--- a/doc/content/source/kernels/ADEEDFElasticTownsendLog.md
+++ b/doc/content/source/kernels/ADEEDFElasticTownsendLog.md
@@ -1,0 +1,23 @@
+# ADEEDFElasticTownsendLog
+
+!alert construction title=Undocumented Class
+The ADEEDFElasticTownsendLog has not been documented. The content listed below should be used as a starting point for
+documenting the class, which includes the typical automatic documentation associated with a
+MooseObject; however, what is contained is ultimately determined by what is necessary to make the
+documentation clear for users.
+
+!syntax description /Kernels/ADEEDFElasticTownsendLog
+
+## Overview
+
+!! Replace these lines with information regarding the ADEEDFElasticTownsendLog object.
+
+## Example Input File Syntax
+
+!! Describe and include an example of how to use the ADEEDFElasticTownsendLog object.
+
+!syntax parameters /Kernels/ADEEDFElasticTownsendLog
+
+!syntax inputs /Kernels/ADEEDFElasticTownsendLog
+
+!syntax children /Kernels/ADEEDFElasticTownsendLog

--- a/doc/content/source/kernels/ADEEDFEnergyLog.md
+++ b/doc/content/source/kernels/ADEEDFEnergyLog.md
@@ -1,0 +1,23 @@
+# ADEEDFEnergyLog
+
+!alert construction title=Undocumented Class
+The ADEEDFEnergyLog has not been documented. The content listed below should be used as a starting point for
+documenting the class, which includes the typical automatic documentation associated with a
+MooseObject; however, what is contained is ultimately determined by what is necessary to make the
+documentation clear for users.
+
+!syntax description /Kernels/ADEEDFEnergyLog
+
+## Overview
+
+!! Replace these lines with information regarding the ADEEDFEnergyLog object.
+
+## Example Input File Syntax
+
+!! Describe and include an example of how to use the ADEEDFEnergyLog object.
+
+!syntax parameters /Kernels/ADEEDFEnergyLog
+
+!syntax inputs /Kernels/ADEEDFEnergyLog
+
+!syntax children /Kernels/ADEEDFEnergyLog

--- a/doc/content/source/kernels/ADEEDFEnergyTownsendLog.md
+++ b/doc/content/source/kernels/ADEEDFEnergyTownsendLog.md
@@ -1,0 +1,23 @@
+# ADEEDFEnergyTownsendLog
+
+!alert construction title=Undocumented Class
+The ADEEDFEnergyTownsendLog has not been documented. The content listed below should be used as a starting point for
+documenting the class, which includes the typical automatic documentation associated with a
+MooseObject; however, what is contained is ultimately determined by what is necessary to make the
+documentation clear for users.
+
+!syntax description /Kernels/ADEEDFEnergyTownsendLog
+
+## Overview
+
+!! Replace these lines with information regarding the ADEEDFEnergyTownsendLog object.
+
+## Example Input File Syntax
+
+!! Describe and include an example of how to use the ADEEDFEnergyTownsendLog object.
+
+!syntax parameters /Kernels/ADEEDFEnergyTownsendLog
+
+!syntax inputs /Kernels/ADEEDFEnergyTownsendLog
+
+!syntax children /Kernels/ADEEDFEnergyTownsendLog

--- a/doc/content/source/kernels/ADEEDFReactionLog.md
+++ b/doc/content/source/kernels/ADEEDFReactionLog.md
@@ -1,0 +1,23 @@
+# ADEEDFReactionLog
+
+!alert construction title=Undocumented Class
+The ADEEDFReactionLog has not been documented. The content listed below should be used as a starting point for
+documenting the class, which includes the typical automatic documentation associated with a
+MooseObject; however, what is contained is ultimately determined by what is necessary to make the
+documentation clear for users.
+
+!syntax description /Kernels/ADEEDFReactionLog
+
+## Overview
+
+!! Replace these lines with information regarding the ADEEDFReactionLog object.
+
+## Example Input File Syntax
+
+!! Describe and include an example of how to use the ADEEDFReactionLog object.
+
+!syntax parameters /Kernels/ADEEDFReactionLog
+
+!syntax inputs /Kernels/ADEEDFReactionLog
+
+!syntax children /Kernels/ADEEDFReactionLog

--- a/doc/content/source/kernels/ADEEDFReactionTownsend.md
+++ b/doc/content/source/kernels/ADEEDFReactionTownsend.md
@@ -1,0 +1,23 @@
+# ADEEDFReactionTownsendLog
+
+!alert construction title=Undocumented Class
+The ADEEDFReactionTownsendLog has not been documented. The content listed below should be used as a starting point for
+documenting the class, which includes the typical automatic documentation associated with a
+MooseObject; however, what is contained is ultimately determined by what is necessary to make the
+documentation clear for users.
+
+!syntax description /Kernels/ADEEDFReactionTownsendLog
+
+## Overview
+
+!! Replace these lines with information regarding the ADEEDFReactionTownsendLog object.
+
+## Example Input File Syntax
+
+!! Describe and include an example of how to use the ADEEDFReactionTownsendLog object.
+
+!syntax parameters /Kernels/ADEEDFReactionTownsendLog
+
+!syntax inputs /Kernels/ADEEDFReactionTownsendLog
+
+!syntax children /Kernels/ADEEDFReactionTownsendLog

--- a/doc/content/source/kernels/EEDFElasticLog.md
+++ b/doc/content/source/kernels/EEDFElasticLog.md
@@ -1,0 +1,23 @@
+# EEDFElasticLog
+
+!alert construction title=Undocumented Class
+The EEDFElasticLog has not been documented. The content listed below should be used as a starting point for
+documenting the class, which includes the typical automatic documentation associated with a
+MooseObject; however, what is contained is ultimately determined by what is necessary to make the
+documentation clear for users.
+
+!syntax description /Kernels/EEDFElasticLog
+
+## Overview
+
+!! Replace these lines with information regarding the EEDFElasticLog object.
+
+## Example Input File Syntax
+
+!! Describe and include an example of how to use the EEDFElasticLog object.
+
+!syntax parameters /Kernels/EEDFElasticLog
+
+!syntax inputs /Kernels/EEDFElasticLog
+
+!syntax children /Kernels/EEDFElasticLog

--- a/doc/content/source/kernels/EEDFElasticTownsendLog.md
+++ b/doc/content/source/kernels/EEDFElasticTownsendLog.md
@@ -1,0 +1,23 @@
+# EEDFElasticTownsendLog
+
+!alert construction title=Undocumented Class
+The EEDFElasticTownsendLog has not been documented. The content listed below should be used as a starting point for
+documenting the class, which includes the typical automatic documentation associated with a
+MooseObject; however, what is contained is ultimately determined by what is necessary to make the
+documentation clear for users.
+
+!syntax description /Kernels/EEDFElasticTownsendLog
+
+## Overview
+
+!! Replace these lines with information regarding the EEDFElasticTownsendLog object.
+
+## Example Input File Syntax
+
+!! Describe and include an example of how to use the EEDFElasticTownsendLog object.
+
+!syntax parameters /Kernels/EEDFElasticTownsendLog
+
+!syntax inputs /Kernels/EEDFElasticTownsendLog
+
+!syntax children /Kernels/EEDFElasticTownsendLog

--- a/doc/content/source/kernels/EEDFEnergyLog.md
+++ b/doc/content/source/kernels/EEDFEnergyLog.md
@@ -1,0 +1,23 @@
+# EEDFEnergyLog
+
+!alert construction title=Undocumented Class
+The EEDFEnergyLog has not been documented. The content listed below should be used as a starting point for
+documenting the class, which includes the typical automatic documentation associated with a
+MooseObject; however, what is contained is ultimately determined by what is necessary to make the
+documentation clear for users.
+
+!syntax description /Kernels/EEDFEnergyLog
+
+## Overview
+
+!! Replace these lines with information regarding the EEDFEnergyLog object.
+
+## Example Input File Syntax
+
+!! Describe and include an example of how to use the EEDFEnergyLog object.
+
+!syntax parameters /Kernels/EEDFEnergyLog
+
+!syntax inputs /Kernels/EEDFEnergyLog
+
+!syntax children /Kernels/EEDFEnergyLog

--- a/doc/content/source/kernels/EEDFEnergyTownsendLog.md
+++ b/doc/content/source/kernels/EEDFEnergyTownsendLog.md
@@ -1,0 +1,23 @@
+# EEDFEnergyTownsendLog
+
+!alert construction title=Undocumented Class
+The EEDFEnergyTownsendLog has not been documented. The content listed below should be used as a starting point for
+documenting the class, which includes the typical automatic documentation associated with a
+MooseObject; however, what is contained is ultimately determined by what is necessary to make the
+documentation clear for users.
+
+!syntax description /Kernels/EEDFEnergyTownsendLog
+
+## Overview
+
+!! Replace these lines with information regarding the EEDFEnergyTownsendLog object.
+
+## Example Input File Syntax
+
+!! Describe and include an example of how to use the EEDFEnergyTownsendLog object.
+
+!syntax parameters /Kernels/EEDFEnergyTownsendLog
+
+!syntax inputs /Kernels/EEDFEnergyTownsendLog
+
+!syntax children /Kernels/EEDFEnergyTownsendLog

--- a/doc/content/source/kernels/EEDFReactionLog.md
+++ b/doc/content/source/kernels/EEDFReactionLog.md
@@ -1,0 +1,23 @@
+# EEDFReactionLog
+
+!alert construction title=Undocumented Class
+The EEDFReactionLog has not been documented. The content listed below should be used as a starting point for
+documenting the class, which includes the typical automatic documentation associated with a
+MooseObject; however, what is contained is ultimately determined by what is necessary to make the
+documentation clear for users.
+
+!syntax description /Kernels/EEDFReactionLog
+
+## Overview
+
+!! Replace these lines with information regarding the EEDFReactionLog object.
+
+## Example Input File Syntax
+
+!! Describe and include an example of how to use the EEDFReactionLog object.
+
+!syntax parameters /Kernels/EEDFReactionLog
+
+!syntax inputs /Kernels/EEDFReactionLog
+
+!syntax children /Kernels/EEDFReactionLog

--- a/doc/content/source/kernels/EEDFReactionTownsendLog.md
+++ b/doc/content/source/kernels/EEDFReactionTownsendLog.md
@@ -1,0 +1,23 @@
+# EEDFReactionTownsendLog
+
+!alert construction title=Undocumented Class
+The EEDFReactionTownsendLog has not been documented. The content listed below should be used as a starting point for
+documenting the class, which includes the typical automatic documentation associated with a
+MooseObject; however, what is contained is ultimately determined by what is necessary to make the
+documentation clear for users.
+
+!syntax description /Kernels/EEDFReactionTownsendLog
+
+## Overview
+
+!! Replace these lines with information regarding the EEDFReactionTownsendLog object.
+
+## Example Input File Syntax
+
+!! Describe and include an example of how to use the EEDFReactionTownsendLog object.
+
+!syntax parameters /Kernels/EEDFReactionTownsendLog
+
+!syntax inputs /Kernels/EEDFReactionTownsendLog
+
+!syntax children /Kernels/EEDFReactionTownsendLog

--- a/doc/content/source/kernels/ElectronEnergyTermElasticTownsend.md
+++ b/doc/content/source/kernels/ElectronEnergyTermElasticTownsend.md
@@ -1,1 +1,0 @@
-!template load file=stubs/moose_object.md.template name=ElectronEnergyTermElasticTownsend syntax=/Kernels/ElectronEnergyTermElasticTownsend

--- a/doc/content/source/kernels/ElectronEnergyTermTownsend.md
+++ b/doc/content/source/kernels/ElectronEnergyTermTownsend.md
@@ -1,1 +1,0 @@
-!template load file=stubs/moose_object.md.template name=ElectronEnergyTermTownsend syntax=/Kernels/ElectronEnergyTermTownsend

--- a/doc/content/source/kernels/ElectronImpactReactionProduct.md
+++ b/doc/content/source/kernels/ElectronImpactReactionProduct.md
@@ -1,1 +1,0 @@
-!template load file=stubs/moose_object.md.template name=ElectronImpactReactionProduct syntax=/Kernels/ElectronImpactReactionProduct

--- a/doc/content/source/kernels/ElectronImpactReactionReactant.md
+++ b/doc/content/source/kernels/ElectronImpactReactionReactant.md
@@ -1,1 +1,0 @@
-!template load file=stubs/moose_object.md.template name=ElectronImpactReactionReactant syntax=/Kernels/ElectronImpactReactionReactant

--- a/doc/content/source/kernels/ElectronProductSecondOrderLog.md
+++ b/doc/content/source/kernels/ElectronProductSecondOrderLog.md
@@ -1,1 +1,0 @@
-!template load file=stubs/moose_object.md.template name=ElectronProductSecondOrderLog syntax=/Kernels/ElectronProductSecondOrderLog

--- a/doc/content/source/kernels/ElectronReactantSecondOrderLog.md
+++ b/doc/content/source/kernels/ElectronReactantSecondOrderLog.md
@@ -1,1 +1,0 @@
-!template load file=stubs/moose_object.md.template name=ElectronReactantSecondOrderLog syntax=/Kernels/ElectronReactantSecondOrderLog

--- a/doc/content/source/kernels/EnergyTermRate.md
+++ b/doc/content/source/kernels/EnergyTermRate.md
@@ -1,1 +1,0 @@
-!template load file=stubs/moose_object.md.template name=EnergyTermRate syntax=/Kernels/EnergyTermRate

--- a/doc/content/source/kernels/LogStabilization.md
+++ b/doc/content/source/kernels/LogStabilization.md
@@ -1,1 +1,23 @@
-!template load file=stubs/moose_object.md.template name=LogStabilization syntax=/Kernels/LogStabilization
+# LogStabilization
+
+!alert construction title=Undocumented Class
+The LogStabilization has not been documented. The content listed below should be used as a starting point for
+documenting the class, which includes the typical automatic documentation associated with a
+MooseObject; however, what is contained is ultimately determined by what is necessary to make the
+documentation clear for users.
+
+!syntax description /Kernels/LogStabilization
+
+## Overview
+
+!! Replace these lines with information regarding the LogStabilization object.
+
+## Example Input File Syntax
+
+!! Describe and include an example of how to use the LogStabilization object.
+
+!syntax parameters /Kernels/LogStabilization
+
+!syntax inputs /Kernels/LogStabilization
+
+!syntax children /Kernels/LogStabilization

--- a/doc/content/source/kernels/ProductFirstOrder.md
+++ b/doc/content/source/kernels/ProductFirstOrder.md
@@ -1,1 +1,0 @@
-!template load file=stubs/moose_object.md.template name=ProductFirstOrder syntax=/Kernels/ProductFirstOrder

--- a/doc/content/source/kernels/ProductFirstOrderLog.md
+++ b/doc/content/source/kernels/ProductFirstOrderLog.md
@@ -1,1 +1,0 @@
-!template load file=stubs/moose_object.md.template name=ProductFirstOrderLog syntax=/Kernels/ProductFirstOrderLog

--- a/doc/content/source/kernels/ProductSecondOrder.md
+++ b/doc/content/source/kernels/ProductSecondOrder.md
@@ -1,1 +1,0 @@
-!template load file=stubs/moose_object.md.template name=ProductSecondOrder syntax=/Kernels/ProductSecondOrder

--- a/doc/content/source/kernels/ProductSecondOrderLog.md
+++ b/doc/content/source/kernels/ProductSecondOrderLog.md
@@ -1,1 +1,0 @@
-!template load file=stubs/moose_object.md.template name=ProductSecondOrderLog syntax=/Kernels/ProductSecondOrderLog

--- a/doc/content/source/kernels/ProductThirdOrder.md
+++ b/doc/content/source/kernels/ProductThirdOrder.md
@@ -1,1 +1,0 @@
-!template load file=stubs/moose_object.md.template name=ProductThirdOrder syntax=/Kernels/ProductThirdOrder

--- a/doc/content/source/kernels/ProductThirdOrderLog.md
+++ b/doc/content/source/kernels/ProductThirdOrderLog.md
@@ -1,1 +1,0 @@
-!template load file=stubs/moose_object.md.template name=ProductThirdOrderLog syntax=/Kernels/ProductThirdOrderLog

--- a/doc/content/source/kernels/ReactantFirstOrder.md
+++ b/doc/content/source/kernels/ReactantFirstOrder.md
@@ -1,1 +1,0 @@
-!template load file=stubs/moose_object.md.template name=ReactantFirstOrder syntax=/Kernels/ReactantFirstOrder

--- a/doc/content/source/kernels/ReactantFirstOrderLog.md
+++ b/doc/content/source/kernels/ReactantFirstOrderLog.md
@@ -1,1 +1,0 @@
-!template load file=stubs/moose_object.md.template name=ReactantFirstOrderLog syntax=/Kernels/ReactantFirstOrderLog

--- a/doc/content/source/kernels/ReactantSecondOrder.md
+++ b/doc/content/source/kernels/ReactantSecondOrder.md
@@ -1,1 +1,0 @@
-!template load file=stubs/moose_object.md.template name=ReactantSecondOrder syntax=/Kernels/ReactantSecondOrder

--- a/doc/content/source/kernels/ReactantSecondOrderLog.md
+++ b/doc/content/source/kernels/ReactantSecondOrderLog.md
@@ -1,1 +1,0 @@
-!template load file=stubs/moose_object.md.template name=ReactantSecondOrderLog syntax=/Kernels/ReactantSecondOrderLog

--- a/doc/content/source/kernels/ReactantThirdOrder.md
+++ b/doc/content/source/kernels/ReactantThirdOrder.md
@@ -1,1 +1,0 @@
-!template load file=stubs/moose_object.md.template name=ReactantThirdOrder syntax=/Kernels/ReactantThirdOrder

--- a/doc/content/source/kernels/ReactantThirdOrderLog.md
+++ b/doc/content/source/kernels/ReactantThirdOrderLog.md
@@ -1,1 +1,0 @@
-!template load file=stubs/moose_object.md.template name=ReactantThirdOrderLog syntax=/Kernels/ReactantThirdOrderLog

--- a/doc/content/source/kernels/ReactionFirstOrder.md
+++ b/doc/content/source/kernels/ReactionFirstOrder.md
@@ -1,0 +1,23 @@
+# ReactionFirstOrder
+
+!alert construction title=Undocumented Class
+The ReactionFirstOrder has not been documented. The content listed below should be used as a starting point for
+documenting the class, which includes the typical automatic documentation associated with a
+MooseObject; however, what is contained is ultimately determined by what is necessary to make the
+documentation clear for users.
+
+!syntax description /Kernels/ReactionFirstOrder
+
+## Overview
+
+!! Replace these lines with information regarding the ReactionFirstOrder object.
+
+## Example Input File Syntax
+
+!! Describe and include an example of how to use the ReactionFirstOrder object.
+
+!syntax parameters /Kernels/ReactionFirstOrder
+
+!syntax inputs /Kernels/ReactionFirstOrder
+
+!syntax children /Kernels/ReactionFirstOrder

--- a/doc/content/source/kernels/ReactionFirstOrderEnergy.md
+++ b/doc/content/source/kernels/ReactionFirstOrderEnergy.md
@@ -1,0 +1,23 @@
+# ReactionFirstOrderEnergy
+
+!alert construction title=Undocumented Class
+The ReactionFirstOrderEnergy has not been documented. The content listed below should be used as a starting point for
+documenting the class, which includes the typical automatic documentation associated with a
+MooseObject; however, what is contained is ultimately determined by what is necessary to make the
+documentation clear for users.
+
+!syntax description /Kernels/ReactionFirstOrderEnergy
+
+## Overview
+
+!! Replace these lines with information regarding the ReactionFirstOrderEnergy object.
+
+## Example Input File Syntax
+
+!! Describe and include an example of how to use the ReactionFirstOrderEnergy object.
+
+!syntax parameters /Kernels/ReactionFirstOrderEnergy
+
+!syntax inputs /Kernels/ReactionFirstOrderEnergy
+
+!syntax children /Kernels/ReactionFirstOrderEnergy

--- a/doc/content/source/kernels/ReactionFirstOrderEnergyLog.md
+++ b/doc/content/source/kernels/ReactionFirstOrderEnergyLog.md
@@ -1,0 +1,23 @@
+# ReactionFirstOrderEnergyLog
+
+!alert construction title=Undocumented Class
+The ReactionFirstOrderEnergyLog has not been documented. The content listed below should be used as a starting point for
+documenting the class, which includes the typical automatic documentation associated with a
+MooseObject; however, what is contained is ultimately determined by what is necessary to make the
+documentation clear for users.
+
+!syntax description /Kernels/ReactionFirstOrderEnergyLog
+
+## Overview
+
+!! Replace these lines with information regarding the ReactionFirstOrderEnergyLog object.
+
+## Example Input File Syntax
+
+!! Describe and include an example of how to use the ReactionFirstOrderEnergyLog object.
+
+!syntax parameters /Kernels/ReactionFirstOrderEnergyLog
+
+!syntax inputs /Kernels/ReactionFirstOrderEnergyLog
+
+!syntax children /Kernels/ReactionFirstOrderEnergyLog

--- a/doc/content/source/kernels/ReactionFirstOrderLog.md
+++ b/doc/content/source/kernels/ReactionFirstOrderLog.md
@@ -1,0 +1,23 @@
+# ReactionFirstOrderLog
+
+!alert construction title=Undocumented Class
+The ReactionFirstOrderLog has not been documented. The content listed below should be used as a starting point for
+documenting the class, which includes the typical automatic documentation associated with a
+MooseObject; however, what is contained is ultimately determined by what is necessary to make the
+documentation clear for users.
+
+!syntax description /Kernels/ReactionFirstOrderLog
+
+## Overview
+
+!! Replace these lines with information regarding the ReactionFirstOrderLog object.
+
+## Example Input File Syntax
+
+!! Describe and include an example of how to use the ReactionFirstOrderLog object.
+
+!syntax parameters /Kernels/ReactionFirstOrderLog
+
+!syntax inputs /Kernels/ReactionFirstOrderLog
+
+!syntax children /Kernels/ReactionFirstOrderLog

--- a/doc/content/source/kernels/ReactionSecondOrder.md
+++ b/doc/content/source/kernels/ReactionSecondOrder.md
@@ -1,0 +1,23 @@
+# ReactionSecondOrder
+
+!alert construction title=Undocumented Class
+The ReactionSecondOrder has not been documented. The content listed below should be used as a starting point for
+documenting the class, which includes the typical automatic documentation associated with a
+MooseObject; however, what is contained is ultimately determined by what is necessary to make the
+documentation clear for users.
+
+!syntax description /Kernels/ReactionSecondOrder
+
+## Overview
+
+!! Replace these lines with information regarding the ReactionSecondOrder object.
+
+## Example Input File Syntax
+
+!! Describe and include an example of how to use the ReactionSecondOrder object.
+
+!syntax parameters /Kernels/ReactionSecondOrder
+
+!syntax inputs /Kernels/ReactionSecondOrder
+
+!syntax children /Kernels/ReactionSecondOrder

--- a/doc/content/source/kernels/ReactionSecondOrderEnergy.md
+++ b/doc/content/source/kernels/ReactionSecondOrderEnergy.md
@@ -1,0 +1,23 @@
+# ReactionSecondOrderEnergy
+
+!alert construction title=Undocumented Class
+The ReactionSecondOrderEnergy has not been documented. The content listed below should be used as a starting point for
+documenting the class, which includes the typical automatic documentation associated with a
+MooseObject; however, what is contained is ultimately determined by what is necessary to make the
+documentation clear for users.
+
+!syntax description /Kernels/ReactionSecondOrderEnergy
+
+## Overview
+
+!! Replace these lines with information regarding the ReactionSecondOrderEnergy object.
+
+## Example Input File Syntax
+
+!! Describe and include an example of how to use the ReactionSecondOrderEnergy object.
+
+!syntax parameters /Kernels/ReactionSecondOrderEnergy
+
+!syntax inputs /Kernels/ReactionSecondOrderEnergy
+
+!syntax children /Kernels/ReactionSecondOrderEnergy

--- a/doc/content/source/kernels/ReactionSecondOrderEnergyLog.md
+++ b/doc/content/source/kernels/ReactionSecondOrderEnergyLog.md
@@ -1,0 +1,23 @@
+# ReactionSecondOrderEnergyLog
+
+!alert construction title=Undocumented Class
+The ReactionSecondOrderEnergyLog has not been documented. The content listed below should be used as a starting point for
+documenting the class, which includes the typical automatic documentation associated with a
+MooseObject; however, what is contained is ultimately determined by what is necessary to make the
+documentation clear for users.
+
+!syntax description /Kernels/ReactionSecondOrderEnergyLog
+
+## Overview
+
+!! Replace these lines with information regarding the ReactionSecondOrderEnergyLog object.
+
+## Example Input File Syntax
+
+!! Describe and include an example of how to use the ReactionSecondOrderEnergyLog object.
+
+!syntax parameters /Kernels/ReactionSecondOrderEnergyLog
+
+!syntax inputs /Kernels/ReactionSecondOrderEnergyLog
+
+!syntax children /Kernels/ReactionSecondOrderEnergyLog

--- a/doc/content/source/kernels/ReactionSecondOrderLog.md
+++ b/doc/content/source/kernels/ReactionSecondOrderLog.md
@@ -1,0 +1,23 @@
+# ReactionSecondOrderLog
+
+!alert construction title=Undocumented Class
+The ReactionSecondOrderLog has not been documented. The content listed below should be used as a starting point for
+documenting the class, which includes the typical automatic documentation associated with a
+MooseObject; however, what is contained is ultimately determined by what is necessary to make the
+documentation clear for users.
+
+!syntax description /Kernels/ReactionSecondOrderLog
+
+## Overview
+
+!! Replace these lines with information regarding the ReactionSecondOrderLog object.
+
+## Example Input File Syntax
+
+!! Describe and include an example of how to use the ReactionSecondOrderLog object.
+
+!syntax parameters /Kernels/ReactionSecondOrderLog
+
+!syntax inputs /Kernels/ReactionSecondOrderLog
+
+!syntax children /Kernels/ReactionSecondOrderLog

--- a/doc/content/source/kernels/ReactionThirdOrder.md
+++ b/doc/content/source/kernels/ReactionThirdOrder.md
@@ -1,0 +1,23 @@
+# ReactionThirdOrder
+
+!alert construction title=Undocumented Class
+The ReactionThirdOrder has not been documented. The content listed below should be used as a starting point for
+documenting the class, which includes the typical automatic documentation associated with a
+MooseObject; however, what is contained is ultimately determined by what is necessary to make the
+documentation clear for users.
+
+!syntax description /Kernels/ReactionThirdOrder
+
+## Overview
+
+!! Replace these lines with information regarding the ReactionThirdOrder object.
+
+## Example Input File Syntax
+
+!! Describe and include an example of how to use the ReactionThirdOrder object.
+
+!syntax parameters /Kernels/ReactionThirdOrder
+
+!syntax inputs /Kernels/ReactionThirdOrder
+
+!syntax children /Kernels/ReactionThirdOrder

--- a/doc/content/source/kernels/ReactionThirdOrderEnergy.md
+++ b/doc/content/source/kernels/ReactionThirdOrderEnergy.md
@@ -1,0 +1,23 @@
+# ReactionThirdOrderEnergy
+
+!alert construction title=Undocumented Class
+The ReactionThirdOrderEnergy has not been documented. The content listed below should be used as a starting point for
+documenting the class, which includes the typical automatic documentation associated with a
+MooseObject; however, what is contained is ultimately determined by what is necessary to make the
+documentation clear for users.
+
+!syntax description /Kernels/ReactionThirdOrderEnergy
+
+## Overview
+
+!! Replace these lines with information regarding the ReactionThirdOrderEnergy object.
+
+## Example Input File Syntax
+
+!! Describe and include an example of how to use the ReactionThirdOrderEnergy object.
+
+!syntax parameters /Kernels/ReactionThirdOrderEnergy
+
+!syntax inputs /Kernels/ReactionThirdOrderEnergy
+
+!syntax children /Kernels/ReactionThirdOrderEnergy

--- a/doc/content/source/kernels/ReactionThirdOrderEnergyLog.md
+++ b/doc/content/source/kernels/ReactionThirdOrderEnergyLog.md
@@ -1,0 +1,23 @@
+# ReactionThirdOrderEnergyLog
+
+!alert construction title=Undocumented Class
+The ReactionThirdOrderEnergyLog has not been documented. The content listed below should be used as a starting point for
+documenting the class, which includes the typical automatic documentation associated with a
+MooseObject; however, what is contained is ultimately determined by what is necessary to make the
+documentation clear for users.
+
+!syntax description /Kernels/ReactionThirdOrderEnergyLog
+
+## Overview
+
+!! Replace these lines with information regarding the ReactionThirdOrderEnergyLog object.
+
+## Example Input File Syntax
+
+!! Describe and include an example of how to use the ReactionThirdOrderEnergyLog object.
+
+!syntax parameters /Kernels/ReactionThirdOrderEnergyLog
+
+!syntax inputs /Kernels/ReactionThirdOrderEnergyLog
+
+!syntax children /Kernels/ReactionThirdOrderEnergyLog

--- a/doc/content/source/kernels/ReactionThirdOrderLog.md
+++ b/doc/content/source/kernels/ReactionThirdOrderLog.md
@@ -1,0 +1,23 @@
+# ReactionThirdOrderLog
+
+!alert construction title=Undocumented Class
+The ReactionThirdOrderLog has not been documented. The content listed below should be used as a starting point for
+documenting the class, which includes the typical automatic documentation associated with a
+MooseObject; however, what is contained is ultimately determined by what is necessary to make the
+documentation clear for users.
+
+!syntax description /Kernels/ReactionThirdOrderLog
+
+## Overview
+
+!! Replace these lines with information regarding the ReactionThirdOrderLog object.
+
+## Example Input File Syntax
+
+!! Describe and include an example of how to use the ReactionThirdOrderLog object.
+
+!syntax parameters /Kernels/ReactionThirdOrderLog
+
+!syntax inputs /Kernels/ReactionThirdOrderLog
+
+!syntax children /Kernels/ReactionThirdOrderLog

--- a/doc/content/source/kernels/TimeDerivativeLog.md
+++ b/doc/content/source/kernels/TimeDerivativeLog.md
@@ -1,1 +1,23 @@
-!template load file=stubs/moose_object.md.template name=TimeDerivativeLog syntax=/Kernels/TimeDerivativeLog
+# TimeDerivativeLog
+
+!alert construction title=Undocumented Class
+The TimeDerivativeLog has not been documented. The content listed below should be used as a starting point for
+documenting the class, which includes the typical automatic documentation associated with a
+MooseObject; however, what is contained is ultimately determined by what is necessary to make the
+documentation clear for users.
+
+!syntax description /Kernels/TimeDerivativeLog
+
+## Overview
+
+!! Replace these lines with information regarding the TimeDerivativeLog object.
+
+## Example Input File Syntax
+
+!! Describe and include an example of how to use the TimeDerivativeLog object.
+
+!syntax parameters /Kernels/TimeDerivativeLog
+
+!syntax inputs /Kernels/TimeDerivativeLog
+
+!syntax children /Kernels/TimeDerivativeLog

--- a/doc/content/source/materials/ADEEDFRateConstantTownsend.md
+++ b/doc/content/source/materials/ADEEDFRateConstantTownsend.md
@@ -1,0 +1,23 @@
+# ADEEDFRateConstantTownsend
+
+!alert construction title=Undocumented Class
+The ADEEDFRateConstantTownsend has not been documented. The content listed below should be used as a starting point for
+documenting the class, which includes the typical automatic documentation associated with a
+MooseObject; however, what is contained is ultimately determined by what is necessary to make the
+documentation clear for users.
+
+!syntax description /Materials/ADEEDFRateConstantTownsend
+
+## Overview
+
+!! Replace these lines with information regarding the ADEEDFRateConstantTownsend object.
+
+## Example Input File Syntax
+
+!! Describe and include an example of how to use the ADEEDFRateConstantTownsend object.
+
+!syntax parameters /Materials/ADEEDFRateConstantTownsend
+
+!syntax inputs /Materials/ADEEDFRateConstantTownsend
+
+!syntax children /Materials/ADEEDFRateConstantTownsend

--- a/doc/content/source/materials/ADZapdosEEDFRateConstant.md
+++ b/doc/content/source/materials/ADZapdosEEDFRateConstant.md
@@ -1,0 +1,23 @@
+# ADZapdosEEDFRateConstant
+
+!alert construction title=Undocumented Class
+The ADZapdosEEDFRateConstant has not been documented. The content listed below should be used as a starting point for
+documenting the class, which includes the typical automatic documentation associated with a
+MooseObject; however, what is contained is ultimately determined by what is necessary to make the
+documentation clear for users.
+
+!syntax description /Materials/ADZapdosEEDFRateConstant
+
+## Overview
+
+!! Replace these lines with information regarding the ADZapdosEEDFRateConstant object.
+
+## Example Input File Syntax
+
+!! Describe and include an example of how to use the ADZapdosEEDFRateConstant object.
+
+!syntax parameters /Materials/ADZapdosEEDFRateConstant
+
+!syntax inputs /Materials/ADZapdosEEDFRateConstant
+
+!syntax children /Materials/ADZapdosEEDFRateConstant

--- a/doc/content/source/materials/DiffusionRateTemp.md
+++ b/doc/content/source/materials/DiffusionRateTemp.md
@@ -1,1 +1,23 @@
-!template load file=stubs/moose_object.md.template name=DiffusionRateTemp syntax=/Materials/DiffusionRateTemp
+# DiffusionRateTemp
+
+!alert construction title=Undocumented Class
+The DiffusionRateTemp has not been documented. The content listed below should be used as a starting point for
+documenting the class, which includes the typical automatic documentation associated with a
+MooseObject; however, what is contained is ultimately determined by what is necessary to make the
+documentation clear for users.
+
+!syntax description /Materials/DiffusionRateTemp
+
+## Overview
+
+!! Replace these lines with information regarding the DiffusionRateTemp object.
+
+## Example Input File Syntax
+
+!! Describe and include an example of how to use the DiffusionRateTemp object.
+
+!syntax parameters /Materials/DiffusionRateTemp
+
+!syntax inputs /Materials/DiffusionRateTemp
+
+!syntax children /Materials/DiffusionRateTemp

--- a/doc/content/source/materials/EEDFRateConstant.md
+++ b/doc/content/source/materials/EEDFRateConstant.md
@@ -1,1 +1,23 @@
-!template load file=stubs/moose_object.md.template name=EEDFRateConstant syntax=/Materials/EEDFRateConstant
+# EEDFRateConstant
+
+!alert construction title=Undocumented Class
+The EEDFRateConstant has not been documented. The content listed below should be used as a starting point for
+documenting the class, which includes the typical automatic documentation associated with a
+MooseObject; however, what is contained is ultimately determined by what is necessary to make the
+documentation clear for users.
+
+!syntax description /Materials/EEDFRateConstant
+
+## Overview
+
+!! Replace these lines with information regarding the EEDFRateConstant object.
+
+## Example Input File Syntax
+
+!! Describe and include an example of how to use the EEDFRateConstant object.
+
+!syntax parameters /Materials/EEDFRateConstant
+
+!syntax inputs /Materials/EEDFRateConstant
+
+!syntax children /Materials/EEDFRateConstant

--- a/doc/content/source/materials/EEDFRateConstantTownsend.md
+++ b/doc/content/source/materials/EEDFRateConstantTownsend.md
@@ -1,1 +1,23 @@
-!template load file=stubs/moose_object.md.template name=EEDFRateConstantTownsend syntax=/Materials/EEDFRateConstantTownsend
+# EEDFRateConstantTownsend
+
+!alert construction title=Undocumented Class
+The EEDFRateConstantTownsend has not been documented. The content listed below should be used as a starting point for
+documenting the class, which includes the typical automatic documentation associated with a
+MooseObject; however, what is contained is ultimately determined by what is necessary to make the
+documentation clear for users.
+
+!syntax description /Materials/EEDFRateConstantTownsend
+
+## Overview
+
+!! Replace these lines with information regarding the EEDFRateConstantTownsend object.
+
+## Example Input File Syntax
+
+!! Describe and include an example of how to use the EEDFRateConstantTownsend object.
+
+!syntax parameters /Materials/EEDFRateConstantTownsend
+
+!syntax inputs /Materials/EEDFRateConstantTownsend
+
+!syntax children /Materials/EEDFRateConstantTownsend

--- a/doc/content/source/materials/ElectricField.md
+++ b/doc/content/source/materials/ElectricField.md
@@ -1,1 +1,23 @@
-!template load file=stubs/moose_object.md.template name=ElectricField syntax=/Materials/ElectricField
+# ElectricField
+
+!alert construction title=Undocumented Class
+The ElectricField has not been documented. The content listed below should be used as a starting point for
+documenting the class, which includes the typical automatic documentation associated with a
+MooseObject; however, what is contained is ultimately determined by what is necessary to make the
+documentation clear for users.
+
+!syntax description /Materials/ElectricField
+
+## Overview
+
+!! Replace these lines with information regarding the ElectricField object.
+
+## Example Input File Syntax
+
+!! Describe and include an example of how to use the ElectricField object.
+
+!syntax parameters /Materials/ElectricField
+
+!syntax inputs /Materials/ElectricField
+
+!syntax children /Materials/ElectricField

--- a/doc/content/source/materials/GenericRateConstant.md
+++ b/doc/content/source/materials/GenericRateConstant.md
@@ -1,1 +1,23 @@
-!template load file=stubs/moose_object.md.template name=GenericRateConstant syntax=/Materials/GenericRateConstant
+# GenericRateConstant
+
+!alert construction title=Undocumented Class
+The GenericRateConstant has not been documented. The content listed below should be used as a starting point for
+documenting the class, which includes the typical automatic documentation associated with a
+MooseObject; however, what is contained is ultimately determined by what is necessary to make the
+documentation clear for users.
+
+!syntax description /Materials/GenericRateConstant
+
+## Overview
+
+!! Replace these lines with information regarding the GenericRateConstant object.
+
+## Example Input File Syntax
+
+!! Describe and include an example of how to use the GenericRateConstant object.
+
+!syntax parameters /Materials/GenericRateConstant
+
+!syntax inputs /Materials/GenericRateConstant
+
+!syntax children /Materials/GenericRateConstant

--- a/doc/content/source/materials/HeatCapacityRatio.md
+++ b/doc/content/source/materials/HeatCapacityRatio.md
@@ -1,1 +1,23 @@
-!template load file=stubs/moose_object.md.template name=HeatCapacityRatio syntax=/Materials/HeatCapacityRatio
+# HeatCapacityRatio
+
+!alert construction title=Undocumented Class
+The HeatCapacityRatio has not been documented. The content listed below should be used as a starting point for
+documenting the class, which includes the typical automatic documentation associated with a
+MooseObject; however, what is contained is ultimately determined by what is necessary to make the
+documentation clear for users.
+
+!syntax description /Materials/HeatCapacityRatio
+
+## Overview
+
+!! Replace these lines with information regarding the HeatCapacityRatio object.
+
+## Example Input File Syntax
+
+!! Describe and include an example of how to use the HeatCapacityRatio object.
+
+!syntax parameters /Materials/HeatCapacityRatio
+
+!syntax inputs /Materials/HeatCapacityRatio
+
+!syntax children /Materials/HeatCapacityRatio

--- a/doc/content/source/materials/InterpolatedCoefficientLinear.md
+++ b/doc/content/source/materials/InterpolatedCoefficientLinear.md
@@ -1,0 +1,23 @@
+# InterpolatedCoefficientLinear
+
+!alert construction title=Undocumented Class
+The InterpolatedCoefficientLinear has not been documented. The content listed below should be used as a starting point for
+documenting the class, which includes the typical automatic documentation associated with a
+MooseObject; however, what is contained is ultimately determined by what is necessary to make the
+documentation clear for users.
+
+!syntax description /Materials/InterpolatedCoefficientLinear
+
+## Overview
+
+!! Replace these lines with information regarding the InterpolatedCoefficientLinear object.
+
+## Example Input File Syntax
+
+!! Describe and include an example of how to use the InterpolatedCoefficientLinear object.
+
+!syntax parameters /Materials/InterpolatedCoefficientLinear
+
+!syntax inputs /Materials/InterpolatedCoefficientLinear
+
+!syntax children /Materials/InterpolatedCoefficientLinear

--- a/doc/content/source/materials/InterpolatedCoefficientSpline.md
+++ b/doc/content/source/materials/InterpolatedCoefficientSpline.md
@@ -1,0 +1,23 @@
+# InterpolatedCoefficientSpline
+
+!alert construction title=Undocumented Class
+The InterpolatedCoefficientSpline has not been documented. The content listed below should be used as a starting point for
+documenting the class, which includes the typical automatic documentation associated with a
+MooseObject; however, what is contained is ultimately determined by what is necessary to make the
+documentation clear for users.
+
+!syntax description /Materials/InterpolatedCoefficientSpline
+
+## Overview
+
+!! Replace these lines with information regarding the InterpolatedCoefficientSpline object.
+
+## Example Input File Syntax
+
+!! Describe and include an example of how to use the InterpolatedCoefficientSpline object.
+
+!syntax parameters /Materials/InterpolatedCoefficientSpline
+
+!syntax inputs /Materials/InterpolatedCoefficientSpline
+
+!syntax children /Materials/InterpolatedCoefficientSpline

--- a/doc/content/source/materials/SpeciesSum.md
+++ b/doc/content/source/materials/SpeciesSum.md
@@ -1,1 +1,23 @@
-!template load file=stubs/moose_object.md.template name=SpeciesSum syntax=/Materials/SpeciesSum
+# SpeciesSum
+
+!alert construction title=Undocumented Class
+The SpeciesSum has not been documented. The content listed below should be used as a starting point for
+documenting the class, which includes the typical automatic documentation associated with a
+MooseObject; however, what is contained is ultimately determined by what is necessary to make the
+documentation clear for users.
+
+!syntax description /Materials/SpeciesSum
+
+## Overview
+
+!! Replace these lines with information regarding the SpeciesSum object.
+
+## Example Input File Syntax
+
+!! Describe and include an example of how to use the SpeciesSum object.
+
+!syntax parameters /Materials/SpeciesSum
+
+!syntax inputs /Materials/SpeciesSum
+
+!syntax children /Materials/SpeciesSum

--- a/doc/content/source/materials/SuperelasticReactionRate.md
+++ b/doc/content/source/materials/SuperelasticReactionRate.md
@@ -1,1 +1,23 @@
-!template load file=stubs/moose_object.md.template name=SuperelasticReactionRate syntax=/Materials/SuperelasticReactionRate
+# SuperelasticReactionRate
+
+!alert construction title=Undocumented Class
+The SuperelasticReactionRate has not been documented. The content listed below should be used as a starting point for
+documenting the class, which includes the typical automatic documentation associated with a
+MooseObject; however, what is contained is ultimately determined by what is necessary to make the
+documentation clear for users.
+
+!syntax description /Materials/SuperelasticReactionRate
+
+## Overview
+
+!! Replace these lines with information regarding the SuperelasticReactionRate object.
+
+## Example Input File Syntax
+
+!! Describe and include an example of how to use the SuperelasticReactionRate object.
+
+!syntax parameters /Materials/SuperelasticReactionRate
+
+!syntax inputs /Materials/SuperelasticReactionRate
+
+!syntax children /Materials/SuperelasticReactionRate

--- a/doc/content/source/materials/ZapdosEEDFRateConstant.md
+++ b/doc/content/source/materials/ZapdosEEDFRateConstant.md
@@ -1,1 +1,23 @@
-!template load file=stubs/moose_object.md.template name=ZapdosEEDFRateConstant syntax=/Materials/ZapdosEEDFRateConstant
+# ZapdosEEDFRateConstant
+
+!alert construction title=Undocumented Class
+The ZapdosEEDFRateConstant has not been documented. The content listed below should be used as a starting point for
+documenting the class, which includes the typical automatic documentation associated with a
+MooseObject; however, what is contained is ultimately determined by what is necessary to make the
+documentation clear for users.
+
+!syntax description /Materials/ZapdosEEDFRateConstant
+
+## Overview
+
+!! Replace these lines with information regarding the ZapdosEEDFRateConstant object.
+
+## Example Input File Syntax
+
+!! Describe and include an example of how to use the ZapdosEEDFRateConstant object.
+
+!syntax parameters /Materials/ZapdosEEDFRateConstant
+
+!syntax inputs /Materials/ZapdosEEDFRateConstant
+
+!syntax children /Materials/ZapdosEEDFRateConstant

--- a/doc/content/source/postprocessors/ElectricFieldCalculator.md
+++ b/doc/content/source/postprocessors/ElectricFieldCalculator.md
@@ -1,1 +1,23 @@
-!template load file=stubs/moose_object.md.template name=ElectricFieldCalculator syntax=/Postprocessors/ElectricFieldCalculator
+# ElectricFieldCalculator
+
+!alert construction title=Undocumented Class
+The ElectricFieldCalculator has not been documented. The content listed below should be used as a starting point for
+documenting the class, which includes the typical automatic documentation associated with a
+MooseObject; however, what is contained is ultimately determined by what is necessary to make the
+documentation clear for users.
+
+!syntax description /Postprocessors/ElectricFieldCalculator
+
+## Overview
+
+!! Replace these lines with information regarding the ElectricFieldCalculator object.
+
+## Example Input File Syntax
+
+!! Describe and include an example of how to use the ElectricFieldCalculator object.
+
+!syntax parameters /Postprocessors/ElectricFieldCalculator
+
+!syntax inputs /Postprocessors/ElectricFieldCalculator
+
+!syntax children /Postprocessors/ElectricFieldCalculator

--- a/doc/content/source/scalarkernels/EnergyTermScalar.md
+++ b/doc/content/source/scalarkernels/EnergyTermScalar.md
@@ -1,1 +1,23 @@
-!template load file=stubs/moose_object.md.template name=EnergyTermScalar syntax=/ScalarKernels/EnergyTermScalar
+# EnergyTermScalar
+
+!alert construction title=Undocumented Class
+The EnergyTermScalar has not been documented. The content listed below should be used as a starting point for
+documenting the class, which includes the typical automatic documentation associated with a
+MooseObject; however, what is contained is ultimately determined by what is necessary to make the
+documentation clear for users.
+
+!syntax description /ScalarKernels/EnergyTermScalar
+
+## Overview
+
+!! Replace these lines with information regarding the EnergyTermScalar object.
+
+## Example Input File Syntax
+
+!! Describe and include an example of how to use the EnergyTermScalar object.
+
+!syntax parameters /ScalarKernels/EnergyTermScalar
+
+!syntax inputs /ScalarKernels/EnergyTermScalar
+
+!syntax children /ScalarKernels/EnergyTermScalar

--- a/doc/content/source/scalarkernels/LogStabilizationScalar.md
+++ b/doc/content/source/scalarkernels/LogStabilizationScalar.md
@@ -1,1 +1,23 @@
-!template load file=stubs/moose_object.md.template name=LogStabilizationScalar syntax=/ScalarKernels/LogStabilizationScalar
+# LogStabilizationScalar
+
+!alert construction title=Undocumented Class
+The LogStabilizationScalar has not been documented. The content listed below should be used as a starting point for
+documenting the class, which includes the typical automatic documentation associated with a
+MooseObject; however, what is contained is ultimately determined by what is necessary to make the
+documentation clear for users.
+
+!syntax description /ScalarKernels/LogStabilizationScalar
+
+## Overview
+
+!! Replace these lines with information regarding the LogStabilizationScalar object.
+
+## Example Input File Syntax
+
+!! Describe and include an example of how to use the LogStabilizationScalar object.
+
+!syntax parameters /ScalarKernels/LogStabilizationScalar
+
+!syntax inputs /ScalarKernels/LogStabilizationScalar
+
+!syntax children /ScalarKernels/LogStabilizationScalar

--- a/doc/content/source/scalarkernels/ODETimeDerivativeLog.md
+++ b/doc/content/source/scalarkernels/ODETimeDerivativeLog.md
@@ -1,1 +1,23 @@
-!template load file=stubs/moose_object.md.template name=ODETimeDerivativeLog syntax=/ScalarKernels/ODETimeDerivativeLog
+# ODETimeDerivativeLog
+
+!alert construction title=Undocumented Class
+The ODETimeDerivativeLog has not been documented. The content listed below should be used as a starting point for
+documenting the class, which includes the typical automatic documentation associated with a
+MooseObject; however, what is contained is ultimately determined by what is necessary to make the
+documentation clear for users.
+
+!syntax description /ScalarKernels/ODETimeDerivativeLog
+
+## Overview
+
+!! Replace these lines with information regarding the ODETimeDerivativeLog object.
+
+## Example Input File Syntax
+
+!! Describe and include an example of how to use the ODETimeDerivativeLog object.
+
+!syntax parameters /ScalarKernels/ODETimeDerivativeLog
+
+!syntax inputs /ScalarKernels/ODETimeDerivativeLog
+
+!syntax children /ScalarKernels/ODETimeDerivativeLog

--- a/doc/content/source/scalarkernels/ODETimeDerivativeTemperature.md
+++ b/doc/content/source/scalarkernels/ODETimeDerivativeTemperature.md
@@ -1,1 +1,23 @@
-!template load file=stubs/moose_object.md.template name=ODETimeDerivativeTemperature syntax=/ScalarKernels/ODETimeDerivativeTemperature
+# ODETimeDerivativeTemperature
+
+!alert construction title=Undocumented Class
+The ODETimeDerivativeTemperature has not been documented. The content listed below should be used as a starting point for
+documenting the class, which includes the typical automatic documentation associated with a
+MooseObject; however, what is contained is ultimately determined by what is necessary to make the
+documentation clear for users.
+
+!syntax description /ScalarKernels/ODETimeDerivativeTemperature
+
+## Overview
+
+!! Replace these lines with information regarding the ODETimeDerivativeTemperature object.
+
+## Example Input File Syntax
+
+!! Describe and include an example of how to use the ODETimeDerivativeTemperature object.
+
+!syntax parameters /ScalarKernels/ODETimeDerivativeTemperature
+
+!syntax inputs /ScalarKernels/ODETimeDerivativeTemperature
+
+!syntax children /ScalarKernels/ODETimeDerivativeTemperature

--- a/doc/content/source/scalarkernels/ParsedScalarReaction.md
+++ b/doc/content/source/scalarkernels/ParsedScalarReaction.md
@@ -1,1 +1,23 @@
-!template load file=stubs/moose_object.md.template name=ParsedScalarReaction syntax=/ScalarKernels/ParsedScalarReaction
+# ParsedScalarReaction
+
+!alert construction title=Undocumented Class
+The ParsedScalarReaction has not been documented. The content listed below should be used as a starting point for
+documenting the class, which includes the typical automatic documentation associated with a
+MooseObject; however, what is contained is ultimately determined by what is necessary to make the
+documentation clear for users.
+
+!syntax description /ScalarKernels/ParsedScalarReaction
+
+## Overview
+
+!! Replace these lines with information regarding the ParsedScalarReaction object.
+
+## Example Input File Syntax
+
+!! Describe and include an example of how to use the ParsedScalarReaction object.
+
+!syntax parameters /ScalarKernels/ParsedScalarReaction
+
+!syntax inputs /ScalarKernels/ParsedScalarReaction
+
+!syntax children /ScalarKernels/ParsedScalarReaction

--- a/doc/content/source/scalarkernels/Product1BodyScalar.md
+++ b/doc/content/source/scalarkernels/Product1BodyScalar.md
@@ -1,1 +1,23 @@
-!template load file=stubs/moose_object.md.template name=Product1BodyScalar syntax=/ScalarKernels/Product1BodyScalar
+# Product1BodyScalar
+
+!alert construction title=Undocumented Class
+The Product1BodyScalar has not been documented. The content listed below should be used as a starting point for
+documenting the class, which includes the typical automatic documentation associated with a
+MooseObject; however, what is contained is ultimately determined by what is necessary to make the
+documentation clear for users.
+
+!syntax description /ScalarKernels/Product1BodyScalar
+
+## Overview
+
+!! Replace these lines with information regarding the Product1BodyScalar object.
+
+## Example Input File Syntax
+
+!! Describe and include an example of how to use the Product1BodyScalar object.
+
+!syntax parameters /ScalarKernels/Product1BodyScalar
+
+!syntax inputs /ScalarKernels/Product1BodyScalar
+
+!syntax children /ScalarKernels/Product1BodyScalar

--- a/doc/content/source/scalarkernels/Product1BodyScalarLog.md
+++ b/doc/content/source/scalarkernels/Product1BodyScalarLog.md
@@ -1,1 +1,23 @@
-!template load file=stubs/moose_object.md.template name=Product1BodyScalarLog syntax=/ScalarKernels/Product1BodyScalarLog
+# Product1BodyScalarLog
+
+!alert construction title=Undocumented Class
+The Product1BodyScalarLog has not been documented. The content listed below should be used as a starting point for
+documenting the class, which includes the typical automatic documentation associated with a
+MooseObject; however, what is contained is ultimately determined by what is necessary to make the
+documentation clear for users.
+
+!syntax description /ScalarKernels/Product1BodyScalarLog
+
+## Overview
+
+!! Replace these lines with information regarding the Product1BodyScalarLog object.
+
+## Example Input File Syntax
+
+!! Describe and include an example of how to use the Product1BodyScalarLog object.
+
+!syntax parameters /ScalarKernels/Product1BodyScalarLog
+
+!syntax inputs /ScalarKernels/Product1BodyScalarLog
+
+!syntax children /ScalarKernels/Product1BodyScalarLog

--- a/doc/content/source/scalarkernels/Product2BodyScalar.md
+++ b/doc/content/source/scalarkernels/Product2BodyScalar.md
@@ -1,1 +1,23 @@
-!template load file=stubs/moose_object.md.template name=Product2BodyScalar syntax=/ScalarKernels/Product2BodyScalar
+# Product2BodyScalar
+
+!alert construction title=Undocumented Class
+The Product2BodyScalar has not been documented. The content listed below should be used as a starting point for
+documenting the class, which includes the typical automatic documentation associated with a
+MooseObject; however, what is contained is ultimately determined by what is necessary to make the
+documentation clear for users.
+
+!syntax description /ScalarKernels/Product2BodyScalar
+
+## Overview
+
+!! Replace these lines with information regarding the Product2BodyScalar object.
+
+## Example Input File Syntax
+
+!! Describe and include an example of how to use the Product2BodyScalar object.
+
+!syntax parameters /ScalarKernels/Product2BodyScalar
+
+!syntax inputs /ScalarKernels/Product2BodyScalar
+
+!syntax children /ScalarKernels/Product2BodyScalar

--- a/doc/content/source/scalarkernels/Product2BodyScalarLog.md
+++ b/doc/content/source/scalarkernels/Product2BodyScalarLog.md
@@ -1,1 +1,23 @@
-!template load file=stubs/moose_object.md.template name=Product2BodyScalarLog syntax=/ScalarKernels/Product2BodyScalarLog
+# Product2BodyScalarLog
+
+!alert construction title=Undocumented Class
+The Product2BodyScalarLog has not been documented. The content listed below should be used as a starting point for
+documenting the class, which includes the typical automatic documentation associated with a
+MooseObject; however, what is contained is ultimately determined by what is necessary to make the
+documentation clear for users.
+
+!syntax description /ScalarKernels/Product2BodyScalarLog
+
+## Overview
+
+!! Replace these lines with information regarding the Product2BodyScalarLog object.
+
+## Example Input File Syntax
+
+!! Describe and include an example of how to use the Product2BodyScalarLog object.
+
+!syntax parameters /ScalarKernels/Product2BodyScalarLog
+
+!syntax inputs /ScalarKernels/Product2BodyScalarLog
+
+!syntax children /ScalarKernels/Product2BodyScalarLog

--- a/doc/content/source/scalarkernels/Product3BodyScalar.md
+++ b/doc/content/source/scalarkernels/Product3BodyScalar.md
@@ -1,1 +1,23 @@
-!template load file=stubs/moose_object.md.template name=Product3BodyScalar syntax=/ScalarKernels/Product3BodyScalar
+# Product3BodyScalar
+
+!alert construction title=Undocumented Class
+The Product3BodyScalar has not been documented. The content listed below should be used as a starting point for
+documenting the class, which includes the typical automatic documentation associated with a
+MooseObject; however, what is contained is ultimately determined by what is necessary to make the
+documentation clear for users.
+
+!syntax description /ScalarKernels/Product3BodyScalar
+
+## Overview
+
+!! Replace these lines with information regarding the Product3BodyScalar object.
+
+## Example Input File Syntax
+
+!! Describe and include an example of how to use the Product3BodyScalar object.
+
+!syntax parameters /ScalarKernels/Product3BodyScalar
+
+!syntax inputs /ScalarKernels/Product3BodyScalar
+
+!syntax children /ScalarKernels/Product3BodyScalar

--- a/doc/content/source/scalarkernels/Product3BodyScalarLog.md
+++ b/doc/content/source/scalarkernels/Product3BodyScalarLog.md
@@ -1,1 +1,23 @@
-!template load file=stubs/moose_object.md.template name=Product3BodyScalarLog syntax=/ScalarKernels/Product3BodyScalarLog
+# Product3BodyScalarLog
+
+!alert construction title=Undocumented Class
+The Product3BodyScalarLog has not been documented. The content listed below should be used as a starting point for
+documenting the class, which includes the typical automatic documentation associated with a
+MooseObject; however, what is contained is ultimately determined by what is necessary to make the
+documentation clear for users.
+
+!syntax description /ScalarKernels/Product3BodyScalarLog
+
+## Overview
+
+!! Replace these lines with information regarding the Product3BodyScalarLog object.
+
+## Example Input File Syntax
+
+!! Describe and include an example of how to use the Product3BodyScalarLog object.
+
+!syntax parameters /ScalarKernels/Product3BodyScalarLog
+
+!syntax inputs /ScalarKernels/Product3BodyScalarLog
+
+!syntax children /ScalarKernels/Product3BodyScalarLog

--- a/doc/content/source/scalarkernels/Reactant1BodyScalar.md
+++ b/doc/content/source/scalarkernels/Reactant1BodyScalar.md
@@ -1,1 +1,23 @@
-!template load file=stubs/moose_object.md.template name=Reactant1BodyScalar syntax=/ScalarKernels/Reactant1BodyScalar
+# Reactant1BodyScalar
+
+!alert construction title=Undocumented Class
+The Reactant1BodyScalar has not been documented. The content listed below should be used as a starting point for
+documenting the class, which includes the typical automatic documentation associated with a
+MooseObject; however, what is contained is ultimately determined by what is necessary to make the
+documentation clear for users.
+
+!syntax description /ScalarKernels/Reactant1BodyScalar
+
+## Overview
+
+!! Replace these lines with information regarding the Reactant1BodyScalar object.
+
+## Example Input File Syntax
+
+!! Describe and include an example of how to use the Reactant1BodyScalar object.
+
+!syntax parameters /ScalarKernels/Reactant1BodyScalar
+
+!syntax inputs /ScalarKernels/Reactant1BodyScalar
+
+!syntax children /ScalarKernels/Reactant1BodyScalar

--- a/doc/content/source/scalarkernels/Reactant1BodyScalarLog.md
+++ b/doc/content/source/scalarkernels/Reactant1BodyScalarLog.md
@@ -1,1 +1,23 @@
-!template load file=stubs/moose_object.md.template name=Reactant1BodyScalarLog syntax=/ScalarKernels/Reactant1BodyScalarLog
+# Reactant1BodyScalarLog
+
+!alert construction title=Undocumented Class
+The Reactant1BodyScalarLog has not been documented. The content listed below should be used as a starting point for
+documenting the class, which includes the typical automatic documentation associated with a
+MooseObject; however, what is contained is ultimately determined by what is necessary to make the
+documentation clear for users.
+
+!syntax description /ScalarKernels/Reactant1BodyScalarLog
+
+## Overview
+
+!! Replace these lines with information regarding the Reactant1BodyScalarLog object.
+
+## Example Input File Syntax
+
+!! Describe and include an example of how to use the Reactant1BodyScalarLog object.
+
+!syntax parameters /ScalarKernels/Reactant1BodyScalarLog
+
+!syntax inputs /ScalarKernels/Reactant1BodyScalarLog
+
+!syntax children /ScalarKernels/Reactant1BodyScalarLog

--- a/doc/content/source/scalarkernels/Reactant2BodyScalar.md
+++ b/doc/content/source/scalarkernels/Reactant2BodyScalar.md
@@ -1,1 +1,23 @@
-!template load file=stubs/moose_object.md.template name=Reactant2BodyScalar syntax=/ScalarKernels/Reactant2BodyScalar
+# Reactant2BodyScalar
+
+!alert construction title=Undocumented Class
+The Reactant2BodyScalar has not been documented. The content listed below should be used as a starting point for
+documenting the class, which includes the typical automatic documentation associated with a
+MooseObject; however, what is contained is ultimately determined by what is necessary to make the
+documentation clear for users.
+
+!syntax description /ScalarKernels/Reactant2BodyScalar
+
+## Overview
+
+!! Replace these lines with information regarding the Reactant2BodyScalar object.
+
+## Example Input File Syntax
+
+!! Describe and include an example of how to use the Reactant2BodyScalar object.
+
+!syntax parameters /ScalarKernels/Reactant2BodyScalar
+
+!syntax inputs /ScalarKernels/Reactant2BodyScalar
+
+!syntax children /ScalarKernels/Reactant2BodyScalar

--- a/doc/content/source/scalarkernels/Reactant2BodyScalarLog.md
+++ b/doc/content/source/scalarkernels/Reactant2BodyScalarLog.md
@@ -1,1 +1,23 @@
-!template load file=stubs/moose_object.md.template name=Reactant2BodyScalarLog syntax=/ScalarKernels/Reactant2BodyScalarLog
+# Reactant2BodyScalarLog
+
+!alert construction title=Undocumented Class
+The Reactant2BodyScalarLog has not been documented. The content listed below should be used as a starting point for
+documenting the class, which includes the typical automatic documentation associated with a
+MooseObject; however, what is contained is ultimately determined by what is necessary to make the
+documentation clear for users.
+
+!syntax description /ScalarKernels/Reactant2BodyScalarLog
+
+## Overview
+
+!! Replace these lines with information regarding the Reactant2BodyScalarLog object.
+
+## Example Input File Syntax
+
+!! Describe and include an example of how to use the Reactant2BodyScalarLog object.
+
+!syntax parameters /ScalarKernels/Reactant2BodyScalarLog
+
+!syntax inputs /ScalarKernels/Reactant2BodyScalarLog
+
+!syntax children /ScalarKernels/Reactant2BodyScalarLog

--- a/doc/content/source/scalarkernels/Reactant3BodyScalar.md
+++ b/doc/content/source/scalarkernels/Reactant3BodyScalar.md
@@ -1,1 +1,23 @@
-!template load file=stubs/moose_object.md.template name=Reactant3BodyScalar syntax=/ScalarKernels/Reactant3BodyScalar
+# Reactant3BodyScalar
+
+!alert construction title=Undocumented Class
+The Reactant3BodyScalar has not been documented. The content listed below should be used as a starting point for
+documenting the class, which includes the typical automatic documentation associated with a
+MooseObject; however, what is contained is ultimately determined by what is necessary to make the
+documentation clear for users.
+
+!syntax description /ScalarKernels/Reactant3BodyScalar
+
+## Overview
+
+!! Replace these lines with information regarding the Reactant3BodyScalar object.
+
+## Example Input File Syntax
+
+!! Describe and include an example of how to use the Reactant3BodyScalar object.
+
+!syntax parameters /ScalarKernels/Reactant3BodyScalar
+
+!syntax inputs /ScalarKernels/Reactant3BodyScalar
+
+!syntax children /ScalarKernels/Reactant3BodyScalar

--- a/doc/content/source/scalarkernels/Reactant3BodyScalarLog.md
+++ b/doc/content/source/scalarkernels/Reactant3BodyScalarLog.md
@@ -1,1 +1,23 @@
-!template load file=stubs/moose_object.md.template name=Reactant3BodyScalarLog syntax=/ScalarKernels/Reactant3BodyScalarLog
+# Reactant3BodyScalarLog
+
+!alert construction title=Undocumented Class
+The Reactant3BodyScalarLog has not been documented. The content listed below should be used as a starting point for
+documenting the class, which includes the typical automatic documentation associated with a
+MooseObject; however, what is contained is ultimately determined by what is necessary to make the
+documentation clear for users.
+
+!syntax description /ScalarKernels/Reactant3BodyScalarLog
+
+## Overview
+
+!! Replace these lines with information regarding the Reactant3BodyScalarLog object.
+
+## Example Input File Syntax
+
+!! Describe and include an example of how to use the Reactant3BodyScalarLog object.
+
+!syntax parameters /ScalarKernels/Reactant3BodyScalarLog
+
+!syntax inputs /ScalarKernels/Reactant3BodyScalarLog
+
+!syntax children /ScalarKernels/Reactant3BodyScalarLog

--- a/doc/content/source/scalarkernels/ScalarDiffusion.md
+++ b/doc/content/source/scalarkernels/ScalarDiffusion.md
@@ -1,1 +1,23 @@
-!template load file=stubs/moose_object.md.template name=ScalarDiffusion syntax=/ScalarKernels/ScalarDiffusion
+# ScalarDiffusion
+
+!alert construction title=Undocumented Class
+The ScalarDiffusion has not been documented. The content listed below should be used as a starting point for
+documenting the class, which includes the typical automatic documentation associated with a
+MooseObject; however, what is contained is ultimately determined by what is necessary to make the
+documentation clear for users.
+
+!syntax description /ScalarKernels/ScalarDiffusion
+
+## Overview
+
+!! Replace these lines with information regarding the ScalarDiffusion object.
+
+## Example Input File Syntax
+
+!! Describe and include an example of how to use the ScalarDiffusion object.
+
+!syntax parameters /ScalarKernels/ScalarDiffusion
+
+!syntax inputs /ScalarKernels/ScalarDiffusion
+
+!syntax children /ScalarKernels/ScalarDiffusion

--- a/doc/content/source/userobjects/BoltzmannSolverScalar.md
+++ b/doc/content/source/userobjects/BoltzmannSolverScalar.md
@@ -1,1 +1,23 @@
-!template load file=stubs/moose_object.md.template name=BoltzmannSolverScalar syntax=/UserObjects/BoltzmannSolverScalar
+# BoltzmannSolverScalar
+
+!alert construction title=Undocumented Class
+The BoltzmannSolverScalar has not been documented. The content listed below should be used as a starting point for
+documenting the class, which includes the typical automatic documentation associated with a
+MooseObject; however, what is contained is ultimately determined by what is necessary to make the
+documentation clear for users.
+
+!syntax description /UserObjects/BoltzmannSolverScalar
+
+## Overview
+
+!! Replace these lines with information regarding the BoltzmannSolverScalar object.
+
+## Example Input File Syntax
+
+!! Describe and include an example of how to use the BoltzmannSolverScalar object.
+
+!syntax parameters /UserObjects/BoltzmannSolverScalar
+
+!syntax inputs /UserObjects/BoltzmannSolverScalar
+
+!syntax children /UserObjects/BoltzmannSolverScalar

--- a/doc/content/source/userobjects/ObjTest.md
+++ b/doc/content/source/userobjects/ObjTest.md
@@ -1,1 +1,23 @@
-!template load file=stubs/moose_object.md.template name=ObjTest syntax=/UserObjects/ObjTest
+# ObjTest
+
+!alert construction title=Undocumented Class
+The ObjTest has not been documented. The content listed below should be used as a starting point for
+documenting the class, which includes the typical automatic documentation associated with a
+MooseObject; however, what is contained is ultimately determined by what is necessary to make the
+documentation clear for users.
+
+!syntax description /UserObjects/ObjTest
+
+## Overview
+
+!! Replace these lines with information regarding the ObjTest object.
+
+## Example Input File Syntax
+
+!! Describe and include an example of how to use the ObjTest object.
+
+!syntax parameters /UserObjects/ObjTest
+
+!syntax inputs /UserObjects/ObjTest
+
+!syntax children /UserObjects/ObjTest

--- a/doc/content/source/userobjects/PolynomialCoefficients.md
+++ b/doc/content/source/userobjects/PolynomialCoefficients.md
@@ -1,1 +1,23 @@
-!template load file=stubs/moose_object.md.template name=PolynomialCoefficients syntax=/UserObjects/PolynomialCoefficients
+# PolynomialCoefficients
+
+!alert construction title=Undocumented Class
+The PolynomialCoefficients has not been documented. The content listed below should be used as a starting point for
+documenting the class, which includes the typical automatic documentation associated with a
+MooseObject; however, what is contained is ultimately determined by what is necessary to make the
+documentation clear for users.
+
+!syntax description /UserObjects/PolynomialCoefficients
+
+## Overview
+
+!! Replace these lines with information regarding the PolynomialCoefficients object.
+
+## Example Input File Syntax
+
+!! Describe and include an example of how to use the PolynomialCoefficients object.
+
+!syntax parameters /UserObjects/PolynomialCoefficients
+
+!syntax inputs /UserObjects/PolynomialCoefficients
+
+!syntax children /UserObjects/PolynomialCoefficients

--- a/doc/content/source/userobjects/RateCoefficientProvider.md
+++ b/doc/content/source/userobjects/RateCoefficientProvider.md
@@ -1,1 +1,23 @@
-!template load file=stubs/moose_object.md.template name=RateCoefficientProvider syntax=/UserObjects/RateCoefficientProvider
+# RateCoefficientProvider
+
+!alert construction title=Undocumented Class
+The RateCoefficientProvider has not been documented. The content listed below should be used as a starting point for
+documenting the class, which includes the typical automatic documentation associated with a
+MooseObject; however, what is contained is ultimately determined by what is necessary to make the
+documentation clear for users.
+
+!syntax description /UserObjects/RateCoefficientProvider
+
+## Overview
+
+!! Replace these lines with information regarding the RateCoefficientProvider object.
+
+## Example Input File Syntax
+
+!! Describe and include an example of how to use the RateCoefficientProvider object.
+
+!syntax parameters /UserObjects/RateCoefficientProvider
+
+!syntax inputs /UserObjects/RateCoefficientProvider
+
+!syntax children /UserObjects/RateCoefficientProvider

--- a/doc/content/source/userobjects/ValueProvider.md
+++ b/doc/content/source/userobjects/ValueProvider.md
@@ -1,1 +1,23 @@
-!template load file=stubs/moose_object.md.template name=ValueProvider syntax=/UserObjects/ValueProvider
+# ValueProvider
+
+!alert construction title=Undocumented Class
+The ValueProvider has not been documented. The content listed below should be used as a starting point for
+documenting the class, which includes the typical automatic documentation associated with a
+MooseObject; however, what is contained is ultimately determined by what is necessary to make the
+documentation clear for users.
+
+!syntax description /UserObjects/ValueProvider
+
+## Overview
+
+!! Replace these lines with information regarding the ValueProvider object.
+
+## Example Input File Syntax
+
+!! Describe and include an example of how to use the ValueProvider object.
+
+!syntax parameters /UserObjects/ValueProvider
+
+!syntax inputs /UserObjects/ValueProvider
+
+!syntax children /UserObjects/ValueProvider


### PR DESCRIPTION
- Remove deprecated items from `crane/doc/config.yml` and add content to appsyntax, common, and acronym extensions
- Use MooseDocs bibliography system instead of manually adding citations
- Remove old documentation stubs
- Add new documentation stubs for current objects

@smpeyres This update is necessary for Zapdos, as I wanted to include CRANE objects in the syntax listing on the [Zapdos website](https://shannon-lab.github.io/zapdos/syntax/index.html). 