### PR TITLE
Add const to getValue method in ElectricFieldCalculator

### DIFF
--- a/include/postprocessors/ElectricFieldCalculator.h
+++ b/include/postprocessors/ElectricFieldCalculator.h
@@ -25,7 +25,7 @@ public:
 
   virtual void initialize() override {};
   virtual void execute() override {};
-  virtual Real getValue() override;
+  virtual Real getValue() const override;
 
 protected:
   // virtual Real reducedField();

--- a/src/postprocessors/ElectricFieldCalculator.C
+++ b/src/postprocessors/ElectricFieldCalculator.C
@@ -35,7 +35,7 @@ ElectricFieldCalculator::ElectricFieldCalculator(const InputParameters & paramet
 }
 
 Real
-ElectricFieldCalculator::getValue()
+ElectricFieldCalculator::getValue() const
 {
   return 1000;
   // _Vdr[_qp] = mult1 * _reduced_field_old[_qp] * _mobility.sample(_reduced_field_old[_qp]);


### PR DESCRIPTION
Zapdos is currently failing devel testing due to a change in MOOSE that adds const-ness to the postprocessor `getValue()` method: https://civet.inl.gov/event/138892/.

This PR adds const-ness to that in `ElectricFieldCalculator` and updates the MOOSE submodule.

Tagging @smpeyres and @dcurreli for review and merge. This is necessary to get shannon-lab/zapdos#203 passing. 