### PR TITLE
[Temporary] Remove moose submodule update from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,8 +24,6 @@ After installing MOOSE, make sure you have the following folder on your local ma
 
 `cd crane`
 
-`git submodule update --init moose`
-
 `mamba activate moose` 
 
 `make -jn` 


### PR DESCRIPTION
Want to remove ``git submodule update --init moose`` step until CI implemented #86 