### PR TITLE
Add default value for vector type input parameters

### DIFF
--- a/src/actions/ChemicalReactions.C
+++ b/src/actions/ChemicalReactions.C
@@ -52,7 +52,7 @@ ChemicalReactions::validParams()
   InputParameters params = AddVariableAction::validParams();
   params.addRequiredParam<std::vector<NonlinearVariableName>>(
       "species", "List of (tracked) species included in reactions (both products and reactants)");
-  params.addParam<std::vector<Real>>("reaction_coefficient", "The reaction coefficients.");
+  params.addParam<std::vector<Real>>("reaction_coefficient", {}, "The reaction coefficients.");
   params.addParam<bool>(
       "include_electrons", false, "Whether or not electrons are being considered.");
   params.addParam<bool>("track_energy", false, "Whether or not to track gas energy/temperature.");
@@ -64,7 +64,7 @@ ChemicalReactions::validParams()
       "List of (tracked) energy values. (Optional; requires 'track_energy' to be True.)");
   params.addParam<std::string>("electron_density", "The variable used for density of electrons.");
   params.addParam<std::vector<VariableName>>(
-      "electron_energy", "Electron energy, used for energy-dependent reaction rates.");
+      "electron_energy", {}, "Electron energy, used for energy-dependent reaction rates.");
   params.addParam<std::vector<std::string>>("gas_species",
                                             "All of the background gas species in the system.");
   params.addParam<std::vector<Real>>("gas_fraction", "The initial fraction of each gas species.");
@@ -92,10 +92,10 @@ ChemicalReactions::validParams()
       "Sample rate constants with E/N (reduced_field) or Te (electron_energy).");
   params.addParam<bool>(
       "scalar_problem", false, "The problem is scalar if it is a pure ODE problem (Global/0D).");
-  params.addParam<std::vector<std::string>>("equation_constants",
-                                            "The constants included in the reaction equation(s).");
   params.addParam<std::vector<std::string>>(
-      "equation_values", "The values of the constants included in the reaction equation(s).");
+      "equation_constants", {}, "The constants included in the reaction equation(s).");
+  params.addParam<std::vector<std::string>>(
+      "equation_values", {}, "The values of the constants included in the reaction equation(s).");
   params.addParam<std::vector<VariableName>>(
       "equation_variables", "Any nonlinear variables that appear in the equations.");
   params.addParam<std::vector<VariableName>>(

--- a/src/actions/ChemicalReactionsBase.C
+++ b/src/actions/ChemicalReactionsBase.C
@@ -56,7 +56,7 @@ ChemicalReactionsBase::validParams()
       "species", "List of (tracked) species included in reactions (both products and reactants)");
   params.addParam<std::vector<std::string>>(
       "aux_species", "Auxiliary species that are not included in nonlinear solve.");
-  params.addParam<std::vector<Real>>("reaction_coefficient", "The reaction coefficients.");
+  params.addParam<std::vector<Real>>("reaction_coefficient", {}, "The reaction coefficients.");
   params.addParam<bool>(
       "include_electrons", false, "Whether or not electrons are being considered.");
   params.addParam<bool>(
@@ -65,9 +65,9 @@ ChemicalReactionsBase::validParams()
       "track_rates", false, "Whether or not to track production rates for each reaction");
   params.addParam<std::string>("electron_density", "The variable used for density of electrons.");
   params.addParam<std::vector<NonlinearVariableName>>(
-      "electron_energy", "Electron energy, used for energy-dependent reaction rates.");
+      "electron_energy", {}, "Electron energy, used for energy-dependent reaction rates.");
   params.addParam<std::vector<NonlinearVariableName>>(
-      "gas_energy", "Gas energy, used for energy-dependent reaction rates.");
+      "gas_energy", {}, "Gas energy, used for energy-dependent reaction rates.");
   params.addParam<std::vector<std::string>>("gas_species",
                                             "All of the background gas species in the system.");
   params.addParam<std::vector<Real>>("gas_fraction", "The initial fraction of each gas species.");
@@ -81,10 +81,10 @@ ChemicalReactionsBase::validParams()
       "sampling_variable",
       "reduced_field",
       "Sample rate constants with E/N (reduced_field) or Te (electron_energy).");
-  params.addParam<std::vector<std::string>>("equation_constants",
-                                            "The constants included in the reaction equation(s).");
   params.addParam<std::vector<std::string>>(
-      "equation_values", "The values of the constants included in the reaction equation(s).");
+      "equation_constants", {}, "The constants included in the reaction equation(s).");
+  params.addParam<std::vector<std::string>>(
+      "equation_values", {}, "The values of the constants included in the reaction equation(s).");
   params.addParam<std::vector<VariableName>>(
       "equation_variables", "Any nonlinear variables that appear in the equations.");
   params.addParam<std::vector<VariableName>>(
@@ -93,8 +93,8 @@ ChemicalReactionsBase::validParams()
                         false,
                         "If true, the input file parser will look for a parameter denoting lumped "
                         "species (NEUTRAL for now...eventually arbitrary?).");
-  params.addParam<std::vector<std::string>>("lumped",
-                                            "The neutral species that will be lumped together.");
+  params.addParam<std::vector<std::string>>(
+      "lumped", {}, "The neutral species that will be lumped together.");
   params.addParam<std::string>("lumped_name",
                                "The name of the variable that will account for multiple species.");
   params.addParam<bool>(
@@ -189,7 +189,7 @@ ChemicalReactionsBase::ChemicalReactionsBase(const InputParameters & params)
   else
     _aux_species.push_back("none");
 
-  if (getParam<bool>("lumped_species") && !isParamValid("lumped"))
+  if (getParam<bool>("lumped_species") && _lumped_species.size() == 0)
     mooseError("The lumped_species parameter is set to true, but vector of neutrals (lumped = "
                "'...') is not set.");
 
@@ -832,17 +832,17 @@ ChemicalReactionsBase::ChemicalReactionsBase(const InputParameters & params)
 
     if (_energy_change[i])
     {
-      if (!isParamValid("electron_energy") && !isParamValid("gas_energy"))
+      if (_electron_energy.size() == 0 && _gas_energy.size() == 0)
         mooseError("Reactions have energy changes, but no electron or gas temperature variable is "
                    "included!");
     }
   }
-  if (isParamValid("electron_energy"))
+  if (_electron_energy.size() > 0)
   {
     _electron_energy_term.push_back(true);
     _energy_variable.push_back(_electron_energy[0]);
   }
-  if (isParamValid("gas_energy"))
+  if (_gas_energy.size() > 0)
   {
     _electron_energy_term.push_back(false);
     _energy_variable.push_back(_gas_energy[0]);

--- a/src/actions/ChemicalReactionsBase.C
+++ b/src/actions/ChemicalReactionsBase.C
@@ -901,7 +901,7 @@ ChemicalReactionsBase::ChemicalReactionsBase(const InputParameters & params)
     }
     if (unbalanced)
     {
-      std::string error_str;
+      string error_str;
       for (unsigned int i = 0; i < faulty_reaction.size(); ++i)
       {
         error_str.append("    ");
@@ -909,7 +909,8 @@ ChemicalReactionsBase::ChemicalReactionsBase(const InputParameters & params)
         error_str.append("\n");
       }
 
-      mooseError("The following equations are unbalanced:\n", error_str,
+      mooseError("The following equations are unbalanced:\n",
+                 error_str,
                  "Fix unbalanced reactions or particle conservation will not be enforced.");
     }
   }


### PR DESCRIPTION
## Bug Description
<!--A clear and concise description of the error, failure, fault, incorrect or unexpected result, or unintended behavior (Note: A missing feature is not a bug.).-->
Refer to the issue [#24455](https://github.com/idaholab/moose/issues/24455), a fix is introduced to MOOSE to properly report error when no default value is provided for vector type input parameter. This new fix in MOOSE cause several tests failed in Crane which don't provide default value for vector parameter. 

## Impact
<!--Does this prevent you from getting your work done, or is it more of an annoyance?-->
This patch is made to fix the failed Crane tests due to the new changes in MOOSE