### PR TITLE
[DOCS] Added References to ReadTheDocs; cited arXiv preprint in welcome page

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -1,16 +1,15 @@
-CRANE
+Welcome to CRANE
 =====
 
-.. warning:: 
+.. warning::
 
    Documentation pages of CRANE are under construction.
 
-`CRANE <https://github.com/lcpp-org/crane>`_ is an open-source 
-`MOOSE <https://mooseframework.inl.gov/>`_-based **plasma chemistry** 
-software developed by the Laboratory of Computational Plasma Physics (LCPP) 
-at the University of Illinois at Urbana-Champaign, that was designed to 
-address non-equilibrium plasma chemistry problems of arbitrary size. 
-
+`CRANE <https://arxiv.org/abs/1905.10004>`_ (Chemical ReAction NEtwork) is an open-source
+`MOOSE <https://mooseframework.inl.gov/>`_-based **plasma chemistry**
+software developed by the Laboratory of Computational Plasma Physics (LCPP)
+at the University of Illinois Urbana-Champaign, that was designed to
+address non-equilibrium plasma chemistry problems of arbitrary size.
 
 Contents
 --------
@@ -18,19 +17,18 @@ Contents
 .. toctree::
    :maxdepth: 1
 
-   overview 
+   overview
    build
    running
    tutorials
    contributing
 
-
 Acknowledgements
 ----------------
 
 The development of CRANE was supported by the National Science
-Foundation under Grant No. 
-`1740310 <https://www.nsf.gov/awardsearch/showAward?AWD_ID=1740310>`_. 
+Foundation under Grant No.
+`1740310 <https://www.nsf.gov/awardsearch/showAward?AWD_ID=1740310>`_.
 CRANE is built as part of the MOOSE
 framework developed at Idaho National Laboratory. The MOOSE team has
-been an invaluable resource during the development of CRANE. 
+been an invaluable resource during the development of CRANE.

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -22,6 +22,7 @@ Contents
    running
    tutorials
    contributing
+   references
 
 Acknowledgements
 ----------------

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -24,6 +24,29 @@ Contents
    contributing
    references
 
+Citing
+------
+
+If you use hPIC2, please cite us in your publication :cite:`keniely2019crane`:
+
+.. code-block:: bibtex
+
+   @misc{keniley2019crane,
+      title={CRANE: A MOOSE-based Open Source Tool for Plasma Chemistry Applications},
+      author={Shane Keniley and Davide Curreli},
+      year={2019},
+      eprint={1905.10004},
+      archivePrefix={arXiv},
+      primaryClass={physics.plasm-ph}
+   }
+
+.. admonition:: Citing
+
+   S. Keniley and D. Curreli,
+   CRANE: A MOOSE-based Open Source Tool for Plasma Chemistry Applications,
+   arXiv:1905.10004v1 [physics.plasma-ph], 2019.
+   `https://arxiv.org/abs/1905.10004 <https://arxiv.org/abs/1905.10004>`_
+
 Acknowledgements
 ----------------
 

--- a/docs/source/references.rst
+++ b/docs/source/references.rst
@@ -1,0 +1,4 @@
+References
+==========
+
+.. bibliography::

--- a/docs/source/refs.bib
+++ b/docs/source/refs.bib
@@ -1,5 +1,5 @@
 @misc{keniley2019crane,
-  title={CRANE: A MOOSE-based Open Source Tool for Plasma Chemistry Applications}, 
+  title={CRANE: A MOOSE-based Open Source Tool for Plasma Chemistry Applications},
   author={Shane Keniley and Davide Curreli},
   year={2019},
   eprint={1905.10004},
@@ -7,7 +7,7 @@
   primaryClass={physics.plasm-ph}
 }
 
-@article{Keniley_2022,
+@article{keniley2022plasmaliquid,
   doi = {10.1088/1361-6595/ac7891},
   url = {https://dx.doi.org/10.1088/1361-6595/ac7891},
   year = {2022},


### PR DESCRIPTION
See Title. I linked ‘CRANE’ to the arXiv preprint instead of the github page (since most people get to the ReadTheDocs through the GitHub, and not the other way around) following the hpic2 ReadTheDocs, but let me know if you want this reversed.