### PR TITLE
Make sure overload resolution occurs with the right getValue

### DIFF
--- a/include/postprocessors/ElectricFieldCalculator.h
+++ b/include/postprocessors/ElectricFieldCalculator.h
@@ -25,6 +25,7 @@ public:
 
   virtual void initialize() override {};
   virtual void execute() override {};
+  using Postprocessor::getValue;
   virtual Real getValue() const override;
 
 protected:


### PR DESCRIPTION
One more fixup here @smpeyres, as I missed this in the previous PR (only shows up in debug mode). Ready for review and merge. 

refs shannon-lab/zapdos#203