### PR TITLE
Remove unused parameter from zdplaskin example 2

### DIFF
--- a/tests/scalar_network/zdplaskin_ex2.i
+++ b/tests/scalar_network/zdplaskin_ex2.i
@@ -70,7 +70,6 @@
 [ChemicalReactions]
   [./ScalarNetwork]
     species = 'e Ar* Ar+ Ar Ar2+'
-    reaction_coefficient_format = 'rate'
     file_location = 'Example2'
     interpolation_type = 'spline'
 


### PR DESCRIPTION
CRANE is failing CIVET testing with the following error:

```
scalar_network.zdplaskin_ex2: *** ERROR ***
scalar_network.zdplaskin_ex2: /data/civet2/build/crane/tests/scalar_network/zdplaskin_ex2.i:73: unused parameter 'ChemicalReactions/ScalarNetwork/reaction_coefficient_format'
```

This param was removed from AddScalarReactions some time ago, so this PR fixes that up in example 2