### PR TITLE
Add _config.yml to exclude MOOSE submodule from Jekyll build

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,0 +1,3 @@
+# This file is used with GitHub Pages (Jekyll)
+exclude:
+  - moose/


### PR DESCRIPTION
Refs #87

@smpeyres I think this should fix the broken GitHub deployment runner.  