### PR TITLE
Copyright fix for issue #25 Standardize Headers

### DIFF
--- a/include/actions/AddGeneralReactions.h
+++ b/include/actions/AddGeneralReactions.h
@@ -1,3 +1,13 @@
+//* This file is part of Crane, an open-source
+//* application for plasma chemistry and thermochemistry
+//* https://github.com/lcpp-org/crane
+//*
+//* Crane is powered by the MOOSE Framework
+//* https://www.mooseframework.org
+//*
+//* Licensed under LGPL 2.1, please see LICENSE for details
+//* https://www.gnu.org/licenses/lgpl-2.1.html
+
 //#ifndef ADDGENERALREACTIONS_H
 //#define ADDGENERALREACTIONS_H
 #pragma once

--- a/include/actions/AddReactions.h
+++ b/include/actions/AddReactions.h
@@ -1,3 +1,13 @@
+//* This file is part of Crane, an open-source
+//* application for plasma chemistry and thermochemistry
+//* https://github.com/lcpp-org/crane
+//*
+//* Crane is powered by the MOOSE Framework
+//* https://www.mooseframework.org
+//*
+//* Licensed under LGPL 2.1, please see LICENSE for details
+//* https://www.gnu.org/licenses/lgpl-2.1.html
+
 #pragma once
 
 #include "AddVariableAction.h"

--- a/include/actions/AddScalarReactions.h
+++ b/include/actions/AddScalarReactions.h
@@ -1,3 +1,13 @@
+//* This file is part of Crane, an open-source
+//* application for plasma chemistry and thermochemistry
+//* https://github.com/lcpp-org/crane
+//*
+//* Crane is powered by the MOOSE Framework
+//* https://www.mooseframework.org
+//*
+//* Licensed under LGPL 2.1, please see LICENSE for details
+//* https://www.gnu.org/licenses/lgpl-2.1.html
+
 #pragma once
 
 #include "AddVariableAction.h"

--- a/include/actions/AddSpecies.h
+++ b/include/actions/AddSpecies.h
@@ -1,3 +1,13 @@
+//* This file is part of Crane, an open-source
+//* application for plasma chemistry and thermochemistry
+//* https://github.com/lcpp-org/crane
+//*
+//* Crane is powered by the MOOSE Framework
+//* https://www.mooseframework.org
+//*
+//* Licensed under LGPL 2.1, please see LICENSE for details
+//* https://www.gnu.org/licenses/lgpl-2.1.html
+
 #pragma once
 
 #include "AddVariableAction.h"

--- a/include/actions/AddZapdosReactions.h
+++ b/include/actions/AddZapdosReactions.h
@@ -1,3 +1,13 @@
+//* This file is part of Crane, an open-source
+//* application for plasma chemistry and thermochemistry
+//* https://github.com/lcpp-org/crane
+//*
+//* Crane is powered by the MOOSE Framework
+//* https://www.mooseframework.org
+//*
+//* Licensed under LGPL 2.1, please see LICENSE for details
+//* https://www.gnu.org/licenses/lgpl-2.1.html
+
 #pragma once
 
 #include "AddVariableAction.h"

--- a/include/actions/ChemicalReactions.h
+++ b/include/actions/ChemicalReactions.h
@@ -1,3 +1,13 @@
+//* This file is part of Crane, an open-source
+//* application for plasma chemistry and thermochemistry
+//* https://github.com/lcpp-org/crane
+//*
+//* Crane is powered by the MOOSE Framework
+//* https://www.mooseframework.org
+//*
+//* Licensed under LGPL 2.1, please see LICENSE for details
+//* https://www.gnu.org/licenses/lgpl-2.1.html
+
 #pragma once
 
 #include "AddVariableAction.h"

--- a/include/actions/ChemicalReactionsBase.h
+++ b/include/actions/ChemicalReactionsBase.h
@@ -1,3 +1,13 @@
+//* This file is part of Crane, an open-source
+//* application for plasma chemistry and thermochemistry
+//* https://github.com/lcpp-org/crane
+//*
+//* Crane is powered by the MOOSE Framework
+//* https://www.mooseframework.org
+//*
+//* Licensed under LGPL 2.1, please see LICENSE for details
+//* https://www.gnu.org/licenses/lgpl-2.1.html
+
 #pragma once
 
 #include "AddVariableAction.h"

--- a/include/auxkernels/AuxInitialConditionScalar.h
+++ b/include/auxkernels/AuxInitialConditionScalar.h
@@ -1,3 +1,13 @@
+//* This file is part of Crane, an open-source
+//* application for plasma chemistry and thermochemistry
+//* https://github.com/lcpp-org/crane
+//*
+//* Crane is powered by the MOOSE Framework
+//* https://www.mooseframework.org
+//*
+//* Licensed under LGPL 2.1, please see LICENSE for details
+//* https://www.gnu.org/licenses/lgpl-2.1.html
+
 #pragma once
 
 #include "AuxScalarKernel.h"

--- a/include/auxkernels/BolsigValueScalar.h
+++ b/include/auxkernels/BolsigValueScalar.h
@@ -1,3 +1,13 @@
+//* This file is part of Crane, an open-source
+//* application for plasma chemistry and thermochemistry
+//* https://github.com/lcpp-org/crane
+//*
+//* Crane is powered by the MOOSE Framework
+//* https://www.mooseframework.org
+//*
+//* Licensed under LGPL 2.1, please see LICENSE for details
+//* https://www.gnu.org/licenses/lgpl-2.1.html
+
 #pragma once
 
 #include "AuxScalarKernel.h"

--- a/include/auxkernels/DataRead.h
+++ b/include/auxkernels/DataRead.h
@@ -1,3 +1,13 @@
+//* This file is part of Crane, an open-source
+//* application for plasma chemistry and thermochemistry
+//* https://github.com/lcpp-org/crane
+//*
+//* Crane is powered by the MOOSE Framework
+//* https://www.mooseframework.org
+//*
+//* Licensed under LGPL 2.1, please see LICENSE for details
+//* https://www.gnu.org/licenses/lgpl-2.1.html
+
 #pragma once
 
 #include "AuxKernel.h"

--- a/include/auxkernels/DensityLogConvert.h
+++ b/include/auxkernels/DensityLogConvert.h
@@ -1,3 +1,13 @@
+//* This file is part of Crane, an open-source
+//* application for plasma chemistry and thermochemistry
+//* https://github.com/lcpp-org/crane
+//*
+//* Crane is powered by the MOOSE Framework
+//* https://www.mooseframework.org
+//*
+//* Licensed under LGPL 2.1, please see LICENSE for details
+//* https://www.gnu.org/licenses/lgpl-2.1.html
+
 #pragma once
 
 #include "AuxKernel.h"

--- a/include/auxkernels/DensityLogConvertScalar.h
+++ b/include/auxkernels/DensityLogConvertScalar.h
@@ -1,3 +1,13 @@
+//* This file is part of Crane, an open-source
+//* application for plasma chemistry and thermochemistry
+//* https://github.com/lcpp-org/crane
+//*
+//* Crane is powered by the MOOSE Framework
+//* https://www.mooseframework.org
+//*
+//* Licensed under LGPL 2.1, please see LICENSE for details
+//* https://www.gnu.org/licenses/lgpl-2.1.html
+
 #pragma once
 
 #include "AuxScalarKernel.h"

--- a/include/auxkernels/EEDFRateCoefficientScalar.h
+++ b/include/auxkernels/EEDFRateCoefficientScalar.h
@@ -1,3 +1,13 @@
+//* This file is part of Crane, an open-source
+//* application for plasma chemistry and thermochemistry
+//* https://github.com/lcpp-org/crane
+//*
+//* Crane is powered by the MOOSE Framework
+//* https://www.mooseframework.org
+//*
+//* Licensed under LGPL 2.1, please see LICENSE for details
+//* https://www.gnu.org/licenses/lgpl-2.1.html
+
 #pragma once
 
 #include "AuxScalarKernel.h"

--- a/include/auxkernels/ElectronMobility.h
+++ b/include/auxkernels/ElectronMobility.h
@@ -1,3 +1,13 @@
+//* This file is part of Crane, an open-source
+//* application for plasma chemistry and thermochemistry
+//* https://github.com/lcpp-org/crane
+//*
+//* Crane is powered by the MOOSE Framework
+//* https://www.mooseframework.org
+//*
+//* Licensed under LGPL 2.1, please see LICENSE for details
+//* https://www.gnu.org/licenses/lgpl-2.1.html
+
 #pragma once
 
 #include "AuxScalarKernel.h"

--- a/include/auxkernels/MoleFraction.h
+++ b/include/auxkernels/MoleFraction.h
@@ -1,3 +1,13 @@
+//* This file is part of Crane, an open-source
+//* application for plasma chemistry and thermochemistry
+//* https://github.com/lcpp-org/crane
+//*
+//* Crane is powered by the MOOSE Framework
+//* https://www.mooseframework.org
+//*
+//* Licensed under LGPL 2.1, please see LICENSE for details
+//* https://www.gnu.org/licenses/lgpl-2.1.html
+
 #pragma once
 
 #include "AuxScalarKernel.h"

--- a/include/auxkernels/ParsedAuxScalar.h
+++ b/include/auxkernels/ParsedAuxScalar.h
@@ -1,3 +1,13 @@
+//* This file is part of Crane, an open-source
+//* application for plasma chemistry and thermochemistry
+//* https://github.com/lcpp-org/crane
+//*
+//* Crane is powered by the MOOSE Framework
+//* https://www.mooseframework.org
+//*
+//* Licensed under LGPL 2.1, please see LICENSE for details
+//* https://www.gnu.org/licenses/lgpl-2.1.html
+
 #pragma once
 
 #include "AuxScalarKernel.h"

--- a/include/auxkernels/ParsedScalarRateCoefficient.h
+++ b/include/auxkernels/ParsedScalarRateCoefficient.h
@@ -1,3 +1,13 @@
+//* This file is part of Crane, an open-source
+//* application for plasma chemistry and thermochemistry
+//* https://github.com/lcpp-org/crane
+//*
+//* Crane is powered by the MOOSE Framework
+//* https://www.mooseframework.org
+//*
+//* Licensed under LGPL 2.1, please see LICENSE for details
+//* https://www.gnu.org/licenses/lgpl-2.1.html
+
 #pragma once
 
 #include "AuxScalarKernel.h"

--- a/include/auxkernels/ReactionRateEEDFTownsendLog.h
+++ b/include/auxkernels/ReactionRateEEDFTownsendLog.h
@@ -1,3 +1,13 @@
+//* This file is part of Crane, an open-source
+//* application for plasma chemistry and thermochemistry
+//* https://github.com/lcpp-org/crane
+//*
+//* Crane is powered by the MOOSE Framework
+//* https://www.mooseframework.org
+//*
+//* Licensed under LGPL 2.1, please see LICENSE for details
+//* https://www.gnu.org/licenses/lgpl-2.1.html
+
 #pragma once
 
 #include "AuxKernel.h"

--- a/include/auxkernels/ReactionRateFirstOrder.h
+++ b/include/auxkernels/ReactionRateFirstOrder.h
@@ -1,3 +1,13 @@
+//* This file is part of Crane, an open-source
+//* application for plasma chemistry and thermochemistry
+//* https://github.com/lcpp-org/crane
+//*
+//* Crane is powered by the MOOSE Framework
+//* https://www.mooseframework.org
+//*
+//* Licensed under LGPL 2.1, please see LICENSE for details
+//* https://www.gnu.org/licenses/lgpl-2.1.html
+
 #pragma once
 
 #include "AuxKernel.h"

--- a/include/auxkernels/ReactionRateFirstOrderLog.h
+++ b/include/auxkernels/ReactionRateFirstOrderLog.h
@@ -1,3 +1,13 @@
+//* This file is part of Crane, an open-source
+//* application for plasma chemistry and thermochemistry
+//* https://github.com/lcpp-org/crane
+//*
+//* Crane is powered by the MOOSE Framework
+//* https://www.mooseframework.org
+//*
+//* Licensed under LGPL 2.1, please see LICENSE for details
+//* https://www.gnu.org/licenses/lgpl-2.1.html
+
 #pragma once
 
 #include "AuxKernel.h"

--- a/include/auxkernels/ReactionRateOneBodyScalar.h
+++ b/include/auxkernels/ReactionRateOneBodyScalar.h
@@ -1,3 +1,13 @@
+//* This file is part of Crane, an open-source
+//* application for plasma chemistry and thermochemistry
+//* https://github.com/lcpp-org/crane
+//*
+//* Crane is powered by the MOOSE Framework
+//* https://www.mooseframework.org
+//*
+//* Licensed under LGPL 2.1, please see LICENSE for details
+//* https://www.gnu.org/licenses/lgpl-2.1.html
+
 #pragma once
 
 #include "AuxScalarKernel.h"

--- a/include/auxkernels/ReactionRateSecondOrder.h
+++ b/include/auxkernels/ReactionRateSecondOrder.h
@@ -1,3 +1,13 @@
+//* This file is part of Crane, an open-source
+//* application for plasma chemistry and thermochemistry
+//* https://github.com/lcpp-org/crane
+//*
+//* Crane is powered by the MOOSE Framework
+//* https://www.mooseframework.org
+//*
+//* Licensed under LGPL 2.1, please see LICENSE for details
+//* https://www.gnu.org/licenses/lgpl-2.1.html
+
 #pragma once
 
 #include "AuxKernel.h"

--- a/include/auxkernels/ReactionRateSecondOrderLog.h
+++ b/include/auxkernels/ReactionRateSecondOrderLog.h
@@ -1,3 +1,13 @@
+//* This file is part of Crane, an open-source
+//* application for plasma chemistry and thermochemistry
+//* https://github.com/lcpp-org/crane
+//*
+//* Crane is powered by the MOOSE Framework
+//* https://www.mooseframework.org
+//*
+//* Licensed under LGPL 2.1, please see LICENSE for details
+//* https://www.gnu.org/licenses/lgpl-2.1.html
+
 #pragma once
 
 #include "AuxKernel.h"

--- a/include/auxkernels/ReactionRateThirdOrder.h
+++ b/include/auxkernels/ReactionRateThirdOrder.h
@@ -1,3 +1,13 @@
+//* This file is part of Crane, an open-source
+//* application for plasma chemistry and thermochemistry
+//* https://github.com/lcpp-org/crane
+//*
+//* Crane is powered by the MOOSE Framework
+//* https://www.mooseframework.org
+//*
+//* Licensed under LGPL 2.1, please see LICENSE for details
+//* https://www.gnu.org/licenses/lgpl-2.1.html
+
 #pragma once
 
 #include "AuxKernel.h"

--- a/include/auxkernels/ReactionRateThirdOrderLog.h
+++ b/include/auxkernels/ReactionRateThirdOrderLog.h
@@ -1,3 +1,13 @@
+//* This file is part of Crane, an open-source
+//* application for plasma chemistry and thermochemistry
+//* https://github.com/lcpp-org/crane
+//*
+//* Crane is powered by the MOOSE Framework
+//* https://www.mooseframework.org
+//*
+//* Licensed under LGPL 2.1, please see LICENSE for details
+//* https://www.gnu.org/licenses/lgpl-2.1.html
+
 #pragma once
 
 #include "AuxKernel.h"

--- a/include/auxkernels/ReactionRateThreeBodyScalar.h
+++ b/include/auxkernels/ReactionRateThreeBodyScalar.h
@@ -1,3 +1,13 @@
+//* This file is part of Crane, an open-source
+//* application for plasma chemistry and thermochemistry
+//* https://github.com/lcpp-org/crane
+//*
+//* Crane is powered by the MOOSE Framework
+//* https://www.mooseframework.org
+//*
+//* Licensed under LGPL 2.1, please see LICENSE for details
+//* https://www.gnu.org/licenses/lgpl-2.1.html
+
 #pragma once
 
 #include "AuxScalarKernel.h"

--- a/include/auxkernels/ReactionRateTwoBodyScalar.h
+++ b/include/auxkernels/ReactionRateTwoBodyScalar.h
@@ -1,3 +1,13 @@
+//* This file is part of Crane, an open-source
+//* application for plasma chemistry and thermochemistry
+//* https://github.com/lcpp-org/crane
+//*
+//* Crane is powered by the MOOSE Framework
+//* https://www.mooseframework.org
+//*
+//* Licensed under LGPL 2.1, please see LICENSE for details
+//* https://www.gnu.org/licenses/lgpl-2.1.html
+
 #pragma once
 
 #include "AuxScalarKernel.h"

--- a/include/auxkernels/ReducedField.h
+++ b/include/auxkernels/ReducedField.h
@@ -1,3 +1,13 @@
+//* This file is part of Crane, an open-source
+//* application for plasma chemistry and thermochemistry
+//* https://github.com/lcpp-org/crane
+//*
+//* Crane is powered by the MOOSE Framework
+//* https://www.mooseframework.org
+//*
+//* Licensed under LGPL 2.1, please see LICENSE for details
+//* https://www.gnu.org/licenses/lgpl-2.1.html
+
 #pragma once
 
 #include "AuxScalarKernel.h"

--- a/include/auxkernels/ReducedFieldScalar.h
+++ b/include/auxkernels/ReducedFieldScalar.h
@@ -1,8 +1,9 @@
-//* This file is part of the MOOSE framework
-//* https://www.mooseframework.org
+//* This file is part of Crane, an open-source
+//* application for plasma chemistry and thermochemistry
+//* https://github.com/lcpp-org/crane
 //*
-//* All rights reserved, see COPYRIGHT for full restrictions
-//* https://github.com/idaholab/moose/blob/master/COPYRIGHT
+//* Crane is powered by the MOOSE Framework
+//* https://www.mooseframework.org
 //*
 //* Licensed under LGPL 2.1, please see LICENSE for details
 //* https://www.gnu.org/licenses/lgpl-2.1.html

--- a/include/auxkernels/ScalarLinearInterpolation.h
+++ b/include/auxkernels/ScalarLinearInterpolation.h
@@ -1,3 +1,13 @@
+//* This file is part of Crane, an open-source
+//* application for plasma chemistry and thermochemistry
+//* https://github.com/lcpp-org/crane
+//*
+//* Crane is powered by the MOOSE Framework
+//* https://www.mooseframework.org
+//*
+//* Licensed under LGPL 2.1, please see LICENSE for details
+//* https://www.gnu.org/licenses/lgpl-2.1.html
+
 #pragma once
 
 #include "AuxScalarKernel.h"

--- a/include/auxkernels/ScalarSplineInterpolation.h
+++ b/include/auxkernels/ScalarSplineInterpolation.h
@@ -1,3 +1,13 @@
+//* This file is part of Crane, an open-source
+//* application for plasma chemistry and thermochemistry
+//* https://github.com/lcpp-org/crane
+//*
+//* Crane is powered by the MOOSE Framework
+//* https://www.mooseframework.org
+//*
+//* Licensed under LGPL 2.1, please see LICENSE for details
+//* https://www.gnu.org/licenses/lgpl-2.1.html
+
 #pragma once
 
 #include "AuxScalarKernel.h"

--- a/include/auxkernels/SuperelasticRateCoefficientScalar.h
+++ b/include/auxkernels/SuperelasticRateCoefficientScalar.h
@@ -1,3 +1,13 @@
+//* This file is part of Crane, an open-source
+//* application for plasma chemistry and thermochemistry
+//* https://github.com/lcpp-org/crane
+//*
+//* Crane is powered by the MOOSE Framework
+//* https://www.mooseframework.org
+//*
+//* Licensed under LGPL 2.1, please see LICENSE for details
+//* https://www.gnu.org/licenses/lgpl-2.1.html
+
 #pragma once
 
 #include "AuxScalarKernel.h"

--- a/include/auxkernels/VariableSum.h
+++ b/include/auxkernels/VariableSum.h
@@ -1,3 +1,13 @@
+//* This file is part of Crane, an open-source
+//* application for plasma chemistry and thermochemistry
+//* https://github.com/lcpp-org/crane
+//*
+//* Crane is powered by the MOOSE Framework
+//* https://www.mooseframework.org
+//*
+//* Licensed under LGPL 2.1, please see LICENSE for details
+//* https://www.gnu.org/licenses/lgpl-2.1.html
+
 #pragma once
 
 #include "AuxScalarKernel.h"

--- a/include/auxkernels/VariableSumLog.h
+++ b/include/auxkernels/VariableSumLog.h
@@ -1,3 +1,13 @@
+//* This file is part of Crane, an open-source
+//* application for plasma chemistry and thermochemistry
+//* https://github.com/lcpp-org/crane
+//*
+//* Crane is powered by the MOOSE Framework
+//* https://www.mooseframework.org
+//*
+//* Licensed under LGPL 2.1, please see LICENSE for details
+//* https://www.gnu.org/licenses/lgpl-2.1.html
+
 #pragma once
 
 #include "AuxScalarKernel.h"

--- a/include/base/CraneApp.h
+++ b/include/base/CraneApp.h
@@ -1,11 +1,13 @@
-//* This file is part of the MOOSE framework
-//* https://www.mooseframework.org
+//* This file is part of Crane, an open-source
+//* application for plasma chemistry and thermochemistry
+//* https://github.com/lcpp-org/crane
 //*
-//* All rights reserved, see COPYRIGHT for full restrictions
-//* https://github.com/idaholab/moose/blob/master/COPYRIGHT
+//* Crane is powered by the MOOSE Framework
+//* https://www.mooseframework.org
 //*
 //* Licensed under LGPL 2.1, please see LICENSE for details
 //* https://www.gnu.org/licenses/lgpl-2.1.html
+
 #pragma once
 
 #include "MooseApp.h"

--- a/include/kernels/ADEEDFElasticLog.h
+++ b/include/kernels/ADEEDFElasticLog.h
@@ -1,3 +1,13 @@
+//* This file is part of Crane, an open-source
+//* application for plasma chemistry and thermochemistry
+//* https://github.com/lcpp-org/crane
+//*
+//* Crane is powered by the MOOSE Framework
+//* https://www.mooseframework.org
+//*
+//* Licensed under LGPL 2.1, please see LICENSE for details
+//* https://www.gnu.org/licenses/lgpl-2.1.html
+
 #pragma once
 
 #include "ADKernel.h"

--- a/include/kernels/ADEEDFElasticTownsendLog.h
+++ b/include/kernels/ADEEDFElasticTownsendLog.h
@@ -1,3 +1,13 @@
+//* This file is part of Crane, an open-source
+//* application for plasma chemistry and thermochemistry
+//* https://github.com/lcpp-org/crane
+//*
+//* Crane is powered by the MOOSE Framework
+//* https://www.mooseframework.org
+//*
+//* Licensed under LGPL 2.1, please see LICENSE for details
+//* https://www.gnu.org/licenses/lgpl-2.1.html
+
 #pragma once
 
 #include "ADKernel.h"

--- a/include/kernels/ADEEDFEnergyLog.h
+++ b/include/kernels/ADEEDFEnergyLog.h
@@ -1,3 +1,13 @@
+//* This file is part of Crane, an open-source
+//* application for plasma chemistry and thermochemistry
+//* https://github.com/lcpp-org/crane
+//*
+//* Crane is powered by the MOOSE Framework
+//* https://www.mooseframework.org
+//*
+//* Licensed under LGPL 2.1, please see LICENSE for details
+//* https://www.gnu.org/licenses/lgpl-2.1.html
+
 #pragma once
 
 #include "ADKernel.h"

--- a/include/kernels/ADEEDFEnergyTownsendLog.h
+++ b/include/kernels/ADEEDFEnergyTownsendLog.h
@@ -1,3 +1,13 @@
+//* This file is part of Crane, an open-source
+//* application for plasma chemistry and thermochemistry
+//* https://github.com/lcpp-org/crane
+//*
+//* Crane is powered by the MOOSE Framework
+//* https://www.mooseframework.org
+//*
+//* Licensed under LGPL 2.1, please see LICENSE for details
+//* https://www.gnu.org/licenses/lgpl-2.1.html
+
 #pragma once
 
 #include "ADKernel.h"

--- a/include/kernels/ADEEDFReactionLog.h
+++ b/include/kernels/ADEEDFReactionLog.h
@@ -1,3 +1,13 @@
+//* This file is part of Crane, an open-source
+//* application for plasma chemistry and thermochemistry
+//* https://github.com/lcpp-org/crane
+//*
+//* Crane is powered by the MOOSE Framework
+//* https://www.mooseframework.org
+//*
+//* Licensed under LGPL 2.1, please see LICENSE for details
+//* https://www.gnu.org/licenses/lgpl-2.1.html
+
 #pragma once
 
 #include "ADKernel.h"

--- a/include/kernels/ADEEDFReactionTownsendLog.h
+++ b/include/kernels/ADEEDFReactionTownsendLog.h
@@ -1,3 +1,13 @@
+//* This file is part of Crane, an open-source
+//* application for plasma chemistry and thermochemistry
+//* https://github.com/lcpp-org/crane
+//*
+//* Crane is powered by the MOOSE Framework
+//* https://www.mooseframework.org
+//*
+//* Licensed under LGPL 2.1, please see LICENSE for details
+//* https://www.gnu.org/licenses/lgpl-2.1.html
+
 #pragma once
 
 #include "ADKernel.h"

--- a/include/kernels/EEDFElasticLog.h
+++ b/include/kernels/EEDFElasticLog.h
@@ -1,8 +1,8 @@
-//* This file is part of Zapdos, an open-source
-//* application for the simulation of plasmas
-//* https://github.com/shannon-lab/zapdos
+//* This file is part of Crane, an open-source
+//* application for plasma chemistry and thermochemistry
+//* https://github.com/lcpp-org/crane
 //*
-//* Zapdos is powered by the MOOSE Framework
+//* Crane is powered by the MOOSE Framework
 //* https://www.mooseframework.org
 //*
 //* Licensed under LGPL 2.1, please see LICENSE for details

--- a/include/kernels/EEDFElasticTownsendLog.h
+++ b/include/kernels/EEDFElasticTownsendLog.h
@@ -1,8 +1,8 @@
-//* This file is part of Zapdos, an open-source
-//* application for the simulation of plasmas
-//* https://github.com/shannon-lab/zapdos
+//* This file is part of Crane, an open-source
+//* application for plasma chemistry and thermochemistry
+//* https://github.com/lcpp-org/crane
 //*
-//* Zapdos is powered by the MOOSE Framework
+//* Crane is powered by the MOOSE Framework
 //* https://www.mooseframework.org
 //*
 //* Licensed under LGPL 2.1, please see LICENSE for details

--- a/include/kernels/EEDFEnergyLog.h
+++ b/include/kernels/EEDFEnergyLog.h
@@ -1,3 +1,13 @@
+//* This file is part of Crane, an open-source
+//* application for plasma chemistry and thermochemistry
+//* https://github.com/lcpp-org/crane
+//*
+//* Crane is powered by the MOOSE Framework
+//* https://www.mooseframework.org
+//*
+//* Licensed under LGPL 2.1, please see LICENSE for details
+//* https://www.gnu.org/licenses/lgpl-2.1.html
+
 #pragma once
 
 #include "Kernel.h"

--- a/include/kernels/EEDFEnergyTownsendLog.h
+++ b/include/kernels/EEDFEnergyTownsendLog.h
@@ -1,3 +1,13 @@
+//* This file is part of Crane, an open-source
+//* application for plasma chemistry and thermochemistry
+//* https://github.com/lcpp-org/crane
+//*
+//* Crane is powered by the MOOSE Framework
+//* https://www.mooseframework.org
+//*
+//* Licensed under LGPL 2.1, please see LICENSE for details
+//* https://www.gnu.org/licenses/lgpl-2.1.html
+
 #pragma once
 
 #include "Kernel.h"

--- a/include/kernels/EEDFReactionLog.h
+++ b/include/kernels/EEDFReactionLog.h
@@ -1,3 +1,13 @@
+//* This file is part of Crane, an open-source
+//* application for plasma chemistry and thermochemistry
+//* https://github.com/lcpp-org/crane
+//*
+//* Crane is powered by the MOOSE Framework
+//* https://www.mooseframework.org
+//*
+//* Licensed under LGPL 2.1, please see LICENSE for details
+//* https://www.gnu.org/licenses/lgpl-2.1.html
+
 #pragma once
 
 #include "Kernel.h"

--- a/include/kernels/EEDFReactionTownsendLog.h
+++ b/include/kernels/EEDFReactionTownsendLog.h
@@ -1,3 +1,13 @@
+//* This file is part of Crane, an open-source
+//* application for plasma chemistry and thermochemistry
+//* https://github.com/lcpp-org/crane
+//*
+//* Crane is powered by the MOOSE Framework
+//* https://www.mooseframework.org
+//*
+//* Licensed under LGPL 2.1, please see LICENSE for details
+//* https://www.gnu.org/licenses/lgpl-2.1.html
+
 #pragma once
 
 #include "Kernel.h"

--- a/include/kernels/LogStabilization.h
+++ b/include/kernels/LogStabilization.h
@@ -1,3 +1,13 @@
+//* This file is part of Crane, an open-source
+//* application for plasma chemistry and thermochemistry
+//* https://github.com/lcpp-org/crane
+//*
+//* Crane is powered by the MOOSE Framework
+//* https://www.mooseframework.org
+//*
+//* Licensed under LGPL 2.1, please see LICENSE for details
+//* https://www.gnu.org/licenses/lgpl-2.1.html
+
 #pragma once
 
 #include "Kernel.h"

--- a/include/kernels/ReactionFirstOrder.h
+++ b/include/kernels/ReactionFirstOrder.h
@@ -1,3 +1,13 @@
+//* This file is part of Crane, an open-source
+//* application for plasma chemistry and thermochemistry
+//* https://github.com/lcpp-org/crane
+//*
+//* Crane is powered by the MOOSE Framework
+//* https://www.mooseframework.org
+//*
+//* Licensed under LGPL 2.1, please see LICENSE for details
+//* https://www.gnu.org/licenses/lgpl-2.1.html
+
 #pragma once
 
 #include "Kernel.h"

--- a/include/kernels/ReactionFirstOrderEnergy.h
+++ b/include/kernels/ReactionFirstOrderEnergy.h
@@ -1,3 +1,13 @@
+//* This file is part of Crane, an open-source
+//* application for plasma chemistry and thermochemistry
+//* https://github.com/lcpp-org/crane
+//*
+//* Crane is powered by the MOOSE Framework
+//* https://www.mooseframework.org
+//*
+//* Licensed under LGPL 2.1, please see LICENSE for details
+//* https://www.gnu.org/licenses/lgpl-2.1.html
+
 #pragma once
 
 #include "Kernel.h"

--- a/include/kernels/ReactionFirstOrderEnergyLog.h
+++ b/include/kernels/ReactionFirstOrderEnergyLog.h
@@ -1,3 +1,13 @@
+//* This file is part of Crane, an open-source
+//* application for plasma chemistry and thermochemistry
+//* https://github.com/lcpp-org/crane
+//*
+//* Crane is powered by the MOOSE Framework
+//* https://www.mooseframework.org
+//*
+//* Licensed under LGPL 2.1, please see LICENSE for details
+//* https://www.gnu.org/licenses/lgpl-2.1.html
+
 #pragma once
 
 #include "Kernel.h"

--- a/include/kernels/ReactionFirstOrderLog.h
+++ b/include/kernels/ReactionFirstOrderLog.h
@@ -1,3 +1,13 @@
+//* This file is part of Crane, an open-source
+//* application for plasma chemistry and thermochemistry
+//* https://github.com/lcpp-org/crane
+//*
+//* Crane is powered by the MOOSE Framework
+//* https://www.mooseframework.org
+//*
+//* Licensed under LGPL 2.1, please see LICENSE for details
+//* https://www.gnu.org/licenses/lgpl-2.1.html
+
 #pragma once
 
 #include "Kernel.h"

--- a/include/kernels/ReactionSecondOrder.h
+++ b/include/kernels/ReactionSecondOrder.h
@@ -1,3 +1,13 @@
+//* This file is part of Crane, an open-source
+//* application for plasma chemistry and thermochemistry
+//* https://github.com/lcpp-org/crane
+//*
+//* Crane is powered by the MOOSE Framework
+//* https://www.mooseframework.org
+//*
+//* Licensed under LGPL 2.1, please see LICENSE for details
+//* https://www.gnu.org/licenses/lgpl-2.1.html
+
 #pragma once
 
 #include "Kernel.h"

--- a/include/kernels/ReactionSecondOrderEnergy.h
+++ b/include/kernels/ReactionSecondOrderEnergy.h
@@ -1,3 +1,13 @@
+//* This file is part of Crane, an open-source
+//* application for plasma chemistry and thermochemistry
+//* https://github.com/lcpp-org/crane
+//*
+//* Crane is powered by the MOOSE Framework
+//* https://www.mooseframework.org
+//*
+//* Licensed under LGPL 2.1, please see LICENSE for details
+//* https://www.gnu.org/licenses/lgpl-2.1.html
+
 #pragma once
 
 #include "Kernel.h"

--- a/include/kernels/ReactionSecondOrderEnergyLog.h
+++ b/include/kernels/ReactionSecondOrderEnergyLog.h
@@ -1,3 +1,13 @@
+//* This file is part of Crane, an open-source
+//* application for plasma chemistry and thermochemistry
+//* https://github.com/lcpp-org/crane
+//*
+//* Crane is powered by the MOOSE Framework
+//* https://www.mooseframework.org
+//*
+//* Licensed under LGPL 2.1, please see LICENSE for details
+//* https://www.gnu.org/licenses/lgpl-2.1.html
+
 #pragma once
 
 #include "Kernel.h"

--- a/include/kernels/ReactionSecondOrderLog.h
+++ b/include/kernels/ReactionSecondOrderLog.h
@@ -1,3 +1,13 @@
+//* This file is part of Crane, an open-source
+//* application for plasma chemistry and thermochemistry
+//* https://github.com/lcpp-org/crane
+//*
+//* Crane is powered by the MOOSE Framework
+//* https://www.mooseframework.org
+//*
+//* Licensed under LGPL 2.1, please see LICENSE for details
+//* https://www.gnu.org/licenses/lgpl-2.1.html
+
 #pragma once
 
 #include "GenericKernel.h"

--- a/include/kernels/ReactionThirdOrder.h
+++ b/include/kernels/ReactionThirdOrder.h
@@ -1,3 +1,13 @@
+//* This file is part of Crane, an open-source
+//* application for plasma chemistry and thermochemistry
+//* https://github.com/lcpp-org/crane
+//*
+//* Crane is powered by the MOOSE Framework
+//* https://www.mooseframework.org
+//*
+//* Licensed under LGPL 2.1, please see LICENSE for details
+//* https://www.gnu.org/licenses/lgpl-2.1.html
+
 #pragma once
 
 #include "Kernel.h"

--- a/include/kernels/ReactionThirdOrderEnergy.h
+++ b/include/kernels/ReactionThirdOrderEnergy.h
@@ -1,3 +1,13 @@
+//* This file is part of Crane, an open-source
+//* application for plasma chemistry and thermochemistry
+//* https://github.com/lcpp-org/crane
+//*
+//* Crane is powered by the MOOSE Framework
+//* https://www.mooseframework.org
+//*
+//* Licensed under LGPL 2.1, please see LICENSE for details
+//* https://www.gnu.org/licenses/lgpl-2.1.html
+
 #pragma once
 
 #include "Kernel.h"

--- a/include/kernels/ReactionThirdOrderEnergyLog.h
+++ b/include/kernels/ReactionThirdOrderEnergyLog.h
@@ -1,3 +1,13 @@
+//* This file is part of Crane, an open-source
+//* application for plasma chemistry and thermochemistry
+//* https://github.com/lcpp-org/crane
+//*
+//* Crane is powered by the MOOSE Framework
+//* https://www.mooseframework.org
+//*
+//* Licensed under LGPL 2.1, please see LICENSE for details
+//* https://www.gnu.org/licenses/lgpl-2.1.html
+
 #pragma once
 
 #include "Kernel.h"

--- a/include/kernels/ReactionThirdOrderLog.h
+++ b/include/kernels/ReactionThirdOrderLog.h
@@ -1,3 +1,13 @@
+//* This file is part of Crane, an open-source
+//* application for plasma chemistry and thermochemistry
+//* https://github.com/lcpp-org/crane
+//*
+//* Crane is powered by the MOOSE Framework
+//* https://www.mooseframework.org
+//*
+//* Licensed under LGPL 2.1, please see LICENSE for details
+//* https://www.gnu.org/licenses/lgpl-2.1.html
+
 #pragma once
 
 #include "GenericKernel.h"

--- a/include/kernels/TimeDerivativeLog.h
+++ b/include/kernels/TimeDerivativeLog.h
@@ -1,3 +1,13 @@
+//* This file is part of Crane, an open-source
+//* application for plasma chemistry and thermochemistry
+//* https://github.com/lcpp-org/crane
+//*
+//* Crane is powered by the MOOSE Framework
+//* https://www.mooseframework.org
+//*
+//* Licensed under LGPL 2.1, please see LICENSE for details
+//* https://www.gnu.org/licenses/lgpl-2.1.html
+
 #pragma once
 
 #include "ADTimeDerivative.h"

--- a/include/materials/ADEEDFRateConstantTownsend.h
+++ b/include/materials/ADEEDFRateConstantTownsend.h
@@ -1,3 +1,13 @@
+//* This file is part of Crane, an open-source
+//* application for plasma chemistry and thermochemistry
+//* https://github.com/lcpp-org/crane
+//*
+//* Crane is powered by the MOOSE Framework
+//* https://www.mooseframework.org
+//*
+//* Licensed under LGPL 2.1, please see LICENSE for details
+//* https://www.gnu.org/licenses/lgpl-2.1.html
+
 #pragma once
 
 #include "ADMaterial.h"

--- a/include/materials/ADZapdosEEDFRateConstant.h
+++ b/include/materials/ADZapdosEEDFRateConstant.h
@@ -1,3 +1,13 @@
+//* This file is part of Crane, an open-source
+//* application for plasma chemistry and thermochemistry
+//* https://github.com/lcpp-org/crane
+//*
+//* Crane is powered by the MOOSE Framework
+//* https://www.mooseframework.org
+//*
+//* Licensed under LGPL 2.1, please see LICENSE for details
+//* https://www.gnu.org/licenses/lgpl-2.1.html
+
 #pragma once
 
 #include "ADMaterial.h"

--- a/include/materials/DiffusionRateTemp.h
+++ b/include/materials/DiffusionRateTemp.h
@@ -1,3 +1,13 @@
+//* This file is part of Crane, an open-source
+//* application for plasma chemistry and thermochemistry
+//* https://github.com/lcpp-org/crane
+//*
+//* Crane is powered by the MOOSE Framework
+//* https://www.mooseframework.org
+//*
+//* Licensed under LGPL 2.1, please see LICENSE for details
+//* https://www.gnu.org/licenses/lgpl-2.1.html
+
 #pragma once
 
 #include "Material.h"

--- a/include/materials/EEDFRateConstant.h
+++ b/include/materials/EEDFRateConstant.h
@@ -1,3 +1,13 @@
+//* This file is part of Crane, an open-source
+//* application for plasma chemistry and thermochemistry
+//* https://github.com/lcpp-org/crane
+//*
+//* Crane is powered by the MOOSE Framework
+//* https://www.mooseframework.org
+//*
+//* Licensed under LGPL 2.1, please see LICENSE for details
+//* https://www.gnu.org/licenses/lgpl-2.1.html
+
 #pragma once
 
 #include "Material.h"

--- a/include/materials/EEDFRateConstantTownsend.h
+++ b/include/materials/EEDFRateConstantTownsend.h
@@ -1,3 +1,13 @@
+//* This file is part of Crane, an open-source
+//* application for plasma chemistry and thermochemistry
+//* https://github.com/lcpp-org/crane
+//*
+//* Crane is powered by the MOOSE Framework
+//* https://www.mooseframework.org
+//*
+//* Licensed under LGPL 2.1, please see LICENSE for details
+//* https://www.gnu.org/licenses/lgpl-2.1.html
+
 #pragma once
 
 #include "Material.h"

--- a/include/materials/ElectricField.h
+++ b/include/materials/ElectricField.h
@@ -1,3 +1,13 @@
+//* This file is part of Crane, an open-source
+//* application for plasma chemistry and thermochemistry
+//* https://github.com/lcpp-org/crane
+//*
+//* Crane is powered by the MOOSE Framework
+//* https://www.mooseframework.org
+//*
+//* Licensed under LGPL 2.1, please see LICENSE for details
+//* https://www.gnu.org/licenses/lgpl-2.1.html
+
 #pragma once
 
 #include "Material.h"

--- a/include/materials/GenericRateConstant.h
+++ b/include/materials/GenericRateConstant.h
@@ -1,3 +1,13 @@
+//* This file is part of Crane, an open-source
+//* application for plasma chemistry and thermochemistry
+//* https://github.com/lcpp-org/crane
+//*
+//* Crane is powered by the MOOSE Framework
+//* https://www.mooseframework.org
+//*
+//* Licensed under LGPL 2.1, please see LICENSE for details
+//* https://www.gnu.org/licenses/lgpl-2.1.html
+
 #pragma once
 
 #include "Material.h"

--- a/include/materials/HeatCapacityRatio.h
+++ b/include/materials/HeatCapacityRatio.h
@@ -1,3 +1,13 @@
+//* This file is part of Crane, an open-source
+//* application for plasma chemistry and thermochemistry
+//* https://github.com/lcpp-org/crane
+//*
+//* Crane is powered by the MOOSE Framework
+//* https://www.mooseframework.org
+//*
+//* Licensed under LGPL 2.1, please see LICENSE for details
+//* https://www.gnu.org/licenses/lgpl-2.1.html
+
 #pragma once
 
 // #include "Material.h"

--- a/include/materials/InterpolatedCoefficientLinear.h
+++ b/include/materials/InterpolatedCoefficientLinear.h
@@ -1,3 +1,13 @@
+//* This file is part of Crane, an open-source
+//* application for plasma chemistry and thermochemistry
+//* https://github.com/lcpp-org/crane
+//*
+//* Crane is powered by the MOOSE Framework
+//* https://www.mooseframework.org
+//*
+//* Licensed under LGPL 2.1, please see LICENSE for details
+//* https://www.gnu.org/licenses/lgpl-2.1.html
+
 #pragma once
 
 #include "ADMaterial.h"

--- a/include/materials/InterpolatedCoefficientSpline.h
+++ b/include/materials/InterpolatedCoefficientSpline.h
@@ -1,3 +1,13 @@
+//* This file is part of Crane, an open-source
+//* application for plasma chemistry and thermochemistry
+//* https://github.com/lcpp-org/crane
+//*
+//* Crane is powered by the MOOSE Framework
+//* https://www.mooseframework.org
+//*
+//* Licensed under LGPL 2.1, please see LICENSE for details
+//* https://www.gnu.org/licenses/lgpl-2.1.html
+
 #pragma once
 
 #include "ADMaterial.h"

--- a/include/materials/SpeciesSum.h
+++ b/include/materials/SpeciesSum.h
@@ -1,3 +1,13 @@
+//* This file is part of Crane, an open-source
+//* application for plasma chemistry and thermochemistry
+//* https://github.com/lcpp-org/crane
+//*
+//* Crane is powered by the MOOSE Framework
+//* https://www.mooseframework.org
+//*
+//* Licensed under LGPL 2.1, please see LICENSE for details
+//* https://www.gnu.org/licenses/lgpl-2.1.html
+
 #pragma once
 
 #include "Material.h"

--- a/include/materials/SuperelasticReactionRate.h
+++ b/include/materials/SuperelasticReactionRate.h
@@ -1,3 +1,13 @@
+//* This file is part of Crane, an open-source
+//* application for plasma chemistry and thermochemistry
+//* https://github.com/lcpp-org/crane
+//*
+//* Crane is powered by the MOOSE Framework
+//* https://www.mooseframework.org
+//*
+//* Licensed under LGPL 2.1, please see LICENSE for details
+//* https://www.gnu.org/licenses/lgpl-2.1.html
+
 #pragma once
 
 #include "Material.h"

--- a/include/materials/ZapdosEEDFRateConstant.h
+++ b/include/materials/ZapdosEEDFRateConstant.h
@@ -1,3 +1,13 @@
+//* This file is part of Crane, an open-source
+//* application for plasma chemistry and thermochemistry
+//* https://github.com/lcpp-org/crane
+//*
+//* Crane is powered by the MOOSE Framework
+//* https://www.mooseframework.org
+//*
+//* Licensed under LGPL 2.1, please see LICENSE for details
+//* https://www.gnu.org/licenses/lgpl-2.1.html
+
 #pragma once
 
 #include "Material.h"

--- a/include/postprocessors/ElectricFieldCalculator.h
+++ b/include/postprocessors/ElectricFieldCalculator.h
@@ -1,3 +1,13 @@
+//* This file is part of Crane, an open-source
+//* application for plasma chemistry and thermochemistry
+//* https://github.com/lcpp-org/crane
+//*
+//* Crane is powered by the MOOSE Framework
+//* https://www.mooseframework.org
+//*
+//* Licensed under LGPL 2.1, please see LICENSE for details
+//* https://www.gnu.org/licenses/lgpl-2.1.html
+
 #pragma once
 
 // MOOSE includes

--- a/include/scalarkernels/EnergyTermScalar.h
+++ b/include/scalarkernels/EnergyTermScalar.h
@@ -1,3 +1,13 @@
+//* This file is part of Crane, an open-source
+//* application for plasma chemistry and thermochemistry
+//* https://github.com/lcpp-org/crane
+//*
+//* Crane is powered by the MOOSE Framework
+//* https://www.mooseframework.org
+//*
+//* Licensed under LGPL 2.1, please see LICENSE for details
+//* https://www.gnu.org/licenses/lgpl-2.1.html
+
 #pragma once
 
 #include "ODEKernel.h"

--- a/include/scalarkernels/LogStabilizationScalar.h
+++ b/include/scalarkernels/LogStabilizationScalar.h
@@ -1,3 +1,13 @@
+//* This file is part of Crane, an open-source
+//* application for plasma chemistry and thermochemistry
+//* https://github.com/lcpp-org/crane
+//*
+//* Crane is powered by the MOOSE Framework
+//* https://www.mooseframework.org
+//*
+//* Licensed under LGPL 2.1, please see LICENSE for details
+//* https://www.gnu.org/licenses/lgpl-2.1.html
+
 #pragma once
 
 #include "ODEKernel.h"

--- a/include/scalarkernels/ODETimeDerivativeLog.h
+++ b/include/scalarkernels/ODETimeDerivativeLog.h
@@ -1,3 +1,13 @@
+//* This file is part of Crane, an open-source
+//* application for plasma chemistry and thermochemistry
+//* https://github.com/lcpp-org/crane
+//*
+//* Crane is powered by the MOOSE Framework
+//* https://www.mooseframework.org
+//*
+//* Licensed under LGPL 2.1, please see LICENSE for details
+//* https://www.gnu.org/licenses/lgpl-2.1.html
+
 #pragma once
 
 #include "ODETimeKernel.h"

--- a/include/scalarkernels/ODETimeDerivativeTemperature.h
+++ b/include/scalarkernels/ODETimeDerivativeTemperature.h
@@ -1,8 +1,9 @@
-//* This file is part of the MOOSE framework
-//* https://www.mooseframework.org
+//* This file is part of Crane, an open-source
+//* application for plasma chemistry and thermochemistry
+//* https://github.com/lcpp-org/crane
 //*
-//* All rights reserved, see COPYRIGHT for full restrictions
-//* https://github.com/idaholab/moose/blob/master/COPYRIGHT
+//* Crane is powered by the MOOSE Framework
+//* https://www.mooseframework.org
 //*
 //* Licensed under LGPL 2.1, please see LICENSE for details
 //* https://www.gnu.org/licenses/lgpl-2.1.html

--- a/include/scalarkernels/ParsedScalarReaction.h
+++ b/include/scalarkernels/ParsedScalarReaction.h
@@ -1,3 +1,13 @@
+//* This file is part of Crane, an open-source
+//* application for plasma chemistry and thermochemistry
+//* https://github.com/lcpp-org/crane
+//*
+//* Crane is powered by the MOOSE Framework
+//* https://www.mooseframework.org
+//*
+//* Licensed under LGPL 2.1, please see LICENSE for details
+//* https://www.gnu.org/licenses/lgpl-2.1.html
+
 #pragma once
 
 #include "ParsedODEKernel.h"

--- a/include/scalarkernels/Product1BodyScalar.h
+++ b/include/scalarkernels/Product1BodyScalar.h
@@ -1,3 +1,13 @@
+//* This file is part of Crane, an open-source
+//* application for plasma chemistry and thermochemistry
+//* https://github.com/lcpp-org/crane
+//*
+//* Crane is powered by the MOOSE Framework
+//* https://www.mooseframework.org
+//*
+//* Licensed under LGPL 2.1, please see LICENSE for details
+//* https://www.gnu.org/licenses/lgpl-2.1.html
+
 #pragma once
 
 #include "ODEKernel.h"

--- a/include/scalarkernels/Product1BodyScalarLog.h
+++ b/include/scalarkernels/Product1BodyScalarLog.h
@@ -1,3 +1,13 @@
+//* This file is part of Crane, an open-source
+//* application for plasma chemistry and thermochemistry
+//* https://github.com/lcpp-org/crane
+//*
+//* Crane is powered by the MOOSE Framework
+//* https://www.mooseframework.org
+//*
+//* Licensed under LGPL 2.1, please see LICENSE for details
+//* https://www.gnu.org/licenses/lgpl-2.1.html
+
 #pragma once
 
 #include "ODEKernel.h"

--- a/include/scalarkernels/Product2BodyScalar.h
+++ b/include/scalarkernels/Product2BodyScalar.h
@@ -1,3 +1,13 @@
+//* This file is part of Crane, an open-source
+//* application for plasma chemistry and thermochemistry
+//* https://github.com/lcpp-org/crane
+//*
+//* Crane is powered by the MOOSE Framework
+//* https://www.mooseframework.org
+//*
+//* Licensed under LGPL 2.1, please see LICENSE for details
+//* https://www.gnu.org/licenses/lgpl-2.1.html
+
 #pragma once
 
 #include "ODEKernel.h"

--- a/include/scalarkernels/Product2BodyScalarLog.h
+++ b/include/scalarkernels/Product2BodyScalarLog.h
@@ -1,3 +1,13 @@
+//* This file is part of Crane, an open-source
+//* application for plasma chemistry and thermochemistry
+//* https://github.com/lcpp-org/crane
+//*
+//* Crane is powered by the MOOSE Framework
+//* https://www.mooseframework.org
+//*
+//* Licensed under LGPL 2.1, please see LICENSE for details
+//* https://www.gnu.org/licenses/lgpl-2.1.html
+
 #pragma once
 
 #include "ODEKernel.h"

--- a/include/scalarkernels/Product3BodyScalar.h
+++ b/include/scalarkernels/Product3BodyScalar.h
@@ -1,3 +1,13 @@
+//* This file is part of Crane, an open-source
+//* application for plasma chemistry and thermochemistry
+//* https://github.com/lcpp-org/crane
+//*
+//* Crane is powered by the MOOSE Framework
+//* https://www.mooseframework.org
+//*
+//* Licensed under LGPL 2.1, please see LICENSE for details
+//* https://www.gnu.org/licenses/lgpl-2.1.html
+
 #pragma once
 
 #include "ODEKernel.h"

--- a/include/scalarkernels/Product3BodyScalarLog.h
+++ b/include/scalarkernels/Product3BodyScalarLog.h
@@ -1,3 +1,13 @@
+//* This file is part of Crane, an open-source
+//* application for plasma chemistry and thermochemistry
+//* https://github.com/lcpp-org/crane
+//*
+//* Crane is powered by the MOOSE Framework
+//* https://www.mooseframework.org
+//*
+//* Licensed under LGPL 2.1, please see LICENSE for details
+//* https://www.gnu.org/licenses/lgpl-2.1.html
+
 #pragma once
 
 #include "ODEKernel.h"

--- a/include/scalarkernels/Reactant1BodyScalar.h
+++ b/include/scalarkernels/Reactant1BodyScalar.h
@@ -1,3 +1,13 @@
+//* This file is part of Crane, an open-source
+//* application for plasma chemistry and thermochemistry
+//* https://github.com/lcpp-org/crane
+//*
+//* Crane is powered by the MOOSE Framework
+//* https://www.mooseframework.org
+//*
+//* Licensed under LGPL 2.1, please see LICENSE for details
+//* https://www.gnu.org/licenses/lgpl-2.1.html
+
 #pragma once
 
 #include "ODEKernel.h"

--- a/include/scalarkernels/Reactant1BodyScalarLog.h
+++ b/include/scalarkernels/Reactant1BodyScalarLog.h
@@ -1,3 +1,13 @@
+//* This file is part of Crane, an open-source
+//* application for plasma chemistry and thermochemistry
+//* https://github.com/lcpp-org/crane
+//*
+//* Crane is powered by the MOOSE Framework
+//* https://www.mooseframework.org
+//*
+//* Licensed under LGPL 2.1, please see LICENSE for details
+//* https://www.gnu.org/licenses/lgpl-2.1.html
+
 #pragma once
 
 #include "ODEKernel.h"

--- a/include/scalarkernels/Reactant2BodyScalar.h
+++ b/include/scalarkernels/Reactant2BodyScalar.h
@@ -1,3 +1,13 @@
+//* This file is part of Crane, an open-source
+//* application for plasma chemistry and thermochemistry
+//* https://github.com/lcpp-org/crane
+//*
+//* Crane is powered by the MOOSE Framework
+//* https://www.mooseframework.org
+//*
+//* Licensed under LGPL 2.1, please see LICENSE for details
+//* https://www.gnu.org/licenses/lgpl-2.1.html
+
 #pragma once
 
 #include "ODEKernel.h"

--- a/include/scalarkernels/Reactant2BodyScalarLog.h
+++ b/include/scalarkernels/Reactant2BodyScalarLog.h
@@ -1,3 +1,13 @@
+//* This file is part of Crane, an open-source
+//* application for plasma chemistry and thermochemistry
+//* https://github.com/lcpp-org/crane
+//*
+//* Crane is powered by the MOOSE Framework
+//* https://www.mooseframework.org
+//*
+//* Licensed under LGPL 2.1, please see LICENSE for details
+//* https://www.gnu.org/licenses/lgpl-2.1.html
+
 #pragma once
 
 #include "ODEKernel.h"

--- a/include/scalarkernels/Reactant3BodyScalar.h
+++ b/include/scalarkernels/Reactant3BodyScalar.h
@@ -1,3 +1,13 @@
+//* This file is part of Crane, an open-source
+//* application for plasma chemistry and thermochemistry
+//* https://github.com/lcpp-org/crane
+//*
+//* Crane is powered by the MOOSE Framework
+//* https://www.mooseframework.org
+//*
+//* Licensed under LGPL 2.1, please see LICENSE for details
+//* https://www.gnu.org/licenses/lgpl-2.1.html
+
 #pragma once
 
 #include "ODEKernel.h"

--- a/include/scalarkernels/Reactant3BodyScalarLog.h
+++ b/include/scalarkernels/Reactant3BodyScalarLog.h
@@ -1,3 +1,13 @@
+//* This file is part of Crane, an open-source
+//* application for plasma chemistry and thermochemistry
+//* https://github.com/lcpp-org/crane
+//*
+//* Crane is powered by the MOOSE Framework
+//* https://www.mooseframework.org
+//*
+//* Licensed under LGPL 2.1, please see LICENSE for details
+//* https://www.gnu.org/licenses/lgpl-2.1.html
+
 #pragma once
 
 #include "ODEKernel.h"

--- a/include/scalarkernels/ScalarDiffusion.h
+++ b/include/scalarkernels/ScalarDiffusion.h
@@ -1,3 +1,13 @@
+//* This file is part of Crane, an open-source
+//* application for plasma chemistry and thermochemistry
+//* https://github.com/lcpp-org/crane
+//*
+//* Crane is powered by the MOOSE Framework
+//* https://www.mooseframework.org
+//*
+//* Licensed under LGPL 2.1, please see LICENSE for details
+//* https://www.gnu.org/licenses/lgpl-2.1.html
+
 #pragma once
 
 #include "ODEKernel.h"

--- a/include/userobjects/BoltzmannSolverScalar.h
+++ b/include/userobjects/BoltzmannSolverScalar.h
@@ -1,3 +1,13 @@
+//* This file is part of Crane, an open-source
+//* application for plasma chemistry and thermochemistry
+//* https://github.com/lcpp-org/crane
+//*
+//* Crane is powered by the MOOSE Framework
+//* https://www.mooseframework.org
+//*
+//* Licensed under LGPL 2.1, please see LICENSE for details
+//* https://www.gnu.org/licenses/lgpl-2.1.html
+
 #pragma once
 
 #include "GeneralUserObject.h"

--- a/include/userobjects/ObjTest.h
+++ b/include/userobjects/ObjTest.h
@@ -1,3 +1,13 @@
+//* This file is part of Crane, an open-source
+//* application for plasma chemistry and thermochemistry
+//* https://github.com/lcpp-org/crane
+//*
+//* Crane is powered by the MOOSE Framework
+//* https://www.mooseframework.org
+//*
+//* Licensed under LGPL 2.1, please see LICENSE for details
+//* https://www.gnu.org/licenses/lgpl-2.1.html
+
 #pragma once
 
 #include "GeneralUserObject.h"

--- a/include/userobjects/PolynomialCoefficients.h
+++ b/include/userobjects/PolynomialCoefficients.h
@@ -1,3 +1,13 @@
+//* This file is part of Crane, an open-source
+//* application for plasma chemistry and thermochemistry
+//* https://github.com/lcpp-org/crane
+//*
+//* Crane is powered by the MOOSE Framework
+//* https://www.mooseframework.org
+//*
+//* Licensed under LGPL 2.1, please see LICENSE for details
+//* https://www.gnu.org/licenses/lgpl-2.1.html
+
 #pragma once
 
 #include "GeneralUserObject.h"

--- a/include/userobjects/RateCoefficientProvider.h
+++ b/include/userobjects/RateCoefficientProvider.h
@@ -1,3 +1,13 @@
+//* This file is part of Crane, an open-source
+//* application for plasma chemistry and thermochemistry
+//* https://github.com/lcpp-org/crane
+//*
+//* Crane is powered by the MOOSE Framework
+//* https://www.mooseframework.org
+//*
+//* Licensed under LGPL 2.1, please see LICENSE for details
+//* https://www.gnu.org/licenses/lgpl-2.1.html
+
 #pragma once
 
 #include "GeneralUserObject.h"

--- a/include/userobjects/ValueProvider.h
+++ b/include/userobjects/ValueProvider.h
@@ -1,3 +1,13 @@
+//* This file is part of Crane, an open-source
+//* application for plasma chemistry and thermochemistry
+//* https://github.com/lcpp-org/crane
+//*
+//* Crane is powered by the MOOSE Framework
+//* https://www.mooseframework.org
+//*
+//* Licensed under LGPL 2.1, please see LICENSE for details
+//* https://www.gnu.org/licenses/lgpl-2.1.html
+
 #pragma once
 
 #include "GeneralUserObject.h"

--- a/problems/argon_microdischarge/argon_density_plot.py
+++ b/problems/argon_microdischarge/argon_density_plot.py
@@ -1,3 +1,13 @@
+#* This file is part of Crane, an open-source
+#* application for plasma chemistry and thermochemistry
+#* https://github.com/lcpp-org/crane
+#*
+#* Crane is powered by the MOOSE Framework
+#* https://www.mooseframework.org
+#*
+#* Licensed under LGPL 2.1, please see LICENSE for details
+#* https://www.gnu.org/licenses/lgpl-2.1.html
+
 import numpy as np
 import matplotlib.pyplot as plt
 import pandas as pd

--- a/problems/argon_microdischarge/rate_constant_plot.py
+++ b/problems/argon_microdischarge/rate_constant_plot.py
@@ -1,3 +1,13 @@
+#* This file is part of Crane, an open-source
+#* application for plasma chemistry and thermochemistry
+#* https://github.com/lcpp-org/crane
+#*
+#* Crane is powered by the MOOSE Framework
+#* https://www.mooseframework.org
+#*
+#* Licensed under LGPL 2.1, please see LICENSE for details
+#* https://www.gnu.org/licenses/lgpl-2.1.html
+
 import numpy as np
 import matplotlib.pyplot as plt
 import pandas as pd

--- a/problems/argon_microdischarge/reduced_field_plot.py
+++ b/problems/argon_microdischarge/reduced_field_plot.py
@@ -1,3 +1,13 @@
+#* This file is part of Crane, an open-source
+#* application for plasma chemistry and thermochemistry
+#* https://github.com/lcpp-org/crane
+#*
+#* Crane is powered by the MOOSE Framework
+#* https://www.mooseframework.org
+#*
+#* Licensed under LGPL 2.1, please see LICENSE for details
+#* https://www.gnu.org/licenses/lgpl-2.1.html
+
 import numpy as np
 import matplotlib.pyplot as plt
 import pandas as pd

--- a/problems/e5_plot.py
+++ b/problems/e5_plot.py
@@ -1,3 +1,13 @@
+#* This file is part of Crane, an open-source
+#* application for plasma chemistry and thermochemistry
+#* https://github.com/lcpp-org/crane
+#*
+#* Crane is powered by the MOOSE Framework
+#* https://www.mooseframework.org
+#*
+#* Licensed under LGPL 2.1, please see LICENSE for details
+#* https://www.gnu.org/licenses/lgpl-2.1.html
+
 import numpy as np
 import matplotlib.pylab as plt
 

--- a/problems/example1_plot.py
+++ b/problems/example1_plot.py
@@ -1,3 +1,13 @@
+#* This file is part of Crane, an open-source
+#* application for plasma chemistry and thermochemistry
+#* https://github.com/lcpp-org/crane
+#*
+#* Crane is powered by the MOOSE Framework
+#* https://www.mooseframework.org
+#*
+#* Licensed under LGPL 2.1, please see LICENSE for details
+#* https://www.gnu.org/licenses/lgpl-2.1.html
+
 import numpy as np
 import matplotlib.pylab as plt
 

--- a/problems/example2_plot.py
+++ b/problems/example2_plot.py
@@ -1,3 +1,13 @@
+#* This file is part of Crane, an open-source
+#* application for plasma chemistry and thermochemistry
+#* https://github.com/lcpp-org/crane
+#*
+#* Crane is powered by the MOOSE Framework
+#* https://www.mooseframework.org
+#*
+#* Licensed under LGPL 2.1, please see LICENSE for details
+#* https://www.gnu.org/licenses/lgpl-2.1.html
+
 import numpy as np
 from mpl_toolkits.mplot3d import Axes3D
 import matplotlib.pyplot as plt

--- a/problems/example3_comp.py
+++ b/problems/example3_comp.py
@@ -1,3 +1,13 @@
+#* This file is part of Crane, an open-source
+#* application for plasma chemistry and thermochemistry
+#* https://github.com/lcpp-org/crane
+#*
+#* Crane is powered by the MOOSE Framework
+#* https://www.mooseframework.org
+#*
+#* Licensed under LGPL 2.1, please see LICENSE for details
+#* https://www.gnu.org/licenses/lgpl-2.1.html
+
 import numpy as np
 import matplotlib.pylab as plt
 

--- a/problems/example3_plot.py
+++ b/problems/example3_plot.py
@@ -1,3 +1,13 @@
+#* This file is part of Crane, an open-source
+#* application for plasma chemistry and thermochemistry
+#* https://github.com/lcpp-org/crane
+#*
+#* Crane is powered by the MOOSE Framework
+#* https://www.mooseframework.org
+#*
+#* Licensed under LGPL 2.1, please see LICENSE for details
+#* https://www.gnu.org/licenses/lgpl-2.1.html
+
 import matplotlib.pylab as plt
 import numpy as np
 import csv

--- a/problems/example4_plot.py
+++ b/problems/example4_plot.py
@@ -1,3 +1,13 @@
+#* This file is part of Crane, an open-source
+#* application for plasma chemistry and thermochemistry
+#* https://github.com/lcpp-org/crane
+#*
+#* Crane is powered by the MOOSE Framework
+#* https://www.mooseframework.org
+#*
+#* Licensed under LGPL 2.1, please see LICENSE for details
+#* https://www.gnu.org/licenses/lgpl-2.1.html
+
 import matplotlib.pylab as plt
 from matplotlib.patches import Rectangle
 import numpy as np

--- a/problems/example5_plot.py
+++ b/problems/example5_plot.py
@@ -1,3 +1,13 @@
+#* This file is part of Crane, an open-source
+#* application for plasma chemistry and thermochemistry
+#* https://github.com/lcpp-org/crane
+#*
+#* Crane is powered by the MOOSE Framework
+#* https://www.mooseframework.org
+#*
+#* Licensed under LGPL 2.1, please see LICENSE for details
+#* https://www.gnu.org/licenses/lgpl-2.1.html
+
 import numpy as np
 import matplotlib.pylab as plt
 

--- a/problems/first_order_example/lieberman_ex1_comp.py
+++ b/problems/first_order_example/lieberman_ex1_comp.py
@@ -1,3 +1,13 @@
+#* This file is part of Crane, an open-source
+#* application for plasma chemistry and thermochemistry
+#* https://github.com/lcpp-org/crane
+#*
+#* Crane is powered by the MOOSE Framework
+#* https://www.mooseframework.org
+#*
+#* Licensed under LGPL 2.1, please see LICENSE for details
+#* https://www.gnu.org/licenses/lgpl-2.1.html
+
 import numpy as np
 import matplotlib.pyplot as plt
 

--- a/problems/first_order_example/lieberman_ex1_plot.py
+++ b/problems/first_order_example/lieberman_ex1_plot.py
@@ -1,3 +1,13 @@
+#* This file is part of Crane, an open-source
+#* application for plasma chemistry and thermochemistry
+#* https://github.com/lcpp-org/crane
+#*
+#* Crane is powered by the MOOSE Framework
+#* https://www.mooseframework.org
+#*
+#* Licensed under LGPL 2.1, please see LICENSE for details
+#* https://www.gnu.org/licenses/lgpl-2.1.html
+
 import numpy as np
 import matplotlib.pyplot as plt
 

--- a/problems/helium_oxygen_plot.py
+++ b/problems/helium_oxygen_plot.py
@@ -1,3 +1,13 @@
+#* This file is part of Crane, an open-source
+#* application for plasma chemistry and thermochemistry
+#* https://github.com/lcpp-org/crane
+#*
+#* Crane is powered by the MOOSE Framework
+#* https://www.mooseframework.org
+#*
+#* Licensed under LGPL 2.1, please see LICENSE for details
+#* https://www.gnu.org/licenses/lgpl-2.1.html
+
 import numpy as np
 import matplotlib.pylab as plt
 

--- a/problems/nitrogen_plasma/nitrogen_density_plot.py
+++ b/problems/nitrogen_plasma/nitrogen_density_plot.py
@@ -1,3 +1,13 @@
+#* This file is part of Crane, an open-source
+#* application for plasma chemistry and thermochemistry
+#* https://github.com/lcpp-org/crane
+#*
+#* Crane is powered by the MOOSE Framework
+#* https://www.mooseframework.org
+#*
+#* Licensed under LGPL 2.1, please see LICENSE for details
+#* https://www.gnu.org/licenses/lgpl-2.1.html
+
 import numpy as np
 import matplotlib.pyplot as plt
 import pandas as pd

--- a/scripts/fixup_headers.py
+++ b/scripts/fixup_headers.py
@@ -1,0 +1,179 @@
+#!/usr/bin/env python3
+
+# This script checks and can optionally update Crane source files.
+# You should always run this script without the "-u" option
+# first to make sure there is a clean dry run of the files that should
+# be updated
+# This is based on a script of the same name in the MOOSE Framework:
+# https://github.com/idaholab/moose/blob/master/framework/scripts/fixup_headers.py
+
+import os, string, re, shutil
+from optparse import OptionParser
+
+global_dir_ignores = ['contrib', '.svn', '.git', 'zapdos', 'moose', 'squirrel']
+global_file_ignores = ['moosedocs.py']
+
+unified_header = """\
+//* This file is part of Crane, an open-source
+//* application for plasma chemistry and thermochemistry
+//* https://github.com/lcpp-org/crane
+//*
+//* Crane is powered by the MOOSE Framework
+//* https://www.mooseframework.org
+//*
+//* Licensed under LGPL 2.1, please see LICENSE for details
+//* https://www.gnu.org/licenses/lgpl-2.1.html"""
+
+python_header = """\
+#* This file is part of Crane, an open-source
+#* application for plasma chemistry and thermochemistry
+#* https://github.com/lcpp-org/crane
+#*
+#* Crane is powered by the MOOSE Framework
+#* https://www.mooseframework.org
+#*
+#* Licensed under LGPL 2.1, please see LICENSE for details
+#* https://www.gnu.org/licenses/lgpl-2.1.html"""
+
+global_options = {}
+
+def fixupHeader():
+    for dirpath, dirnames, filenames in os.walk(os.getcwd() + ""):
+
+        # Don't traverse into ignored directories
+        for ignore in global_dir_ignores:
+            if ignore in dirnames:
+                dirnames.remove(ignore)
+
+        # Don't check ignored files
+        for ignore in global_file_ignores:
+            if ignore in filenames:
+                filenames.remove(ignore)
+
+        for file in filenames:
+            suffix = os.path.splitext(file)
+            if (suffix[-1] == '.C' or suffix[-1] == '.h') and not global_options.python_only:
+                checkAndUpdateCPlusPlus(os.path.abspath(dirpath + '/' + file))
+            if suffix[-1] == '.py' and not global_options.cxx_only:
+                checkAndUpdatePython(os.path.abspath(dirpath + '/' + file))
+
+def checkAndUpdateCPlusPlus(filename):
+    # Don't update soft links
+    if os.path.islink(filename):
+        return
+
+    f = open(filename)
+    text = f.read()
+    f.close()
+
+    header = unified_header
+
+    # Check (exact match only)
+    if (text.find(header) == -1 or global_options.force == True):
+        # print the first 10 lines or so of the file
+        if global_options.update == False: # Report only
+            print(filename + ' does not contain an up to date header')
+            if global_options.verbose == True:
+                print('>'*40, '\n', '\n'.join((text.split('\n', 10))[:10]), '\n'*5)
+        else:
+            # Make sure any previous C-style header version is removed
+            text = re.sub(r'^/\*+/$.*^/\*+/$', '', text, flags=re.S | re.M)
+
+            # Make sure that any previous C++-style header (with extra character)
+            # is also removed.
+            text = re.sub(r'(?:^//\*.*\n)*', '', text, flags=re.M)
+
+            # Now cleanup extra blank lines
+            text = re.sub(r'\A(^\s*\n)', '', text)
+
+            # Remove ifdefs in favor of pragmas
+            suffix = os.path.splitext(filename)
+            if suffix[-1] == '.h':
+                text = re.sub(r'^#ifndef\s*\S+_H_?\s*\n#define.*\n', '', text, flags=re.M)
+                text = re.sub(r'^#endif.*\n[\s]*\Z', '', text, flags=re.M)
+
+            # Update
+            f = open(filename + '~tmp', 'w')
+            f.write(header + '\n\n')
+
+            # Insert pragma once if not already present
+            if suffix[-1] == '.h':
+                if not re.search(r'#pragma once', text):
+                    f.write("#pragma once\n")
+
+            f.write(text)
+            f.close()
+            os.rename(filename + '~tmp', filename)
+
+def checkAndUpdatePython(filename):
+    f = open(filename)
+    text = f.read()
+    f.close()
+
+    header = python_header
+
+    # Check (exact match only)
+    if (text.find(header) == -1):
+        # print the first 10 lines or so of the file
+        if global_options.update == False: # Report only
+            print(filename + ' does not contain an up to date header')
+            if global_options.verbose == True:
+                print('>'*40, '\n', '\n'.join((text.split('\n', 10))[:10]), '\n'*5)
+        else:
+            # Save off the shebang line if it exists
+            m = re.match(r'#!.*\n', text)
+            shebang = ''
+            if m:
+                shebang = m.group(0)
+                text = re.sub(r'^.*\n', '', text)
+
+            # Save off any pytlint disable directives
+            m = re.match(r'\A#pylint:\s+disable.*\n', text)
+            pylint_disable = ''
+            if m:
+                pylint_disable = m.group(0)
+                text = re.sub(r'^.*\n', '', text)
+
+            pylint_enable = False
+            if re.search(r'#pylint: enable=missing-docstring', text) != None:
+                pylint_enable = True
+
+            # Make sure any previous box-style header version is removed
+            text = re.sub(r'\A(?:#.*#\n)*', '', text)
+
+            # Make sure any previous version of the new header is removed
+            text = re.sub(r'^#\*.*\n', '', text, flags=re.M)
+
+            # Discard any pylint missing-docstring commands
+            text = re.sub(r'\A#pylint:.*missing-docstring.*\n', '', text)
+
+            # Now cleanup extra blank lines at the beginning of the file
+            text = re.sub(r'\A(^\s*\n)', '', text)
+
+            # Update
+            f = open(filename + '~tmp', 'w')
+
+            f.write(shebang)
+            f.write(pylint_disable)
+            f.write(header + '\n')
+            if pylint_enable:
+                f.write('#pylint: enable=missing-docstring\n')
+
+            if len(text) != 0:
+                f.write('\n' + text)
+
+            f.close()
+
+            shutil.copystat(filename, filename + '~tmp')
+            os.rename(filename + '~tmp', filename)
+
+if __name__ == '__main__':
+    parser = OptionParser()
+    parser.add_option("-u", "--update", action="store_true", dest="update", default=False)
+    parser.add_option("-v", "--verbose", action="store_true", dest="verbose", default=False)
+    parser.add_option("--python-only", action="store_true", dest="python_only", default=False)
+    parser.add_option("--cxx-only", action="store_true", dest="cxx_only", default=False)
+    parser.add_option("-f", "--force", action="store_true", dest="force", default=False)
+
+    (global_options, args) = parser.parse_args()
+    fixupHeader()

--- a/src/actions/AddGeneralReactions.C
+++ b/src/actions/AddGeneralReactions.C
@@ -1,3 +1,13 @@
+//* This file is part of Crane, an open-source
+//* application for plasma chemistry and thermochemistry
+//* https://github.com/lcpp-org/crane
+//*
+//* Crane is powered by the MOOSE Framework
+//* https://www.mooseframework.org
+//*
+//* Licensed under LGPL 2.1, please see LICENSE for details
+//* https://www.gnu.org/licenses/lgpl-2.1.html
+
 #include "AddGeneralReactions.h"
 #include "Parser.h"
 #include "FEProblem.h"

--- a/src/actions/AddReactions.C
+++ b/src/actions/AddReactions.C
@@ -1,3 +1,13 @@
+//* This file is part of Crane, an open-source
+//* application for plasma chemistry and thermochemistry
+//* https://github.com/lcpp-org/crane
+//*
+//* Crane is powered by the MOOSE Framework
+//* https://www.mooseframework.org
+//*
+//* Licensed under LGPL 2.1, please see LICENSE for details
+//* https://www.gnu.org/licenses/lgpl-2.1.html
+
 #include "AddReactions.h"
 #include "Parser.h"
 #include "FEProblem.h"

--- a/src/actions/AddScalarReactions.C
+++ b/src/actions/AddScalarReactions.C
@@ -1,3 +1,13 @@
+//* This file is part of Crane, an open-source
+//* application for plasma chemistry and thermochemistry
+//* https://github.com/lcpp-org/crane
+//*
+//* Crane is powered by the MOOSE Framework
+//* https://www.mooseframework.org
+//*
+//* Licensed under LGPL 2.1, please see LICENSE for details
+//* https://www.gnu.org/licenses/lgpl-2.1.html
+
 #include "AddScalarReactions.h"
 #include "Parser.h"
 #include "FEProblem.h"

--- a/src/actions/AddSpecies.C
+++ b/src/actions/AddSpecies.C
@@ -1,4 +1,13 @@
-//* This file is part of the MOOSE framewo
+//* This file is part of Crane, an open-source
+//* application for plasma chemistry and thermochemistry
+//* https://github.com/lcpp-org/crane
+//*
+//* Crane is powered by the MOOSE Framework
+//* https://www.mooseframework.org
+//*
+//* Licensed under LGPL 2.1, please see LICENSE for details
+//* https://www.gnu.org/licenses/lgpl-2.1.html
+
 #include "AddSpecies.h"
 #include "FEProblem.h"
 

--- a/src/actions/AddZapdosReactions.C
+++ b/src/actions/AddZapdosReactions.C
@@ -1,3 +1,13 @@
+//* This file is part of Crane, an open-source
+//* application for plasma chemistry and thermochemistry
+//* https://github.com/lcpp-org/crane
+//*
+//* Crane is powered by the MOOSE Framework
+//* https://www.mooseframework.org
+//*
+//* Licensed under LGPL 2.1, please see LICENSE for details
+//* https://www.gnu.org/licenses/lgpl-2.1.html
+
 #include "AddZapdosReactions.h"
 #include "Parser.h"
 #include "FEProblem.h"

--- a/src/actions/ChemicalReactions.C
+++ b/src/actions/ChemicalReactions.C
@@ -1,3 +1,13 @@
+//* This file is part of Crane, an open-source
+//* application for plasma chemistry and thermochemistry
+//* https://github.com/lcpp-org/crane
+//*
+//* Crane is powered by the MOOSE Framework
+//* https://www.mooseframework.org
+//*
+//* Licensed under LGPL 2.1, please see LICENSE for details
+//* https://www.gnu.org/licenses/lgpl-2.1.html
+
 #include "ChemicalReactions.h"
 #include "Parser.h"
 #include "FEProblem.h"

--- a/src/actions/ChemicalReactionsBase.C
+++ b/src/actions/ChemicalReactionsBase.C
@@ -1,3 +1,13 @@
+//* This file is part of Crane, an open-source
+//* application for plasma chemistry and thermochemistry
+//* https://github.com/lcpp-org/crane
+//*
+//* Crane is powered by the MOOSE Framework
+//* https://www.mooseframework.org
+//*
+//* Licensed under LGPL 2.1, please see LICENSE for details
+//* https://www.gnu.org/licenses/lgpl-2.1.html
+
 #include "ChemicalReactionsBase.h"
 #include "Parser.h"
 #include "FEProblem.h"

--- a/src/auxkernels/AuxInitialConditionScalar.C
+++ b/src/auxkernels/AuxInitialConditionScalar.C
@@ -1,3 +1,13 @@
+//* This file is part of Crane, an open-source
+//* application for plasma chemistry and thermochemistry
+//* https://github.com/lcpp-org/crane
+//*
+//* Crane is powered by the MOOSE Framework
+//* https://www.mooseframework.org
+//*
+//* Licensed under LGPL 2.1, please see LICENSE for details
+//* https://www.gnu.org/licenses/lgpl-2.1.html
+
 #include "AuxInitialConditionScalar.h"
 
 registerMooseObject("CraneApp", AuxInitialConditionScalar);

--- a/src/auxkernels/BolsigValueScalar.C
+++ b/src/auxkernels/BolsigValueScalar.C
@@ -1,3 +1,13 @@
+//* This file is part of Crane, an open-source
+//* application for plasma chemistry and thermochemistry
+//* https://github.com/lcpp-org/crane
+//*
+//* Crane is powered by the MOOSE Framework
+//* https://www.mooseframework.org
+//*
+//* Licensed under LGPL 2.1, please see LICENSE for details
+//* https://www.gnu.org/licenses/lgpl-2.1.html
+
 #include "BolsigValueScalar.h"
 
 registerMooseObject("CraneApp", BolsigValueScalar);

--- a/src/auxkernels/DataRead.C
+++ b/src/auxkernels/DataRead.C
@@ -1,3 +1,13 @@
+//* This file is part of Crane, an open-source
+//* application for plasma chemistry and thermochemistry
+//* https://github.com/lcpp-org/crane
+//*
+//* Crane is powered by the MOOSE Framework
+//* https://www.mooseframework.org
+//*
+//* Licensed under LGPL 2.1, please see LICENSE for details
+//* https://www.gnu.org/licenses/lgpl-2.1.html
+
 #include "DataRead.h"
 
 registerMooseObject("CraneApp", DataRead);

--- a/src/auxkernels/DensityLogConvert.C
+++ b/src/auxkernels/DensityLogConvert.C
@@ -1,3 +1,13 @@
+//* This file is part of Crane, an open-source
+//* application for plasma chemistry and thermochemistry
+//* https://github.com/lcpp-org/crane
+//*
+//* Crane is powered by the MOOSE Framework
+//* https://www.mooseframework.org
+//*
+//* Licensed under LGPL 2.1, please see LICENSE for details
+//* https://www.gnu.org/licenses/lgpl-2.1.html
+
 #include "DensityLogConvert.h"
 
 registerMooseObject("CraneApp", DensityLogConvert);

--- a/src/auxkernels/DensityLogConvertScalar.C
+++ b/src/auxkernels/DensityLogConvertScalar.C
@@ -1,3 +1,13 @@
+//* This file is part of Crane, an open-source
+//* application for plasma chemistry and thermochemistry
+//* https://github.com/lcpp-org/crane
+//*
+//* Crane is powered by the MOOSE Framework
+//* https://www.mooseframework.org
+//*
+//* Licensed under LGPL 2.1, please see LICENSE for details
+//* https://www.gnu.org/licenses/lgpl-2.1.html
+
 #include "DensityLogConvertScalar.h"
 
 registerMooseObject("CraneApp", DensityLogConvertScalar);

--- a/src/auxkernels/EEDFRateCoefficientScalar.C
+++ b/src/auxkernels/EEDFRateCoefficientScalar.C
@@ -1,3 +1,13 @@
+//* This file is part of Crane, an open-source
+//* application for plasma chemistry and thermochemistry
+//* https://github.com/lcpp-org/crane
+//*
+//* Crane is powered by the MOOSE Framework
+//* https://www.mooseframework.org
+//*
+//* Licensed under LGPL 2.1, please see LICENSE for details
+//* https://www.gnu.org/licenses/lgpl-2.1.html
+
 #include "EEDFRateCoefficientScalar.h"
 
 registerMooseObject("CraneApp", EEDFRateCoefficientScalar);

--- a/src/auxkernels/ElectronMobility.C
+++ b/src/auxkernels/ElectronMobility.C
@@ -1,3 +1,13 @@
+//* This file is part of Crane, an open-source
+//* application for plasma chemistry and thermochemistry
+//* https://github.com/lcpp-org/crane
+//*
+//* Crane is powered by the MOOSE Framework
+//* https://www.mooseframework.org
+//*
+//* Licensed under LGPL 2.1, please see LICENSE for details
+//* https://www.gnu.org/licenses/lgpl-2.1.html
+
 #include "ElectronMobility.h"
 #include "MooseUtils.h"
 

--- a/src/auxkernels/MoleFraction.C
+++ b/src/auxkernels/MoleFraction.C
@@ -1,3 +1,13 @@
+//* This file is part of Crane, an open-source
+//* application for plasma chemistry and thermochemistry
+//* https://github.com/lcpp-org/crane
+//*
+//* Crane is powered by the MOOSE Framework
+//* https://www.mooseframework.org
+//*
+//* Licensed under LGPL 2.1, please see LICENSE for details
+//* https://www.gnu.org/licenses/lgpl-2.1.html
+
 #include "MoleFraction.h"
 
 registerMooseObject("CraneApp", MoleFraction);

--- a/src/auxkernels/ParsedAuxScalar.C
+++ b/src/auxkernels/ParsedAuxScalar.C
@@ -1,8 +1,9 @@
-//* This file is part of the MOOSE framework
-//* https://www.mooseframework.org
+//* This file is part of Crane, an open-source
+//* application for plasma chemistry and thermochemistry
+//* https://github.com/lcpp-org/crane
 //*
-//* All rights reserved, see COPYRIGHT for full restrictions
-//* https://github.com/idaholab/moose/blob/master/COPYRIGHT
+//* Crane is powered by the MOOSE Framework
+//* https://www.mooseframework.org
 //*
 //* Licensed under LGPL 2.1, please see LICENSE for details
 //* https://www.gnu.org/licenses/lgpl-2.1.html

--- a/src/auxkernels/ParsedScalarRateCoefficient.C
+++ b/src/auxkernels/ParsedScalarRateCoefficient.C
@@ -1,3 +1,13 @@
+//* This file is part of Crane, an open-source
+//* application for plasma chemistry and thermochemistry
+//* https://github.com/lcpp-org/crane
+//*
+//* Crane is powered by the MOOSE Framework
+//* https://www.mooseframework.org
+//*
+//* Licensed under LGPL 2.1, please see LICENSE for details
+//* https://www.gnu.org/licenses/lgpl-2.1.html
+
 #include "ParsedScalarRateCoefficient.h"
 
 registerMooseObject("CraneApp", ParsedScalarRateCoefficient);

--- a/src/auxkernels/ReactionRateEEDFTownsendLog.C
+++ b/src/auxkernels/ReactionRateEEDFTownsendLog.C
@@ -1,3 +1,13 @@
+//* This file is part of Crane, an open-source
+//* application for plasma chemistry and thermochemistry
+//* https://github.com/lcpp-org/crane
+//*
+//* Crane is powered by the MOOSE Framework
+//* https://www.mooseframework.org
+//*
+//* Licensed under LGPL 2.1, please see LICENSE for details
+//* https://www.gnu.org/licenses/lgpl-2.1.html
+
 #include "ReactionRateEEDFTownsendLog.h"
 
 #include "metaphysicl/raw_type.h"

--- a/src/auxkernels/ReactionRateFirstOrder.C
+++ b/src/auxkernels/ReactionRateFirstOrder.C
@@ -1,3 +1,13 @@
+//* This file is part of Crane, an open-source
+//* application for plasma chemistry and thermochemistry
+//* https://github.com/lcpp-org/crane
+//*
+//* Crane is powered by the MOOSE Framework
+//* https://www.mooseframework.org
+//*
+//* Licensed under LGPL 2.1, please see LICENSE for details
+//* https://www.gnu.org/licenses/lgpl-2.1.html
+
 #include "ReactionRateFirstOrder.h"
 
 registerMooseObject("CraneApp", ReactionRateFirstOrder);

--- a/src/auxkernels/ReactionRateFirstOrderLog.C
+++ b/src/auxkernels/ReactionRateFirstOrderLog.C
@@ -1,3 +1,13 @@
+//* This file is part of Crane, an open-source
+//* application for plasma chemistry and thermochemistry
+//* https://github.com/lcpp-org/crane
+//*
+//* Crane is powered by the MOOSE Framework
+//* https://www.mooseframework.org
+//*
+//* Licensed under LGPL 2.1, please see LICENSE for details
+//* https://www.gnu.org/licenses/lgpl-2.1.html
+
 #include "ReactionRateFirstOrderLog.h"
 
 registerMooseObject("CraneApp", ReactionRateFirstOrderLog);

--- a/src/auxkernels/ReactionRateOneBodyScalar.C
+++ b/src/auxkernels/ReactionRateOneBodyScalar.C
@@ -1,3 +1,13 @@
+//* This file is part of Crane, an open-source
+//* application for plasma chemistry and thermochemistry
+//* https://github.com/lcpp-org/crane
+//*
+//* Crane is powered by the MOOSE Framework
+//* https://www.mooseframework.org
+//*
+//* Licensed under LGPL 2.1, please see LICENSE for details
+//* https://www.gnu.org/licenses/lgpl-2.1.html
+
 #include "ReactionRateOneBodyScalar.h"
 
 registerMooseObject("CraneApp", ReactionRateOneBodyScalar);

--- a/src/auxkernels/ReactionRateSecondOrder.C
+++ b/src/auxkernels/ReactionRateSecondOrder.C
@@ -1,3 +1,13 @@
+//* This file is part of Crane, an open-source
+//* application for plasma chemistry and thermochemistry
+//* https://github.com/lcpp-org/crane
+//*
+//* Crane is powered by the MOOSE Framework
+//* https://www.mooseframework.org
+//*
+//* Licensed under LGPL 2.1, please see LICENSE for details
+//* https://www.gnu.org/licenses/lgpl-2.1.html
+
 #include "ReactionRateSecondOrder.h"
 
 registerMooseObject("CraneApp", ReactionRateSecondOrder);

--- a/src/auxkernels/ReactionRateSecondOrderLog.C
+++ b/src/auxkernels/ReactionRateSecondOrderLog.C
@@ -1,3 +1,13 @@
+//* This file is part of Crane, an open-source
+//* application for plasma chemistry and thermochemistry
+//* https://github.com/lcpp-org/crane
+//*
+//* Crane is powered by the MOOSE Framework
+//* https://www.mooseframework.org
+//*
+//* Licensed under LGPL 2.1, please see LICENSE for details
+//* https://www.gnu.org/licenses/lgpl-2.1.html
+
 #include "ReactionRateSecondOrderLog.h"
 
 registerMooseObject("CraneApp", ReactionRateSecondOrderLog);

--- a/src/auxkernels/ReactionRateThirdOrder.C
+++ b/src/auxkernels/ReactionRateThirdOrder.C
@@ -1,3 +1,13 @@
+//* This file is part of Crane, an open-source
+//* application for plasma chemistry and thermochemistry
+//* https://github.com/lcpp-org/crane
+//*
+//* Crane is powered by the MOOSE Framework
+//* https://www.mooseframework.org
+//*
+//* Licensed under LGPL 2.1, please see LICENSE for details
+//* https://www.gnu.org/licenses/lgpl-2.1.html
+
 #include "ReactionRateThirdOrder.h"
 
 registerMooseObject("CraneApp", ReactionRateThirdOrder);

--- a/src/auxkernels/ReactionRateThirdOrderLog.C
+++ b/src/auxkernels/ReactionRateThirdOrderLog.C
@@ -1,3 +1,13 @@
+//* This file is part of Crane, an open-source
+//* application for plasma chemistry and thermochemistry
+//* https://github.com/lcpp-org/crane
+//*
+//* Crane is powered by the MOOSE Framework
+//* https://www.mooseframework.org
+//*
+//* Licensed under LGPL 2.1, please see LICENSE for details
+//* https://www.gnu.org/licenses/lgpl-2.1.html
+
 #include "ReactionRateThirdOrderLog.h"
 
 registerMooseObject("CraneApp", ReactionRateThirdOrderLog);

--- a/src/auxkernels/ReactionRateThreeBodyScalar.C
+++ b/src/auxkernels/ReactionRateThreeBodyScalar.C
@@ -1,3 +1,13 @@
+//* This file is part of Crane, an open-source
+//* application for plasma chemistry and thermochemistry
+//* https://github.com/lcpp-org/crane
+//*
+//* Crane is powered by the MOOSE Framework
+//* https://www.mooseframework.org
+//*
+//* Licensed under LGPL 2.1, please see LICENSE for details
+//* https://www.gnu.org/licenses/lgpl-2.1.html
+
 #include "ReactionRateThreeBodyScalar.h"
 
 registerMooseObject("CraneApp", ReactionRateThreeBodyScalar);

--- a/src/auxkernels/ReactionRateTwoBodyScalar.C
+++ b/src/auxkernels/ReactionRateTwoBodyScalar.C
@@ -1,3 +1,13 @@
+//* This file is part of Crane, an open-source
+//* application for plasma chemistry and thermochemistry
+//* https://github.com/lcpp-org/crane
+//*
+//* Crane is powered by the MOOSE Framework
+//* https://www.mooseframework.org
+//*
+//* Licensed under LGPL 2.1, please see LICENSE for details
+//* https://www.gnu.org/licenses/lgpl-2.1.html
+
 #include "ReactionRateTwoBodyScalar.h"
 
 registerMooseObject("CraneApp", ReactionRateTwoBodyScalar);

--- a/src/auxkernels/ReducedField.C
+++ b/src/auxkernels/ReducedField.C
@@ -1,3 +1,13 @@
+//* This file is part of Crane, an open-source
+//* application for plasma chemistry and thermochemistry
+//* https://github.com/lcpp-org/crane
+//*
+//* Crane is powered by the MOOSE Framework
+//* https://www.mooseframework.org
+//*
+//* Licensed under LGPL 2.1, please see LICENSE for details
+//* https://www.gnu.org/licenses/lgpl-2.1.html
+
 #include "ReducedField.h"
 #include "MooseUtils.h"
 

--- a/src/auxkernels/ReducedFieldScalar.C
+++ b/src/auxkernels/ReducedFieldScalar.C
@@ -1,8 +1,9 @@
-//* This file is part of the MOOSE framework
-//* https://www.mooseframework.org
+//* This file is part of Crane, an open-source
+//* application for plasma chemistry and thermochemistry
+//* https://github.com/lcpp-org/crane
 //*
-//* All rights reserved, see COPYRIGHT for full restrictions
-//* https://github.com/idaholab/moose/blob/master/COPYRIGHT
+//* Crane is powered by the MOOSE Framework
+//* https://www.mooseframework.org
 //*
 //* Licensed under LGPL 2.1, please see LICENSE for details
 //* https://www.gnu.org/licenses/lgpl-2.1.html

--- a/src/auxkernels/ScalarLinearInterpolation.C
+++ b/src/auxkernels/ScalarLinearInterpolation.C
@@ -1,3 +1,13 @@
+//* This file is part of Crane, an open-source
+//* application for plasma chemistry and thermochemistry
+//* https://github.com/lcpp-org/crane
+//*
+//* Crane is powered by the MOOSE Framework
+//* https://www.mooseframework.org
+//*
+//* Licensed under LGPL 2.1, please see LICENSE for details
+//* https://www.gnu.org/licenses/lgpl-2.1.html
+
 #include "ScalarLinearInterpolation.h"
 
 registerMooseObject("CraneApp", ScalarLinearInterpolation);

--- a/src/auxkernels/ScalarSplineInterpolation.C
+++ b/src/auxkernels/ScalarSplineInterpolation.C
@@ -1,3 +1,13 @@
+//* This file is part of Crane, an open-source
+//* application for plasma chemistry and thermochemistry
+//* https://github.com/lcpp-org/crane
+//*
+//* Crane is powered by the MOOSE Framework
+//* https://www.mooseframework.org
+//*
+//* Licensed under LGPL 2.1, please see LICENSE for details
+//* https://www.gnu.org/licenses/lgpl-2.1.html
+
 #include "ScalarSplineInterpolation.h"
 
 registerMooseObject("CraneApp", ScalarSplineInterpolation);

--- a/src/auxkernels/SuperelasticRateCoefficientScalar.C
+++ b/src/auxkernels/SuperelasticRateCoefficientScalar.C
@@ -1,3 +1,13 @@
+//* This file is part of Crane, an open-source
+//* application for plasma chemistry and thermochemistry
+//* https://github.com/lcpp-org/crane
+//*
+//* Crane is powered by the MOOSE Framework
+//* https://www.mooseframework.org
+//*
+//* Licensed under LGPL 2.1, please see LICENSE for details
+//* https://www.gnu.org/licenses/lgpl-2.1.html
+
 #include "SuperelasticRateCoefficientScalar.h"
 
 registerMooseObject("CraneApp", SuperelasticRateCoefficientScalar);

--- a/src/auxkernels/VariableSum.C
+++ b/src/auxkernels/VariableSum.C
@@ -1,3 +1,13 @@
+//* This file is part of Crane, an open-source
+//* application for plasma chemistry and thermochemistry
+//* https://github.com/lcpp-org/crane
+//*
+//* Crane is powered by the MOOSE Framework
+//* https://www.mooseframework.org
+//*
+//* Licensed under LGPL 2.1, please see LICENSE for details
+//* https://www.gnu.org/licenses/lgpl-2.1.html
+
 #include "VariableSum.h"
 
 registerMooseObject("CraneApp", VariableSum);

--- a/src/auxkernels/VariableSumLog.C
+++ b/src/auxkernels/VariableSumLog.C
@@ -1,3 +1,13 @@
+//* This file is part of Crane, an open-source
+//* application for plasma chemistry and thermochemistry
+//* https://github.com/lcpp-org/crane
+//*
+//* Crane is powered by the MOOSE Framework
+//* https://www.mooseframework.org
+//*
+//* Licensed under LGPL 2.1, please see LICENSE for details
+//* https://www.gnu.org/licenses/lgpl-2.1.html
+
 #include "VariableSumLog.h"
 
 registerMooseObject("CraneApp", VariableSumLog);

--- a/src/base/CraneApp.C
+++ b/src/base/CraneApp.C
@@ -1,3 +1,13 @@
+//* This file is part of Crane, an open-source
+//* application for plasma chemistry and thermochemistry
+//* https://github.com/lcpp-org/crane
+//*
+//* Crane is powered by the MOOSE Framework
+//* https://www.mooseframework.org
+//*
+//* Licensed under LGPL 2.1, please see LICENSE for details
+//* https://www.gnu.org/licenses/lgpl-2.1.html
+
 #include "CraneApp.h"
 #include "Moose.h"
 #include "AppFactory.h"

--- a/src/kernels/ADEEDFElasticLog.C
+++ b/src/kernels/ADEEDFElasticLog.C
@@ -1,3 +1,13 @@
+//* This file is part of Crane, an open-source
+//* application for plasma chemistry and thermochemistry
+//* https://github.com/lcpp-org/crane
+//*
+//* Crane is powered by the MOOSE Framework
+//* https://www.mooseframework.org
+//*
+//* Licensed under LGPL 2.1, please see LICENSE for details
+//* https://www.gnu.org/licenses/lgpl-2.1.html
+
 #include "ADEEDFElasticLog.h"
 
 // MOOSE includes

--- a/src/kernels/ADEEDFElasticTownsendLog.C
+++ b/src/kernels/ADEEDFElasticTownsendLog.C
@@ -1,3 +1,13 @@
+//* This file is part of Crane, an open-source
+//* application for plasma chemistry and thermochemistry
+//* https://github.com/lcpp-org/crane
+//*
+//* Crane is powered by the MOOSE Framework
+//* https://www.mooseframework.org
+//*
+//* Licensed under LGPL 2.1, please see LICENSE for details
+//* https://www.gnu.org/licenses/lgpl-2.1.html
+
 #include "ADEEDFElasticTownsendLog.h"
 
 // MOOSE includes

--- a/src/kernels/ADEEDFEnergyLog.C
+++ b/src/kernels/ADEEDFEnergyLog.C
@@ -1,3 +1,13 @@
+//* This file is part of Crane, an open-source
+//* application for plasma chemistry and thermochemistry
+//* https://github.com/lcpp-org/crane
+//*
+//* Crane is powered by the MOOSE Framework
+//* https://www.mooseframework.org
+//*
+//* Licensed under LGPL 2.1, please see LICENSE for details
+//* https://www.gnu.org/licenses/lgpl-2.1.html
+
 #include "ADEEDFEnergyLog.h"
 
 // MOOSE includes

--- a/src/kernels/ADEEDFEnergyTownsendLog.C
+++ b/src/kernels/ADEEDFEnergyTownsendLog.C
@@ -1,3 +1,13 @@
+//* This file is part of Crane, an open-source
+//* application for plasma chemistry and thermochemistry
+//* https://github.com/lcpp-org/crane
+//*
+//* Crane is powered by the MOOSE Framework
+//* https://www.mooseframework.org
+//*
+//* Licensed under LGPL 2.1, please see LICENSE for details
+//* https://www.gnu.org/licenses/lgpl-2.1.html
+
 #include "ADEEDFEnergyTownsendLog.h"
 
 // MOOSE includes

--- a/src/kernels/ADEEDFReactionLog.C
+++ b/src/kernels/ADEEDFReactionLog.C
@@ -1,3 +1,13 @@
+//* This file is part of Crane, an open-source
+//* application for plasma chemistry and thermochemistry
+//* https://github.com/lcpp-org/crane
+//*
+//* Crane is powered by the MOOSE Framework
+//* https://www.mooseframework.org
+//*
+//* Licensed under LGPL 2.1, please see LICENSE for details
+//* https://www.gnu.org/licenses/lgpl-2.1.html
+
 #include "ADEEDFReactionLog.h"
 
 // MOOSE includes

--- a/src/kernels/ADEEDFReactionTownsend.C
+++ b/src/kernels/ADEEDFReactionTownsend.C
@@ -1,3 +1,13 @@
+//* This file is part of Crane, an open-source
+//* application for plasma chemistry and thermochemistry
+//* https://github.com/lcpp-org/crane
+//*
+//* Crane is powered by the MOOSE Framework
+//* https://www.mooseframework.org
+//*
+//* Licensed under LGPL 2.1, please see LICENSE for details
+//* https://www.gnu.org/licenses/lgpl-2.1.html
+
 #include "ADEEDFReactionTownsendLog.h"
 
 // MOOSE includes

--- a/src/kernels/EEDFElasticLog.C
+++ b/src/kernels/EEDFElasticLog.C
@@ -1,8 +1,8 @@
-//* This file is part of CRANE, an open-source
-//* application for the simulation of plasmas
+//* This file is part of Crane, an open-source
+//* application for plasma chemistry and thermochemistry
 //* https://github.com/lcpp-org/crane
 //*
-//* CRANE is powered by the MOOSE Framework
+//* Crane is powered by the MOOSE Framework
 //* https://www.mooseframework.org
 //*
 //* Licensed under LGPL 2.1, please see LICENSE for details

--- a/src/kernels/EEDFElasticTownsendLog.C
+++ b/src/kernels/EEDFElasticTownsendLog.C
@@ -1,8 +1,8 @@
-//* This file is part of CRANE, an open-source
-//* application for the simulation of plasmas
+//* This file is part of Crane, an open-source
+//* application for plasma chemistry and thermochemistry
 //* https://github.com/lcpp-org/crane
 //*
-//* CRANE is powered by the MOOSE Framework
+//* Crane is powered by the MOOSE Framework
 //* https://www.mooseframework.org
 //*
 //* Licensed under LGPL 2.1, please see LICENSE for details

--- a/src/kernels/EEDFEnergyLog.C
+++ b/src/kernels/EEDFEnergyLog.C
@@ -1,3 +1,13 @@
+//* This file is part of Crane, an open-source
+//* application for plasma chemistry and thermochemistry
+//* https://github.com/lcpp-org/crane
+//*
+//* Crane is powered by the MOOSE Framework
+//* https://www.mooseframework.org
+//*
+//* Licensed under LGPL 2.1, please see LICENSE for details
+//* https://www.gnu.org/licenses/lgpl-2.1.html
+
 #include "EEDFEnergyLog.h"
 
 registerMooseObject("CraneApp", EEDFEnergyLog);

--- a/src/kernels/EEDFEnergyTownsendLog.C
+++ b/src/kernels/EEDFEnergyTownsendLog.C
@@ -1,3 +1,13 @@
+//* This file is part of Crane, an open-source
+//* application for plasma chemistry and thermochemistry
+//* https://github.com/lcpp-org/crane
+//*
+//* Crane is powered by the MOOSE Framework
+//* https://www.mooseframework.org
+//*
+//* Licensed under LGPL 2.1, please see LICENSE for details
+//* https://www.gnu.org/licenses/lgpl-2.1.html
+
 #include "EEDFEnergyTownsendLog.h"
 
 registerMooseObject("CraneApp", EEDFEnergyTownsendLog);

--- a/src/kernels/EEDFReactionLog.C
+++ b/src/kernels/EEDFReactionLog.C
@@ -1,3 +1,13 @@
+//* This file is part of Crane, an open-source
+//* application for plasma chemistry and thermochemistry
+//* https://github.com/lcpp-org/crane
+//*
+//* Crane is powered by the MOOSE Framework
+//* https://www.mooseframework.org
+//*
+//* Licensed under LGPL 2.1, please see LICENSE for details
+//* https://www.gnu.org/licenses/lgpl-2.1.html
+
 #include "EEDFReactionLog.h"
 
 // MOOSE includes

--- a/src/kernels/EEDFReactionTownsendLog.C
+++ b/src/kernels/EEDFReactionTownsendLog.C
@@ -1,3 +1,13 @@
+//* This file is part of Crane, an open-source
+//* application for plasma chemistry and thermochemistry
+//* https://github.com/lcpp-org/crane
+//*
+//* Crane is powered by the MOOSE Framework
+//* https://www.mooseframework.org
+//*
+//* Licensed under LGPL 2.1, please see LICENSE for details
+//* https://www.gnu.org/licenses/lgpl-2.1.html
+
 #include "EEDFReactionTownsendLog.h"
 
 // MOOSE includes

--- a/src/kernels/LogStabilization.C
+++ b/src/kernels/LogStabilization.C
@@ -1,3 +1,13 @@
+//* This file is part of Crane, an open-source
+//* application for plasma chemistry and thermochemistry
+//* https://github.com/lcpp-org/crane
+//*
+//* Crane is powered by the MOOSE Framework
+//* https://www.mooseframework.org
+//*
+//* Licensed under LGPL 2.1, please see LICENSE for details
+//* https://www.gnu.org/licenses/lgpl-2.1.html
+
 #include "LogStabilization.h"
 
 registerMooseObject("CraneApp", LogStabilization);

--- a/src/kernels/ReactionFirstOrder.C
+++ b/src/kernels/ReactionFirstOrder.C
@@ -1,3 +1,13 @@
+//* This file is part of Crane, an open-source
+//* application for plasma chemistry and thermochemistry
+//* https://github.com/lcpp-org/crane
+//*
+//* Crane is powered by the MOOSE Framework
+//* https://www.mooseframework.org
+//*
+//* Licensed under LGPL 2.1, please see LICENSE for details
+//* https://www.gnu.org/licenses/lgpl-2.1.html
+
 #include "ReactionFirstOrder.h"
 
 // MOOSE includes

--- a/src/kernels/ReactionFirstOrderEnergy.C
+++ b/src/kernels/ReactionFirstOrderEnergy.C
@@ -1,3 +1,13 @@
+//* This file is part of Crane, an open-source
+//* application for plasma chemistry and thermochemistry
+//* https://github.com/lcpp-org/crane
+//*
+//* Crane is powered by the MOOSE Framework
+//* https://www.mooseframework.org
+//*
+//* Licensed under LGPL 2.1, please see LICENSE for details
+//* https://www.gnu.org/licenses/lgpl-2.1.html
+
 #include "ReactionFirstOrderEnergy.h"
 
 // MOOSE includes

--- a/src/kernels/ReactionFirstOrderEnergyLog.C
+++ b/src/kernels/ReactionFirstOrderEnergyLog.C
@@ -1,3 +1,13 @@
+//* This file is part of Crane, an open-source
+//* application for plasma chemistry and thermochemistry
+//* https://github.com/lcpp-org/crane
+//*
+//* Crane is powered by the MOOSE Framework
+//* https://www.mooseframework.org
+//*
+//* Licensed under LGPL 2.1, please see LICENSE for details
+//* https://www.gnu.org/licenses/lgpl-2.1.html
+
 #include "ReactionFirstOrderEnergyLog.h"
 
 // MOOSE includes

--- a/src/kernels/ReactionFirstOrderLog.C
+++ b/src/kernels/ReactionFirstOrderLog.C
@@ -1,3 +1,13 @@
+//* This file is part of Crane, an open-source
+//* application for plasma chemistry and thermochemistry
+//* https://github.com/lcpp-org/crane
+//*
+//* Crane is powered by the MOOSE Framework
+//* https://www.mooseframework.org
+//*
+//* Licensed under LGPL 2.1, please see LICENSE for details
+//* https://www.gnu.org/licenses/lgpl-2.1.html
+
 #include "ReactionFirstOrderLog.h"
 
 // MOOSE includes

--- a/src/kernels/ReactionSecondOrder.C
+++ b/src/kernels/ReactionSecondOrder.C
@@ -1,3 +1,13 @@
+//* This file is part of Crane, an open-source
+//* application for plasma chemistry and thermochemistry
+//* https://github.com/lcpp-org/crane
+//*
+//* Crane is powered by the MOOSE Framework
+//* https://www.mooseframework.org
+//*
+//* Licensed under LGPL 2.1, please see LICENSE for details
+//* https://www.gnu.org/licenses/lgpl-2.1.html
+
 #include "ReactionSecondOrder.h"
 
 // MOOSE includes

--- a/src/kernels/ReactionSecondOrderEnergy.C
+++ b/src/kernels/ReactionSecondOrderEnergy.C
@@ -1,3 +1,13 @@
+//* This file is part of Crane, an open-source
+//* application for plasma chemistry and thermochemistry
+//* https://github.com/lcpp-org/crane
+//*
+//* Crane is powered by the MOOSE Framework
+//* https://www.mooseframework.org
+//*
+//* Licensed under LGPL 2.1, please see LICENSE for details
+//* https://www.gnu.org/licenses/lgpl-2.1.html
+
 #include "ReactionSecondOrderEnergy.h"
 
 // MOOSE includes

--- a/src/kernels/ReactionSecondOrderEnergyLog.C
+++ b/src/kernels/ReactionSecondOrderEnergyLog.C
@@ -1,3 +1,13 @@
+//* This file is part of Crane, an open-source
+//* application for plasma chemistry and thermochemistry
+//* https://github.com/lcpp-org/crane
+//*
+//* Crane is powered by the MOOSE Framework
+//* https://www.mooseframework.org
+//*
+//* Licensed under LGPL 2.1, please see LICENSE for details
+//* https://www.gnu.org/licenses/lgpl-2.1.html
+
 #include "ReactionSecondOrderEnergyLog.h"
 
 // MOOSE includes

--- a/src/kernels/ReactionSecondOrderLog.C
+++ b/src/kernels/ReactionSecondOrderLog.C
@@ -1,3 +1,13 @@
+//* This file is part of Crane, an open-source
+//* application for plasma chemistry and thermochemistry
+//* https://github.com/lcpp-org/crane
+//*
+//* Crane is powered by the MOOSE Framework
+//* https://www.mooseframework.org
+//*
+//* Licensed under LGPL 2.1, please see LICENSE for details
+//* https://www.gnu.org/licenses/lgpl-2.1.html
+
 #include "ReactionSecondOrderLog.h"
 
 using MetaPhysicL::raw_value;

--- a/src/kernels/ReactionThirdOrder.C
+++ b/src/kernels/ReactionThirdOrder.C
@@ -1,3 +1,13 @@
+//* This file is part of Crane, an open-source
+//* application for plasma chemistry and thermochemistry
+//* https://github.com/lcpp-org/crane
+//*
+//* Crane is powered by the MOOSE Framework
+//* https://www.mooseframework.org
+//*
+//* Licensed under LGPL 2.1, please see LICENSE for details
+//* https://www.gnu.org/licenses/lgpl-2.1.html
+
 #include "ReactionThirdOrder.h"
 
 // MOOSE includes

--- a/src/kernels/ReactionThirdOrderEnergy.C
+++ b/src/kernels/ReactionThirdOrderEnergy.C
@@ -1,3 +1,13 @@
+//* This file is part of Crane, an open-source
+//* application for plasma chemistry and thermochemistry
+//* https://github.com/lcpp-org/crane
+//*
+//* Crane is powered by the MOOSE Framework
+//* https://www.mooseframework.org
+//*
+//* Licensed under LGPL 2.1, please see LICENSE for details
+//* https://www.gnu.org/licenses/lgpl-2.1.html
+
 #include "ReactionThirdOrderEnergy.h"
 
 // MOOSE includes

--- a/src/kernels/ReactionThirdOrderEnergyLog.C
+++ b/src/kernels/ReactionThirdOrderEnergyLog.C
@@ -1,3 +1,13 @@
+//* This file is part of Crane, an open-source
+//* application for plasma chemistry and thermochemistry
+//* https://github.com/lcpp-org/crane
+//*
+//* Crane is powered by the MOOSE Framework
+//* https://www.mooseframework.org
+//*
+//* Licensed under LGPL 2.1, please see LICENSE for details
+//* https://www.gnu.org/licenses/lgpl-2.1.html
+
 #include "ReactionThirdOrderEnergyLog.h"
 
 // MOOSE includes

--- a/src/kernels/ReactionThirdOrderLog.C
+++ b/src/kernels/ReactionThirdOrderLog.C
@@ -1,3 +1,13 @@
+//* This file is part of Crane, an open-source
+//* application for plasma chemistry and thermochemistry
+//* https://github.com/lcpp-org/crane
+//*
+//* Crane is powered by the MOOSE Framework
+//* https://www.mooseframework.org
+//*
+//* Licensed under LGPL 2.1, please see LICENSE for details
+//* https://www.gnu.org/licenses/lgpl-2.1.html
+
 #include "ReactionThirdOrderLog.h"
 
 using MetaPhysicL::raw_value;

--- a/src/kernels/TimeDerivativeLog.C
+++ b/src/kernels/TimeDerivativeLog.C
@@ -1,3 +1,13 @@
+//* This file is part of Crane, an open-source
+//* application for plasma chemistry and thermochemistry
+//* https://github.com/lcpp-org/crane
+//*
+//* Crane is powered by the MOOSE Framework
+//* https://www.mooseframework.org
+//*
+//* Licensed under LGPL 2.1, please see LICENSE for details
+//* https://www.gnu.org/licenses/lgpl-2.1.html
+
 #include "TimeDerivativeLog.h"
 
 registerMooseObject("CraneApp", TimeDerivativeLog);

--- a/src/main.C
+++ b/src/main.C
@@ -1,11 +1,13 @@
-//* This file is part of the MOOSE framework
-//* https://www.mooseframework.org
+//* This file is part of Crane, an open-source
+//* application for plasma chemistry and thermochemistry
+//* https://github.com/lcpp-org/crane
 //*
-//* All rights reserved, see COPYRIGHT for full restrictions
-//* https://github.com/idaholab/moose/blob/master/COPYRIGHT
+//* Crane is powered by the MOOSE Framework
+//* https://www.mooseframework.org
 //*
 //* Licensed under LGPL 2.1, please see LICENSE for details
 //* https://www.gnu.org/licenses/lgpl-2.1.html
+
 #include "CraneApp.h"
 #include "MooseInit.h"
 #include "Moose.h"

--- a/src/materials/ADEEDFRateConstantTownsend.C
+++ b/src/materials/ADEEDFRateConstantTownsend.C
@@ -1,3 +1,13 @@
+//* This file is part of Crane, an open-source
+//* application for plasma chemistry and thermochemistry
+//* https://github.com/lcpp-org/crane
+//*
+//* Crane is powered by the MOOSE Framework
+//* https://www.mooseframework.org
+//*
+//* Licensed under LGPL 2.1, please see LICENSE for details
+//* https://www.gnu.org/licenses/lgpl-2.1.html
+
 #include "ADEEDFRateConstantTownsend.h"
 #include "MooseUtils.h"
 

--- a/src/materials/ADZapdosEEDFRateConstant.C
+++ b/src/materials/ADZapdosEEDFRateConstant.C
@@ -1,3 +1,13 @@
+//* This file is part of Crane, an open-source
+//* application for plasma chemistry and thermochemistry
+//* https://github.com/lcpp-org/crane
+//*
+//* Crane is powered by the MOOSE Framework
+//* https://www.mooseframework.org
+//*
+//* Licensed under LGPL 2.1, please see LICENSE for details
+//* https://www.gnu.org/licenses/lgpl-2.1.html
+
 #include "ADZapdosEEDFRateConstant.h"
 #include "MooseUtils.h"
 

--- a/src/materials/DiffusionRateTemp.C
+++ b/src/materials/DiffusionRateTemp.C
@@ -1,3 +1,13 @@
+//* This file is part of Crane, an open-source
+//* application for plasma chemistry and thermochemistry
+//* https://github.com/lcpp-org/crane
+//*
+//* Crane is powered by the MOOSE Framework
+//* https://www.mooseframework.org
+//*
+//* Licensed under LGPL 2.1, please see LICENSE for details
+//* https://www.gnu.org/licenses/lgpl-2.1.html
+
 #include "DiffusionRateTemp.h"
 #include "MooseUtils.h"
 

--- a/src/materials/EEDFRateConstant.C
+++ b/src/materials/EEDFRateConstant.C
@@ -1,3 +1,13 @@
+//* This file is part of Crane, an open-source
+//* application for plasma chemistry and thermochemistry
+//* https://github.com/lcpp-org/crane
+//*
+//* Crane is powered by the MOOSE Framework
+//* https://www.mooseframework.org
+//*
+//* Licensed under LGPL 2.1, please see LICENSE for details
+//* https://www.gnu.org/licenses/lgpl-2.1.html
+
 #include "EEDFRateConstant.h"
 #include "MooseUtils.h"
 

--- a/src/materials/EEDFRateConstantTownsend.C
+++ b/src/materials/EEDFRateConstantTownsend.C
@@ -1,3 +1,13 @@
+//* This file is part of Crane, an open-source
+//* application for plasma chemistry and thermochemistry
+//* https://github.com/lcpp-org/crane
+//*
+//* Crane is powered by the MOOSE Framework
+//* https://www.mooseframework.org
+//*
+//* Licensed under LGPL 2.1, please see LICENSE for details
+//* https://www.gnu.org/licenses/lgpl-2.1.html
+
 #include "EEDFRateConstantTownsend.h"
 #include "MooseUtils.h"
 

--- a/src/materials/ElectricField.C
+++ b/src/materials/ElectricField.C
@@ -1,3 +1,13 @@
+//* This file is part of Crane, an open-source
+//* application for plasma chemistry and thermochemistry
+//* https://github.com/lcpp-org/crane
+//*
+//* Crane is powered by the MOOSE Framework
+//* https://www.mooseframework.org
+//*
+//* Licensed under LGPL 2.1, please see LICENSE for details
+//* https://www.gnu.org/licenses/lgpl-2.1.html
+
 #include "ElectricField.h"
 #include "MooseUtils.h"
 

--- a/src/materials/GenericRateConstant.C
+++ b/src/materials/GenericRateConstant.C
@@ -1,3 +1,13 @@
+//* This file is part of Crane, an open-source
+//* application for plasma chemistry and thermochemistry
+//* https://github.com/lcpp-org/crane
+//*
+//* Crane is powered by the MOOSE Framework
+//* https://www.mooseframework.org
+//*
+//* Licensed under LGPL 2.1, please see LICENSE for details
+//* https://www.gnu.org/licenses/lgpl-2.1.html
+
 #include "GenericRateConstant.h"
 
 registerMooseObject("CraneApp", GenericRateConstant);

--- a/src/materials/HeatCapacityRatio.C
+++ b/src/materials/HeatCapacityRatio.C
@@ -1,3 +1,13 @@
+//* This file is part of Crane, an open-source
+//* application for plasma chemistry and thermochemistry
+//* https://github.com/lcpp-org/crane
+//*
+//* Crane is powered by the MOOSE Framework
+//* https://www.mooseframework.org
+//*
+//* Licensed under LGPL 2.1, please see LICENSE for details
+//* https://www.gnu.org/licenses/lgpl-2.1.html
+
 #include "HeatCapacityRatio.h"
 #include "MooseUtils.h"
 

--- a/src/materials/InterpolatedCoefficientLinear.C
+++ b/src/materials/InterpolatedCoefficientLinear.C
@@ -1,3 +1,13 @@
+//* This file is part of Crane, an open-source
+//* application for plasma chemistry and thermochemistry
+//* https://github.com/lcpp-org/crane
+//*
+//* Crane is powered by the MOOSE Framework
+//* https://www.mooseframework.org
+//*
+//* Licensed under LGPL 2.1, please see LICENSE for details
+//* https://www.gnu.org/licenses/lgpl-2.1.html
+
 #include "InterpolatedCoefficientLinear.h"
 #include "MooseUtils.h"
 

--- a/src/materials/InterpolatedCoefficientSpline.C
+++ b/src/materials/InterpolatedCoefficientSpline.C
@@ -1,3 +1,13 @@
+//* This file is part of Crane, an open-source
+//* application for plasma chemistry and thermochemistry
+//* https://github.com/lcpp-org/crane
+//*
+//* Crane is powered by the MOOSE Framework
+//* https://www.mooseframework.org
+//*
+//* Licensed under LGPL 2.1, please see LICENSE for details
+//* https://www.gnu.org/licenses/lgpl-2.1.html
+
 #include "InterpolatedCoefficientSpline.h"
 #include "MooseUtils.h"
 

--- a/src/materials/SpeciesSum.C
+++ b/src/materials/SpeciesSum.C
@@ -1,3 +1,13 @@
+//* This file is part of Crane, an open-source
+//* application for plasma chemistry and thermochemistry
+//* https://github.com/lcpp-org/crane
+//*
+//* Crane is powered by the MOOSE Framework
+//* https://www.mooseframework.org
+//*
+//* Licensed under LGPL 2.1, please see LICENSE for details
+//* https://www.gnu.org/licenses/lgpl-2.1.html
+
 #include "SpeciesSum.h"
 #include "MooseUtils.h"
 

--- a/src/materials/SuperelasticReactionRate.C
+++ b/src/materials/SuperelasticReactionRate.C
@@ -1,3 +1,13 @@
+//* This file is part of Crane, an open-source
+//* application for plasma chemistry and thermochemistry
+//* https://github.com/lcpp-org/crane
+//*
+//* Crane is powered by the MOOSE Framework
+//* https://www.mooseframework.org
+//*
+//* Licensed under LGPL 2.1, please see LICENSE for details
+//* https://www.gnu.org/licenses/lgpl-2.1.html
+
 #include "SuperelasticReactionRate.h"
 #include "MooseUtils.h"
 

--- a/src/materials/ZapdosEEDFRateConstant.C
+++ b/src/materials/ZapdosEEDFRateConstant.C
@@ -1,3 +1,13 @@
+//* This file is part of Crane, an open-source
+//* application for plasma chemistry and thermochemistry
+//* https://github.com/lcpp-org/crane
+//*
+//* Crane is powered by the MOOSE Framework
+//* https://www.mooseframework.org
+//*
+//* Licensed under LGPL 2.1, please see LICENSE for details
+//* https://www.gnu.org/licenses/lgpl-2.1.html
+
 #include "ZapdosEEDFRateConstant.h"
 #include "MooseUtils.h"
 

--- a/src/postprocessors/ElectricFieldCalculator.C
+++ b/src/postprocessors/ElectricFieldCalculator.C
@@ -1,3 +1,13 @@
+//* This file is part of Crane, an open-source
+//* application for plasma chemistry and thermochemistry
+//* https://github.com/lcpp-org/crane
+//*
+//* Crane is powered by the MOOSE Framework
+//* https://www.mooseframework.org
+//*
+//* Licensed under LGPL 2.1, please see LICENSE for details
+//* https://www.gnu.org/licenses/lgpl-2.1.html
+
 #include "ElectricFieldCalculator.h"
 
 // MOOSE includes

--- a/src/scalarkernels/EnergyTermScalar.C
+++ b/src/scalarkernels/EnergyTermScalar.C
@@ -1,3 +1,13 @@
+//* This file is part of Crane, an open-source
+//* application for plasma chemistry and thermochemistry
+//* https://github.com/lcpp-org/crane
+//*
+//* Crane is powered by the MOOSE Framework
+//* https://www.mooseframework.org
+//*
+//* Licensed under LGPL 2.1, please see LICENSE for details
+//* https://www.gnu.org/licenses/lgpl-2.1.html
+
 #include "EnergyTermScalar.h"
 
 registerMooseObject("CraneApp", EnergyTermScalar);

--- a/src/scalarkernels/LogStabilizationScalar.C
+++ b/src/scalarkernels/LogStabilizationScalar.C
@@ -1,3 +1,13 @@
+//* This file is part of Crane, an open-source
+//* application for plasma chemistry and thermochemistry
+//* https://github.com/lcpp-org/crane
+//*
+//* Crane is powered by the MOOSE Framework
+//* https://www.mooseframework.org
+//*
+//* Licensed under LGPL 2.1, please see LICENSE for details
+//* https://www.gnu.org/licenses/lgpl-2.1.html
+
 #include "LogStabilizationScalar.h"
 
 registerMooseObject("CraneApp", LogStabilizationScalar);

--- a/src/scalarkernels/ODETimeDerivativeLog.C
+++ b/src/scalarkernels/ODETimeDerivativeLog.C
@@ -1,3 +1,13 @@
+//* This file is part of Crane, an open-source
+//* application for plasma chemistry and thermochemistry
+//* https://github.com/lcpp-org/crane
+//*
+//* Crane is powered by the MOOSE Framework
+//* https://www.mooseframework.org
+//*
+//* Licensed under LGPL 2.1, please see LICENSE for details
+//* https://www.gnu.org/licenses/lgpl-2.1.html
+
 #include "ODETimeDerivativeLog.h"
 
 registerMooseObject("CraneApp", ODETimeDerivativeLog);

--- a/src/scalarkernels/ODETimeDerivativeTemperature.C
+++ b/src/scalarkernels/ODETimeDerivativeTemperature.C
@@ -1,8 +1,9 @@
-//* This file is part of the MOOSE framework
-//* https://www.mooseframework.org
+//* This file is part of Crane, an open-source
+//* application for plasma chemistry and thermochemistry
+//* https://github.com/lcpp-org/crane
 //*
-//* All rights reserved, see COPYRIGHT for full restrictions
-//* https://github.com/idaholab/moose/blob/master/COPYRIGHT
+//* Crane is powered by the MOOSE Framework
+//* https://www.mooseframework.org
 //*
 //* Licensed under LGPL 2.1, please see LICENSE for details
 //* https://www.gnu.org/licenses/lgpl-2.1.html

--- a/src/scalarkernels/ParsedScalarReaction.C
+++ b/src/scalarkernels/ParsedScalarReaction.C
@@ -1,3 +1,13 @@
+//* This file is part of Crane, an open-source
+//* application for plasma chemistry and thermochemistry
+//* https://github.com/lcpp-org/crane
+//*
+//* Crane is powered by the MOOSE Framework
+//* https://www.mooseframework.org
+//*
+//* Licensed under LGPL 2.1, please see LICENSE for details
+//* https://www.gnu.org/licenses/lgpl-2.1.html
+
 #include "ParsedScalarReaction.h"
 #include "ParsedODEKernel.h"
 

--- a/src/scalarkernels/Product1BodyScalar.C
+++ b/src/scalarkernels/Product1BodyScalar.C
@@ -1,3 +1,13 @@
+//* This file is part of Crane, an open-source
+//* application for plasma chemistry and thermochemistry
+//* https://github.com/lcpp-org/crane
+//*
+//* Crane is powered by the MOOSE Framework
+//* https://www.mooseframework.org
+//*
+//* Licensed under LGPL 2.1, please see LICENSE for details
+//* https://www.gnu.org/licenses/lgpl-2.1.html
+
 #include "Product1BodyScalar.h"
 
 registerMooseObject("CraneApp", Product1BodyScalar);

--- a/src/scalarkernels/Product1BodyScalarLog.C
+++ b/src/scalarkernels/Product1BodyScalarLog.C
@@ -1,3 +1,13 @@
+//* This file is part of Crane, an open-source
+//* application for plasma chemistry and thermochemistry
+//* https://github.com/lcpp-org/crane
+//*
+//* Crane is powered by the MOOSE Framework
+//* https://www.mooseframework.org
+//*
+//* Licensed under LGPL 2.1, please see LICENSE for details
+//* https://www.gnu.org/licenses/lgpl-2.1.html
+
 #include "Product1BodyScalarLog.h"
 
 registerMooseObject("CraneApp", Product1BodyScalarLog);

--- a/src/scalarkernels/Product2BodyScalar.C
+++ b/src/scalarkernels/Product2BodyScalar.C
@@ -1,3 +1,13 @@
+//* This file is part of Crane, an open-source
+//* application for plasma chemistry and thermochemistry
+//* https://github.com/lcpp-org/crane
+//*
+//* Crane is powered by the MOOSE Framework
+//* https://www.mooseframework.org
+//*
+//* Licensed under LGPL 2.1, please see LICENSE for details
+//* https://www.gnu.org/licenses/lgpl-2.1.html
+
 #include "Product2BodyScalar.h"
 
 registerMooseObject("CraneApp", Product2BodyScalar);

--- a/src/scalarkernels/Product2BodyScalarLog.C
+++ b/src/scalarkernels/Product2BodyScalarLog.C
@@ -1,3 +1,13 @@
+//* This file is part of Crane, an open-source
+//* application for plasma chemistry and thermochemistry
+//* https://github.com/lcpp-org/crane
+//*
+//* Crane is powered by the MOOSE Framework
+//* https://www.mooseframework.org
+//*
+//* Licensed under LGPL 2.1, please see LICENSE for details
+//* https://www.gnu.org/licenses/lgpl-2.1.html
+
 #include "Product2BodyScalarLog.h"
 
 registerMooseObject("CraneApp", Product2BodyScalarLog);

--- a/src/scalarkernels/Product3BodyScalar.C
+++ b/src/scalarkernels/Product3BodyScalar.C
@@ -1,3 +1,13 @@
+//* This file is part of Crane, an open-source
+//* application for plasma chemistry and thermochemistry
+//* https://github.com/lcpp-org/crane
+//*
+//* Crane is powered by the MOOSE Framework
+//* https://www.mooseframework.org
+//*
+//* Licensed under LGPL 2.1, please see LICENSE for details
+//* https://www.gnu.org/licenses/lgpl-2.1.html
+
 #include "Product3BodyScalar.h"
 
 registerMooseObject("CraneApp", Product3BodyScalar);

--- a/src/scalarkernels/Product3BodyScalarLog.C
+++ b/src/scalarkernels/Product3BodyScalarLog.C
@@ -1,3 +1,13 @@
+//* This file is part of Crane, an open-source
+//* application for plasma chemistry and thermochemistry
+//* https://github.com/lcpp-org/crane
+//*
+//* Crane is powered by the MOOSE Framework
+//* https://www.mooseframework.org
+//*
+//* Licensed under LGPL 2.1, please see LICENSE for details
+//* https://www.gnu.org/licenses/lgpl-2.1.html
+
 #include "Product3BodyScalarLog.h"
 
 registerMooseObject("CraneApp", Product3BodyScalarLog);

--- a/src/scalarkernels/Reactant1BodyScalar.C
+++ b/src/scalarkernels/Reactant1BodyScalar.C
@@ -1,3 +1,13 @@
+//* This file is part of Crane, an open-source
+//* application for plasma chemistry and thermochemistry
+//* https://github.com/lcpp-org/crane
+//*
+//* Crane is powered by the MOOSE Framework
+//* https://www.mooseframework.org
+//*
+//* Licensed under LGPL 2.1, please see LICENSE for details
+//* https://www.gnu.org/licenses/lgpl-2.1.html
+
 #include "Reactant1BodyScalar.h"
 
 registerMooseObject("CraneApp", Reactant1BodyScalar);

--- a/src/scalarkernels/Reactant1BodyScalarLog.C
+++ b/src/scalarkernels/Reactant1BodyScalarLog.C
@@ -1,3 +1,13 @@
+//* This file is part of Crane, an open-source
+//* application for plasma chemistry and thermochemistry
+//* https://github.com/lcpp-org/crane
+//*
+//* Crane is powered by the MOOSE Framework
+//* https://www.mooseframework.org
+//*
+//* Licensed under LGPL 2.1, please see LICENSE for details
+//* https://www.gnu.org/licenses/lgpl-2.1.html
+
 #include "Reactant1BodyScalarLog.h"
 
 registerMooseObject("CraneApp", Reactant1BodyScalarLog);

--- a/src/scalarkernels/Reactant2BodyScalar.C
+++ b/src/scalarkernels/Reactant2BodyScalar.C
@@ -1,3 +1,13 @@
+//* This file is part of Crane, an open-source
+//* application for plasma chemistry and thermochemistry
+//* https://github.com/lcpp-org/crane
+//*
+//* Crane is powered by the MOOSE Framework
+//* https://www.mooseframework.org
+//*
+//* Licensed under LGPL 2.1, please see LICENSE for details
+//* https://www.gnu.org/licenses/lgpl-2.1.html
+
 #include "Reactant2BodyScalar.h"
 
 registerMooseObject("CraneApp", Reactant2BodyScalar);

--- a/src/scalarkernels/Reactant2BodyScalarLog.C
+++ b/src/scalarkernels/Reactant2BodyScalarLog.C
@@ -1,3 +1,13 @@
+//* This file is part of Crane, an open-source
+//* application for plasma chemistry and thermochemistry
+//* https://github.com/lcpp-org/crane
+//*
+//* Crane is powered by the MOOSE Framework
+//* https://www.mooseframework.org
+//*
+//* Licensed under LGPL 2.1, please see LICENSE for details
+//* https://www.gnu.org/licenses/lgpl-2.1.html
+
 #include "Reactant2BodyScalarLog.h"
 
 registerMooseObject("CraneApp", Reactant2BodyScalarLog);

--- a/src/scalarkernels/Reactant3BodyScalar.C
+++ b/src/scalarkernels/Reactant3BodyScalar.C
@@ -1,3 +1,13 @@
+//* This file is part of Crane, an open-source
+//* application for plasma chemistry and thermochemistry
+//* https://github.com/lcpp-org/crane
+//*
+//* Crane is powered by the MOOSE Framework
+//* https://www.mooseframework.org
+//*
+//* Licensed under LGPL 2.1, please see LICENSE for details
+//* https://www.gnu.org/licenses/lgpl-2.1.html
+
 #include "Reactant3BodyScalar.h"
 
 registerMooseObject("CraneApp", Reactant3BodyScalar);

--- a/src/scalarkernels/Reactant3BodyScalarLog.C
+++ b/src/scalarkernels/Reactant3BodyScalarLog.C
@@ -1,3 +1,13 @@
+//* This file is part of Crane, an open-source
+//* application for plasma chemistry and thermochemistry
+//* https://github.com/lcpp-org/crane
+//*
+//* Crane is powered by the MOOSE Framework
+//* https://www.mooseframework.org
+//*
+//* Licensed under LGPL 2.1, please see LICENSE for details
+//* https://www.gnu.org/licenses/lgpl-2.1.html
+
 #include "Reactant3BodyScalarLog.h"
 
 registerMooseObject("CraneApp", Reactant3BodyScalarLog);

--- a/src/scalarkernels/ScalarDiffusion.C
+++ b/src/scalarkernels/ScalarDiffusion.C
@@ -1,3 +1,13 @@
+//* This file is part of Crane, an open-source
+//* application for plasma chemistry and thermochemistry
+//* https://github.com/lcpp-org/crane
+//*
+//* Crane is powered by the MOOSE Framework
+//* https://www.mooseframework.org
+//*
+//* Licensed under LGPL 2.1, please see LICENSE for details
+//* https://www.gnu.org/licenses/lgpl-2.1.html
+
 #include "ScalarDiffusion.h"
 
 registerMooseObject("CraneApp", ScalarDiffusion);

--- a/src/userobjects/BoltzmannSolverScalar.C
+++ b/src/userobjects/BoltzmannSolverScalar.C
@@ -1,3 +1,13 @@
+//* This file is part of Crane, an open-source
+//* application for plasma chemistry and thermochemistry
+//* https://github.com/lcpp-org/crane
+//*
+//* Crane is powered by the MOOSE Framework
+//* https://www.mooseframework.org
+//*
+//* Licensed under LGPL 2.1, please see LICENSE for details
+//* https://www.gnu.org/licenses/lgpl-2.1.html
+
 #include "BoltzmannSolverScalar.h"
 #include "Function.h"
 #include <fstream>

--- a/src/userobjects/ObjTest.C
+++ b/src/userobjects/ObjTest.C
@@ -1,3 +1,13 @@
+//* This file is part of Crane, an open-source
+//* application for plasma chemistry and thermochemistry
+//* https://github.com/lcpp-org/crane
+//*
+//* Crane is powered by the MOOSE Framework
+//* https://www.mooseframework.org
+//*
+//* Licensed under LGPL 2.1, please see LICENSE for details
+//* https://www.gnu.org/licenses/lgpl-2.1.html
+
 #include "ObjTest.h"
 
 registerMooseObject("CraneApp", ObjTest);

--- a/src/userobjects/PolynomialCoefficients.C
+++ b/src/userobjects/PolynomialCoefficients.C
@@ -1,3 +1,13 @@
+//* This file is part of Crane, an open-source
+//* application for plasma chemistry and thermochemistry
+//* https://github.com/lcpp-org/crane
+//*
+//* Crane is powered by the MOOSE Framework
+//* https://www.mooseframework.org
+//*
+//* Licensed under LGPL 2.1, please see LICENSE for details
+//* https://www.gnu.org/licenses/lgpl-2.1.html
+
 #include "PolynomialCoefficients.h"
 #include "Function.h"
 

--- a/src/userobjects/RateCoefficientProvider.C
+++ b/src/userobjects/RateCoefficientProvider.C
@@ -1,3 +1,13 @@
+//* This file is part of Crane, an open-source
+//* application for plasma chemistry and thermochemistry
+//* https://github.com/lcpp-org/crane
+//*
+//* Crane is powered by the MOOSE Framework
+//* https://www.mooseframework.org
+//*
+//* Licensed under LGPL 2.1, please see LICENSE for details
+//* https://www.gnu.org/licenses/lgpl-2.1.html
+
 #include "RateCoefficientProvider.h"
 // #include "Function.h"
 

--- a/src/userobjects/ValueProvider.C
+++ b/src/userobjects/ValueProvider.C
@@ -1,3 +1,13 @@
+//* This file is part of Crane, an open-source
+//* application for plasma chemistry and thermochemistry
+//* https://github.com/lcpp-org/crane
+//*
+//* Crane is powered by the MOOSE Framework
+//* https://www.mooseframework.org
+//*
+//* Licensed under LGPL 2.1, please see LICENSE for details
+//* https://www.gnu.org/licenses/lgpl-2.1.html
+
 #include "ValueProvider.h"
 #include "Function.h"
 

--- a/unit/src/SampleTest.C
+++ b/unit/src/SampleTest.C
@@ -1,8 +1,9 @@
-//* This file is part of the MOOSE framework
-//* https://www.mooseframework.org
+//* This file is part of Crane, an open-source
+//* application for plasma chemistry and thermochemistry
+//* https://github.com/lcpp-org/crane
 //*
-//* All rights reserved, see COPYRIGHT for full restrictions
-//* https://github.com/idaholab/moose/blob/master/COPYRIGHT
+//* Crane is powered by the MOOSE Framework
+//* https://www.mooseframework.org
 //*
 //* Licensed under LGPL 2.1, please see LICENSE for details
 //* https://www.gnu.org/licenses/lgpl-2.1.html

--- a/unit/src/main.C
+++ b/unit/src/main.C
@@ -1,8 +1,9 @@
-//* This file is part of the MOOSE framework
-//* https://www.mooseframework.org
+//* This file is part of Crane, an open-source
+//* application for plasma chemistry and thermochemistry
+//* https://github.com/lcpp-org/crane
 //*
-//* All rights reserved, see COPYRIGHT for full restrictions
-//* https://github.com/idaholab/moose/blob/master/COPYRIGHT
+//* Crane is powered by the MOOSE Framework
+//* https://www.mooseframework.org
 //*
 //* Licensed under LGPL 2.1, please see LICENSE for details
 //* https://www.gnu.org/licenses/lgpl-2.1.html


### PR DESCRIPTION
Used fixup_headers.py from Zapdos, modified, and fixed the bad/old copyright headers - fix for #25 