### PR TITLE
Correct file path management

### DIFF
--- a/include/utils/CraneUtils.h
+++ b/include/utils/CraneUtils.h
@@ -1,0 +1,68 @@
+//* This file is part of Crane, an open-source
+//* application for plasma chemistry and thermochemistry
+//* https://github.com/lcpp-org/crane
+//*
+//* Crane is powered by the MOOSE Framework
+//* https://www.mooseframework.org
+//*
+//* Licensed under LGPL 2.1, please see LICENSE for details
+//* https://www.gnu.org/licenses/lgpl-2.1.html
+
+#pragma once
+
+#include "InputParameters.h"
+
+#include "libmesh/libmesh_common.h"
+
+#include <utility>
+#include <vector>
+
+class MooseObject;
+
+namespace CraneUtils
+{
+using Real = libMesh::Real;
+
+/**
+ * The prarameters that describe the base of where to retrieve a property
+ * file from.
+ */
+InputParameters propertyPathParams();
+/**
+ * The parameters that describe the full path of where to retrieve a property
+ * file from, split between the folder base and the file name relative
+ * to said base.
+ */
+InputParameters propertyFileParams();
+
+/**
+ * Gets the tabulated reaction rates from a file where the file is defined by the parameters
+ * in \p object, specified by the parameters "property_file" and "file_location".
+ *
+ * The parameters in the object should be defined by propertyFileParams().
+ *
+ * Performs error checking and passes all errors to \p object.
+ */
+std::pair<std::vector<Real>, std::vector<Real>> getReactionRates(const MooseObject & object);
+/**
+ * Gets the coefficients from a file where the file base is defined by the parameters in
+ * \p object, specified by the parameter "property_file" and the file name specified by
+ * \p property_file.
+ *
+ * The parameters in the object should be defined by propertyPathParams().
+ *
+ * Performs error checking and passes all errors to \p object.
+ */
+std::vector<Real> getCoefficients(const MooseObject & object, const std::string & property_file);
+
+namespace internal
+{
+/**
+ * Internal helper used for getting the file name defined by the parameter "property_file"
+ * (the file base) and the file name \p property_file.
+ *
+ * Performs error checking on whether or not the file exists, and reports errors to \p object.
+ */
+std::string getReactionRateFileName(const MooseObject & object, const std::string & property_file);
+} // namespace internal
+} // namespace CraneUtils

--- a/include/utils/CraneUtils.h
+++ b/include/utils/CraneUtils.h
@@ -24,7 +24,7 @@ namespace CraneUtils
 using Real = libMesh::Real;
 
 /**
- * The prarameters that describe the base of where to retrieve a property
+ * The parameters that describe the base of where to retrieve a property
  * file from.
  */
 InputParameters propertyPathParams();

--- a/src/actions/AddGeneralReactions.C
+++ b/src/actions/AddGeneralReactions.C
@@ -124,7 +124,7 @@ AddGeneralReactions::act()
         Real position_units = getParam<Real>("position_units");
         InputParameters params = _factory.getValidParams("EEDFRateConstantTownsend");
         params.set<std::string>("reaction") = _reaction[i];
-        params.set<std::string>("file_location") = getParam<std::string>("file_location");
+        params.set<FileName>("file_location") = getParam<FileName>("file_location");
         params.set<Real>("position_units") = position_units;
         params.set<std::vector<VariableName>>("em") = {_reactants[i][_electron_index[i]]};
         params.set<std::vector<VariableName>>("mean_en") = {_electron_energy[0]};
@@ -183,7 +183,7 @@ AddGeneralReactions::act()
         params.set<bool>("is_target_aux") = target_species_aux;
 
         params.set<bool>("elastic_collision") = {_elastic_collision[i]};
-        params.set<FileName>("property_file") = "reaction_" + _reaction[i] + ".txt";
+        params.set<RelativeFileName>("property_file") = "reaction_" + _reaction[i] + ".txt";
         params.set<std::vector<SubdomainName>>("block") =
             getParam<std::vector<SubdomainName>>("block");
         _problem->addMaterial("EEDFRateConstantTownsend",
@@ -197,10 +197,10 @@ AddGeneralReactions::act()
         Real position_units = getParam<Real>("position_units");
         InputParameters params = _factory.getValidParams("ZapdosEEDFRateConstant");
         params.set<std::string>("reaction") = _reaction[i];
-        params.set<std::string>("file_location") = getParam<std::string>("file_location");
+        params.set<FileName>("file_location") = getParam<FileName>("file_location");
         params.set<Real>("position_units") = position_units;
         params.set<std::string>("sampling_format") = _sampling_variable;
-        params.set<FileName>("property_file") = "reaction_" + _reaction[i] + ".txt";
+        params.set<RelativeFileName>("property_file") = "reaction_" + _reaction[i] + ".txt";
         params.set<std::vector<VariableName>>("em") = {_reactants[i][_electron_index[i]]};
         params.set<std::vector<VariableName>>("mean_en") = {_electron_energy[0]};
         params.set<bool>("elastic_collision") = _elastic_collision[i];
@@ -276,7 +276,7 @@ AddGeneralReactions::act()
         params.set<std::string>("original_reaction") = _reaction[_superelastic_index[i]];
         params.set<std::vector<Real>>("stoichiometric_coeff") = active_constants;
         params.set<std::vector<std::string>>("participants") = active_participants;
-        params.set<std::string>("file_location") = "PolynomialCoefficients";
+        params.set<FileName>("file_location") = "PolynomialCoefficients";
         params.set<std::vector<SubdomainName>>("block") =
             getParam<std::vector<SubdomainName>>("block");
         _problem->addMaterial("SuperelasticReactionRate",

--- a/src/actions/AddScalarReactions.C
+++ b/src/actions/AddScalarReactions.C
@@ -196,7 +196,7 @@ AddScalarReactions::act()
         InputParameters params = _factory.getValidParams("PolynomialCoefficients");
         params.set<std::vector<Real>>("stoichiometric_coeff") = _reaction_stoichiometric_coeff[i];
         params.set<std::vector<std::string>>("participants") = _reaction_participants[i];
-        params.set<std::string>("file_location") = "PolynomialCoefficients";
+        params.set<FileName>("file_location") = "PolynomialCoefficients";
         params.set<ExecFlagEnum>("execute_on") = "INITIAL";
         _problem->addUserObject(
             "PolynomialCoefficients", _name + "_superelastic_coeff" + std::to_string(i), params);
@@ -242,13 +242,13 @@ AddScalarReactions::act()
               getParam<std::string>("sampling_variable")};
           if (_is_identified[i])
           {
-            params.set<FileName>("property_file") = _reaction_identifier[i];
+            params.set<RelativeFileName>("property_file") = _reaction_identifier[i];
           }
           else
           {
-            params.set<FileName>("property_file") = "reaction_" + _reaction[i] + ".txt";
+            params.set<RelativeFileName>("property_file") = "reaction_" + _reaction[i] + ".txt";
           }
-          params.set<std::string>("file_location") = getParam<std::string>("file_location");
+          params.set<FileName>("file_location") = getParam<FileName>("file_location");
           params.set<ExecFlagEnum>("execute_on") = "INITIAL TIMESTEP_BEGIN";
           _problem->addAuxScalarKernel(
               data_read_name, _name + "aux_rate" + std::to_string(i), params);

--- a/src/actions/AddZapdosReactions.C
+++ b/src/actions/AddZapdosReactions.C
@@ -571,17 +571,17 @@ AddZapdosReactions::addEEDFCoefficient(const unsigned & reaction_num)
 
   auto params = _factory.getValidParams(material_name);
   params.set<std::string>("reaction") = _reaction[reaction_num];
-  params.set<std::string>("file_location") = getParam<std::string>("file_location");
+  params.set<FileName>("file_location") = getParam<FileName>("file_location");
   params.set<std::vector<VariableName>>("electrons") = {
       _reactants[reaction_num][_electron_index[reaction_num]]};
   params.set<std::vector<VariableName>>("mean_energy") = {_electron_energy[0]};
   if (_is_identified[reaction_num])
   {
-    params.set<FileName>("property_file") = _reaction_identifier[reaction_num];
+    params.set<RelativeFileName>("property_file") = _reaction_identifier[reaction_num];
   }
   else
   {
-    params.set<FileName>("property_file") = "reaction_" + _reaction[reaction_num] + ".txt";
+    params.set<RelativeFileName>("property_file") = "reaction_" + _reaction[reaction_num] + ".txt";
   }
 
   params.set<std::string>("number") = Moose::stringify(reaction_num);
@@ -682,7 +682,7 @@ AddZapdosReactions::addSuperelasticRateCoefficient(const unsigned & reaction_num
   params.set<std::string>("original_reaction") = _reaction[_superelastic_index[reaction_num]];
   params.set<std::vector<Real>>("stoichiometric_coeff") = active_constants;
   params.set<std::vector<std::string>>("participants") = active_participants;
-  params.set<std::string>("file_location") = "PolynomialCoefficients";
+  params.set<FileName>("file_location") = "PolynomialCoefficients";
   params.set<std::vector<SubdomainName>>("block") = getParam<std::vector<SubdomainName>>("block");
   params.set<std::string>("number") = Moose::stringify(reaction_num);
   _problem->addMaterial("SuperelasticReactionRate",

--- a/src/actions/ChemicalReactions.C
+++ b/src/actions/ChemicalReactions.C
@@ -84,7 +84,7 @@ ChemicalReactions::validParams()
   params.addParam<FileName>(
       "file_location",
       ".",
-      "The location of the reaction rate files. Default: empty string (current directory).");
+      "The location of the reaction rate files. Default: the current directory.");
   params.addParam<bool>("use_moles", "Whether to use molar units.");
   params.addParam<std::string>(
       "sampling_format",

--- a/src/actions/ChemicalReactions.C
+++ b/src/actions/ChemicalReactions.C
@@ -81,9 +81,9 @@ ChemicalReactions::validParams()
   params.addRequiredParam<std::string>(
       "reaction_coefficient_format",
       "The format of the reaction coefficient. Options: rate or townsend.");
-  params.addParam<std::string>(
+  params.addParam<FileName>(
       "file_location",
-      "",
+      ".",
       "The location of the reaction rate files. Default: empty string (current directory).");
   params.addParam<bool>("use_moles", "Whether to use molar units.");
   params.addParam<std::string>(
@@ -543,9 +543,9 @@ ChemicalReactions::act()
   //     // if (_rate_type[i] == "EEDF")
   //     // {
   //     //   InputParameters params = _factory.getValidParams("RateCoefficientProvider");
-  //     //   params.set<std::string>("file_location") = getParam<std::string>("file_location");
+  //     //   params.set<FileName>("file_location") = getParam<FileName>("file_location");
   //     //   params.set<std::string>("sampling_format") = _sampling_format;
-  //     //   params.set<FileName>("property_file") = "reaction_"+_reaction[i]+".txt";
+  //     //   params.set<RelativeFileName>("property_file") = "reaction_"+_reaction[i]+".txt";
   //     //   params.set<std::string>("rate_format") = _rate_type[i];
   //     //   params.set<std::vector<VariableName>>("reduced_field") = getParam<std::vector<VariableName>>("rate_provider_var");
   //     //   // params.set<std::vector<VariableName>>("reduced_field") = {"Te"};
@@ -605,8 +605,8 @@ ChemicalReactions::act()
         InputParameters params = _factory.getValidParams("DataReadScalar");
         params.set<AuxVariableName>("variable") = {_aux_var_name[i]};
         params.set<std::vector<VariableName>>("sampler") = {"reduced_field"};
-        params.set<FileName>("property_file") = "reaction_" + _reaction[i] + ".txt";
-        params.set<std::string>("file_location") = "OutputRates_Crane_ex3";
+        params.set<RelativeFileName>("property_file") = "reaction_" + _reaction[i] + ".txt";
+        params.set<FileName>("file_location") = "OutputRates_Crane_ex3";
         params.set<ExecFlagEnum>("execute_on") = "INITIAL TIMESTEP_BEGIN";
         _problem->addAuxScalarKernel("DataReadScalar", "aux_rate" + std::to_string(i), params);
       }
@@ -671,7 +671,7 @@ ChemicalReactions::act()
         Real position_units = getParam<Real>("position_units");
         InputParameters params = _factory.getValidParams("EEDFRateConstantTownsend");
         params.set<std::string>("reaction") = _reaction[i];
-        params.set<std::string>("file_location") = getParam<std::string>("file_location");
+        params.set<FileName>("file_location") = getParam<FileName>("file_location");
         params.set<Real>("position_units") = position_units;
         params.set<std::vector<VariableName>>("em") = {_reactants[i][_electron_index[i]]};
         params.set<std::vector<VariableName>>("mean_en") =
@@ -713,7 +713,7 @@ ChemicalReactions::act()
           params.set<std::vector<VariableName>>("target_species") = {_reactants[i][target]};
         }
         params.set<bool>("elastic_collision") = {_elastic_collision[i]};
-        params.set<FileName>("property_file") = "reaction_" + _reaction[i] + ".txt";
+        params.set<RelativeFileName>("property_file") = "reaction_" + _reaction[i] + ".txt";
 
         _problem->addMaterial("EEDFRateConstantTownsend", "reaction_" + std::to_string(i), params);
       }
@@ -722,10 +722,10 @@ ChemicalReactions::act()
         Real position_units = getParam<Real>("position_units");
         InputParameters params = _factory.getValidParams("EEDFRateConstant");
         params.set<std::string>("reaction") = _reaction[i];
-        params.set<std::string>("file_location") = getParam<std::string>("file_location");
+        params.set<FileName>("file_location") = getParam<FileName>("file_location");
         params.set<Real>("position_units") = position_units;
         params.set<std::string>("sampling_format") = _sampling_format;
-        params.set<FileName>("property_file") = "reaction_" + _reaction[i] + ".txt";
+        params.set<RelativeFileName>("property_file") = "reaction_" + _reaction[i] + ".txt";
         _problem->addMaterial("EEDFRateConstant", "reaction_" + std::to_string(i), params);
       }
       else if (_rate_type[i] == "Constant")
@@ -774,7 +774,7 @@ ChemicalReactions::act()
         params.set<std::string>("original_reaction") = _reaction[_superelastic_index[i]];
         params.set<std::vector<Real>>("stoichiometric_coeff") = active_constants;
         params.set<std::vector<std::string>>("participants") = active_participants;
-        params.set<std::string>("file_location") = "PolynomialCoefficients";
+        params.set<FileName>("file_location") = "PolynomialCoefficients";
         _problem->addMaterial("SuperelasticReactionRate", "reaction_" + std::to_string(i), params);
       }
 

--- a/src/actions/ChemicalReactionsBase.C
+++ b/src/actions/ChemicalReactionsBase.C
@@ -76,7 +76,7 @@ ChemicalReactionsBase::validParams()
   params.addParam<FileName>(
       "file_location",
       ".",
-      "The location of the reaction rate files. Default: empty string (current directory).");
+      "The location of the reaction rate files. Default: the current directory.");
   params.addParam<std::string>(
       "sampling_variable",
       "reduced_field",

--- a/src/actions/ChemicalReactionsBase.C
+++ b/src/actions/ChemicalReactionsBase.C
@@ -73,9 +73,9 @@ ChemicalReactionsBase::validParams()
   params.addParam<std::vector<Real>>("gas_fraction", "The initial fraction of each gas species.");
   params.addRequiredParam<std::string>("reactions", "The list of reactions to be added");
   params.addParam<Real>("position_units", 1.0, "The units of position.");
-  params.addParam<std::string>(
+  params.addParam<FileName>(
       "file_location",
-      "",
+      ".",
       "The location of the reaction rate files. Default: empty string (current directory).");
   params.addParam<std::string>(
       "sampling_variable",
@@ -938,7 +938,7 @@ ChemicalReactionsBase::ChemicalReactionsBase(const InputParameters & params)
   {
     if (_is_identified[i])
     {
-      std::string fileloc = getParam<std::string>("file_location") + "/" + _reaction_identifier[i];
+      std::string fileloc = getParam<FileName>("file_location") + "/" + _reaction_identifier[i];
       if (file_exists(fileloc))
       {
         continue;

--- a/src/auxkernels/DataRead.C
+++ b/src/auxkernels/DataRead.C
@@ -21,9 +21,10 @@ DataRead::validParams()
   params.addParam<bool>("use_log", false, "Whether or not to return the natural logarithm of the sampled data.");
   params.addParam<Real>("scale_factor", 1.0, "Multiplies the sampled output by a given factor. Convert from m^3 to cm^3, for example.(Optional)");
   params.addParam<Real>("const_sampler", 0, "The value with which the data will be sampled.");
-  params.addParam<FileName>("property_file", "",
-      "The file containing interpolation tables for material properties.");
-  params.addParam<std::string>("file_location", "", "The name of the file that stores the reaction rate tables.");
+  params.addRequiredParam<RelativeFileName>(
+      "property_file", "The file containing interpolation tables for material properties.");
+  params.addParam<FileName>(
+      "file_location", ".", "The name of the file that stores the reaction rate tables.");
   params.addParam<std::string>("sampling_format", "reduced_field",
     "The format that the rate constant files are in. Options: reduced_field and electron_energy.");
   return params;
@@ -40,7 +41,8 @@ DataRead::DataRead(const InputParameters & parameters)
 {
   std::vector<Real> x_val;
   std::vector<Real> y_val;
-  std::string file_name = getParam<std::string>("file_location") + "/" + getParam<FileName>("property_file");
+  std::string file_name =
+      getParam<FileName>("file_location") + "/" + getParam<RelativeFileName>("property_file");
   MooseUtils::checkFileReadable(file_name);
   const char * charPath = file_name.c_str();
   std::ifstream myfile(charPath);

--- a/src/auxkernels/ElectronMobility.C
+++ b/src/auxkernels/ElectronMobility.C
@@ -9,7 +9,8 @@
 //* https://www.gnu.org/licenses/lgpl-2.1.html
 
 #include "ElectronMobility.h"
-#include "MooseUtils.h"
+
+#include "CraneUtils.h"
 
 registerMooseObject("CraneApp", ElectronMobility);
 
@@ -17,8 +18,9 @@ InputParameters
 ElectronMobility::validParams()
 {
  InputParameters params = AuxScalarKernel::validParams();
- params.addRequiredParam<FileName>("file_location",
-                                   "The name of the file that stores the mobility table.");
+ params += CraneUtils::propertyFileParams();
+ params.makeParamNotRequired("property_file");
+ params.set<RelativeFileName>("property_file") = "electron_mobility.txt";
  params.addCoupledVar("reduced_field", "The electron mobility.");
  return params;
 }
@@ -27,27 +29,7 @@ ElectronMobility::ElectronMobility(const InputParameters & parameters)
  : AuxScalarKernel(parameters),
   _reduced_field(coupledScalarValue("reduced_field"))
 {
-  std::string file_name = getParam<FileName>("file_location") + "/" + "electron_mobility.txt";
-  MooseUtils::checkFileReadable(file_name);
-  const char * charPath = file_name.c_str();
-  std::ifstream myfile(charPath);
-  Real value;
-
-  std::vector<Real> reduced_field;
-  std::vector<Real> mobility;
-  if (myfile.is_open())
-  {
-    while (myfile >> value)
-    {
-      reduced_field.push_back(value);
-      myfile >> value;
-      mobility.push_back(value);
-    }
-    myfile.close();
-  }
-  else
-    mooseError("Unable to open file");
-
+  const auto [reduced_field, mobility] = CraneUtils::getReactionRates(*this);
   _mobility.setData(reduced_field, mobility);
 }
 

--- a/src/auxkernels/ElectronMobility.C
+++ b/src/auxkernels/ElectronMobility.C
@@ -17,7 +17,8 @@ InputParameters
 ElectronMobility::validParams()
 {
  InputParameters params = AuxScalarKernel::validParams();
- params.addRequiredParam<std::string>("file_location", "The name of the file that stores the mobility table.");
+ params.addRequiredParam<FileName>("file_location",
+                                   "The name of the file that stores the mobility table.");
  params.addCoupledVar("reduced_field", "The electron mobility.");
  return params;
 }
@@ -26,7 +27,7 @@ ElectronMobility::ElectronMobility(const InputParameters & parameters)
  : AuxScalarKernel(parameters),
   _reduced_field(coupledScalarValue("reduced_field"))
 {
-  std::string file_name = getParam<std::string>("file_location") + "/" + "electron_mobility.txt";
+  std::string file_name = getParam<FileName>("file_location") + "/" + "electron_mobility.txt";
   MooseUtils::checkFileReadable(file_name);
   const char * charPath = file_name.c_str();
   std::ifstream myfile(charPath);

--- a/src/auxkernels/ScalarLinearInterpolation.C
+++ b/src/auxkernels/ScalarLinearInterpolation.C
@@ -25,10 +25,10 @@ ScalarLinearInterpolation::validParams()
                         "Multiplies the sampled output by a given factor. Convert from m^3 to "
                         "cm^3, for example.(Optional)");
   params.addParam<Real>("const_sampler", 0, "The value with which the data will be sampled.");
+  params.addRequiredParam<RelativeFileName>(
+      "property_file", "The file containing interpolation tables for material properties.");
   params.addParam<FileName>(
-      "property_file", "", "The file containing interpolation tables for material properties.");
-  params.addParam<std::string>(
-      "file_location", "", "The name of the file that stores the reaction rate tables.");
+      "file_location", ".", "The name of the file that stores the reaction rate tables.");
   params.addParam<std::string>("sampling_format",
                                "reduced_field",
                                "The format that the rate constant files are in. Options: "
@@ -48,7 +48,7 @@ ScalarLinearInterpolation::ScalarLinearInterpolation(const InputParameters & par
   std::vector<Real> x_val;
   std::vector<Real> y_val;
   std::string file_name =
-      getParam<std::string>("file_location") + "/" + getParam<FileName>("property_file");
+      getParam<FileName>("file_location") + "/" + getParam<RelativeFileName>("property_file");
   MooseUtils::checkFileReadable(file_name);
   const char * charPath = file_name.c_str();
   std::ifstream myfile(charPath);

--- a/src/auxkernels/ScalarSplineInterpolation.C
+++ b/src/auxkernels/ScalarSplineInterpolation.C
@@ -25,10 +25,10 @@ ScalarSplineInterpolation::validParams()
                         "Multiplies the sampled output by a given factor. Convert from m^3 to "
                         "cm^3, for example.(Optional)");
   params.addParam<Real>("const_sampler", 0, "The value with which the data will be sampled.");
+  params.addRequiredParam<RelativeFileName>(
+      "property_file", "The file containing interpolation tables for material properties.");
   params.addParam<FileName>(
-      "property_file", "", "The file containing interpolation tables for material properties.");
-  params.addParam<std::string>(
-      "file_location", "", "The name of the file that stores the reaction rate tables.");
+      "file_location", ".", "The name of the file that stores the reaction rate tables.");
   params.addParam<std::string>("sampling_format",
                                "reduced_field",
                                "The format that the rate constant files are in. Options: "
@@ -48,7 +48,7 @@ ScalarSplineInterpolation::ScalarSplineInterpolation(const InputParameters & par
   std::vector<Real> x_val;
   std::vector<Real> y_val;
   std::string file_name =
-      getParam<std::string>("file_location") + "/" + getParam<FileName>("property_file");
+      getParam<FileName>("file_location") + "/" + getParam<RelativeFileName>("property_file");
   MooseUtils::checkFileReadable(file_name);
   const char * charPath = file_name.c_str();
   std::ifstream myfile(charPath);

--- a/src/auxkernels/ScalarSplineInterpolation.C
+++ b/src/auxkernels/ScalarSplineInterpolation.C
@@ -10,12 +10,15 @@
 
 #include "ScalarSplineInterpolation.h"
 
+#include "CraneUtils.h"
+
 registerMooseObject("CraneApp", ScalarSplineInterpolation);
 
 InputParameters
 ScalarSplineInterpolation::validParams()
 {
   InputParameters params = AuxScalarKernel::validParams();
+  params += CraneUtils::propertyFileParams();
   params.addCoupledVar("sampler", 0, "The variable with which the data will be sampled.");
   params.addParam<bool>("use_time", false, "Whether or not to sample with time.");
   params.addParam<bool>(
@@ -25,10 +28,6 @@ ScalarSplineInterpolation::validParams()
                         "Multiplies the sampled output by a given factor. Convert from m^3 to "
                         "cm^3, for example.(Optional)");
   params.addParam<Real>("const_sampler", 0, "The value with which the data will be sampled.");
-  params.addRequiredParam<RelativeFileName>(
-      "property_file", "The file containing interpolation tables for material properties.");
-  params.addParam<FileName>(
-      "file_location", ".", "The name of the file that stores the reaction rate tables.");
   params.addParam<std::string>("sampling_format",
                                "reduced_field",
                                "The format that the rate constant files are in. Options: "
@@ -45,28 +44,7 @@ ScalarSplineInterpolation::ScalarSplineInterpolation(const InputParameters & par
     _use_log(getParam<bool>("use_log")),
     _scale_factor(getParam<Real>("scale_factor"))
 {
-  std::vector<Real> x_val;
-  std::vector<Real> y_val;
-  std::string file_name =
-      getParam<FileName>("file_location") + "/" + getParam<RelativeFileName>("property_file");
-  MooseUtils::checkFileReadable(file_name);
-  const char * charPath = file_name.c_str();
-  std::ifstream myfile(charPath);
-  Real value;
-
-  if (myfile.is_open())
-  {
-    while (myfile >> value)
-    {
-      x_val.push_back(value);
-      myfile >> value;
-      y_val.push_back(value);
-    }
-    myfile.close();
-  }
-  else
-    mooseError("Unable to open file");
-
+  const auto [x_val, y_val] = CraneUtils::getReactionRates(*this);
   _coefficient_interpolation.setData(x_val, y_val);
 }
 

--- a/src/materials/ADEEDFRateConstantTownsend.C
+++ b/src/materials/ADEEDFRateConstantTownsend.C
@@ -9,7 +9,8 @@
 //* https://www.gnu.org/licenses/lgpl-2.1.html
 
 #include "ADEEDFRateConstantTownsend.h"
-#include "MooseUtils.h"
+
+#include "CraneUtils.h"
 
 // MOOSE includes
 #include "MooseVariable.h"
@@ -20,11 +21,8 @@ InputParameters
 ADEEDFRateConstantTownsend::validParams()
 {
   InputParameters params = ADMaterial::validParams();
-  params.addRequiredParam<RelativeFileName>(
-      "property_file", "The file containing interpolation tables for material properties.");
+  params += CraneUtils::propertyFileParams();
   params.addRequiredParam<std::string>("reaction", "The full reaction equation.");
-  params.addRequiredParam<FileName>("file_location",
-                                    "The name of the file that stores the reaction rate tables.");
   params.addParam<std::string>(
       "reaction_coefficient_format",
       "townsend",
@@ -56,28 +54,7 @@ ADEEDFRateConstantTownsend::ADEEDFRateConstantTownsend(const InputParameters & p
     _em(adCoupledValue("electrons")),
     _mean_en(isCoupled("mean_energy") ? adCoupledValue("mean_energy") : _em)
 {
-  std::vector<Real> val_x;
-  std::vector<Real> rate_coefficient;
-  std::string file_name =
-      getParam<FileName>("file_location") + "/" + getParam<RelativeFileName>("property_file");
-  MooseUtils::checkFileReadable(file_name);
-  const char * charPath = file_name.c_str();
-  std::ifstream myfile(charPath);
-  Real value;
-
-  if (myfile.is_open())
-  {
-    while (myfile >> value)
-    {
-      val_x.push_back(value);
-      myfile >> value;
-      rate_coefficient.push_back(value);
-    }
-    myfile.close();
-  }
-  else
-    mooseError("Unable to open file");
-
+  const auto [val_x, rate_coefficient] = CraneUtils::getReactionRates(*this);
   _coefficient_interpolation.setData(val_x, rate_coefficient);
 }
 

--- a/src/materials/ADEEDFRateConstantTownsend.C
+++ b/src/materials/ADEEDFRateConstantTownsend.C
@@ -20,11 +20,11 @@ InputParameters
 ADEEDFRateConstantTownsend::validParams()
 {
   InputParameters params = ADMaterial::validParams();
-  params.addRequiredParam<FileName>(
+  params.addRequiredParam<RelativeFileName>(
       "property_file", "The file containing interpolation tables for material properties.");
   params.addRequiredParam<std::string>("reaction", "The full reaction equation.");
-  params.addRequiredParam<std::string>(
-      "file_location", "The name of the file that stores the reaction rate tables.");
+  params.addRequiredParam<FileName>("file_location",
+                                    "The name of the file that stores the reaction rate tables.");
   params.addParam<std::string>(
       "reaction_coefficient_format",
       "townsend",
@@ -59,7 +59,7 @@ ADEEDFRateConstantTownsend::ADEEDFRateConstantTownsend(const InputParameters & p
   std::vector<Real> val_x;
   std::vector<Real> rate_coefficient;
   std::string file_name =
-      getParam<std::string>("file_location") + "/" + getParam<FileName>("property_file");
+      getParam<FileName>("file_location") + "/" + getParam<RelativeFileName>("property_file");
   MooseUtils::checkFileReadable(file_name);
   const char * charPath = file_name.c_str();
   std::ifstream myfile(charPath);

--- a/src/materials/ADZapdosEEDFRateConstant.C
+++ b/src/materials/ADZapdosEEDFRateConstant.C
@@ -20,11 +20,11 @@ InputParameters
 ADZapdosEEDFRateConstant::validParams()
 {
   InputParameters params = ADMaterial::validParams();
-  params.addRequiredParam<FileName>(
+  params.addRequiredParam<RelativeFileName>(
       "property_file", "The file containing interpolation tables for material properties.");
   params.addRequiredParam<std::string>("reaction", "The full reaction equation.");
-  params.addRequiredParam<std::string>(
-      "file_location", "The name of the file that stores the reaction rate tables.");
+  params.addRequiredParam<FileName>("file_location",
+                                    "The name of the file that stores the reaction rate tables.");
   params.addCoupledVar("mean_energy", "The electron mean energy in log form.");
   params.addCoupledVar("electrons", "The electron density.");
   params.addParam<std::string>(
@@ -47,7 +47,7 @@ ADZapdosEEDFRateConstant::ADZapdosEEDFRateConstant(const InputParameters & param
   std::vector<Real> val_x;
   std::vector<Real> rate_coefficient;
   std::string file_name =
-      getParam<std::string>("file_location") + "/" + getParam<FileName>("property_file");
+      getParam<FileName>("file_location") + "/" + getParam<RelativeFileName>("property_file");
   MooseUtils::checkFileReadable(file_name);
   const char * charPath = file_name.c_str();
   std::ifstream myfile(charPath);

--- a/src/materials/ADZapdosEEDFRateConstant.C
+++ b/src/materials/ADZapdosEEDFRateConstant.C
@@ -9,7 +9,8 @@
 //* https://www.gnu.org/licenses/lgpl-2.1.html
 
 #include "ADZapdosEEDFRateConstant.h"
-#include "MooseUtils.h"
+
+#include "CraneUtils.h"
 
 // MOOSE includes
 #include "MooseVariable.h"
@@ -20,11 +21,8 @@ InputParameters
 ADZapdosEEDFRateConstant::validParams()
 {
   InputParameters params = ADMaterial::validParams();
-  params.addRequiredParam<RelativeFileName>(
-      "property_file", "The file containing interpolation tables for material properties.");
+  params += CraneUtils::propertyFileParams();
   params.addRequiredParam<std::string>("reaction", "The full reaction equation.");
-  params.addRequiredParam<FileName>("file_location",
-                                    "The name of the file that stores the reaction rate tables.");
   params.addCoupledVar("mean_energy", "The electron mean energy in log form.");
   params.addCoupledVar("electrons", "The electron density.");
   params.addParam<std::string>(
@@ -44,28 +42,7 @@ ADZapdosEEDFRateConstant::ADZapdosEEDFRateConstant(const InputParameters & param
     _em(adCoupledValue("electrons")),
     _mean_en(isCoupled("mean_energy") ? adCoupledValue("mean_energy") : _em)
 {
-  std::vector<Real> val_x;
-  std::vector<Real> rate_coefficient;
-  std::string file_name =
-      getParam<FileName>("file_location") + "/" + getParam<RelativeFileName>("property_file");
-  MooseUtils::checkFileReadable(file_name);
-  const char * charPath = file_name.c_str();
-  std::ifstream myfile(charPath);
-  Real value;
-
-  if (myfile.is_open())
-  {
-    while (myfile >> value)
-    {
-      val_x.push_back(value);
-      myfile >> value;
-      rate_coefficient.push_back(value);
-    }
-    myfile.close();
-  }
-  else
-    mooseError("Unable to open file");
-
+  const auto [val_x, rate_coefficient] = CraneUtils::getReactionRates(*this);
   _coefficient_interpolation.setData(val_x, rate_coefficient);
 }
 

--- a/src/materials/DiffusionRateTemp.C
+++ b/src/materials/DiffusionRateTemp.C
@@ -20,7 +20,8 @@ InputParameters
 DiffusionRateTemp::validParams()
 {
   InputParameters params = Material::validParams();
-  params.addRequiredParam<std::string>("file_location", "The name of the file that stores the mobility table.");
+  params.addRequiredParam<FileName>("file_location",
+                                    "The name of the file that stores the mobility table.");
   // params.addRequiredParam<std::string>("reaction", "The full reaction equation.");
   // params.addRequiredParam<Real>("", "The value of the reaction rate (constant).");
 
@@ -33,7 +34,7 @@ DiffusionRateTemp::DiffusionRateTemp(const InputParameters & parameters)
     _gap_length(getMaterialProperty<Real>("gap_length")),
     _radius(getMaterialProperty<Real>("radius"))
 {
-  std::string file_name = getParam<std::string>("file_location") + "/" + "electron_temperature.txt";
+  std::string file_name = getParam<FileName>("file_location") + "/" + "electron_temperature.txt";
   MooseUtils::checkFileReadable(file_name);
   const char * charPath = file_name.c_str();
   std::ifstream myfile(charPath);

--- a/src/materials/EEDFRateConstant.C
+++ b/src/materials/EEDFRateConstant.C
@@ -9,7 +9,8 @@
 //* https://www.gnu.org/licenses/lgpl-2.1.html
 
 #include "EEDFRateConstant.h"
-#include "MooseUtils.h"
+
+#include "CraneUtils.h"
 
 // MOOSE includes
 #include "MooseVariable.h"
@@ -20,11 +21,8 @@ InputParameters
 EEDFRateConstant::validParams()
 {
   InputParameters params = Material::validParams();
-  params.addRequiredParam<RelativeFileName>(
-      "property_file", "The file containing interpolation tables for material properties.");
+  params += CraneUtils::propertyFileParams();
   params.addRequiredParam<std::string>("reaction", "The full reaction equation.");
-  params.addRequiredParam<FileName>("file_location",
-                                    "The name of the file that stores the reaction rate tables.");
   params.addParam<bool>("elastic_collision", false, "If the reaction is elastic (true/false).");
   params.addCoupledVar("sampler", "The variable used to sample.");
   params.addCoupledVar("target_species", "The target species in this collision.");
@@ -49,31 +47,7 @@ EEDFRateConstant::EEDFRateConstant(const InputParameters & parameters)
     _em(isCoupled("electrons") ? coupledValue("electrons") : _zero),
     _mean_en(isCoupled("mean_energy") ? coupledValue("mean_energy") : _zero)
 {
-  if (!isCoupled("sampler"))
-    mooseError("Sampling variable is not coupled! Please input the variable (aux or nonlinear) "
-               "that will be used to sample from data files.");
-  std::vector<Real> val_x;
-  std::vector<Real> rate_coefficient;
-  std::string file_name =
-      getParam<FileName>("file_location") + "/" + getParam<RelativeFileName>("property_file");
-  MooseUtils::checkFileReadable(file_name);
-  const char * charPath = file_name.c_str();
-  std::ifstream myfile(charPath);
-  Real value;
-
-  if (myfile.is_open())
-  {
-    while (myfile >> value)
-    {
-      val_x.push_back(value);
-      myfile >> value;
-      rate_coefficient.push_back(value);
-    }
-    myfile.close();
-  }
-  else
-    mooseError("Unable to open file");
-
+  const auto [val_x, rate_coefficient] = CraneUtils::getReactionRates(*this);
   _coefficient_interpolation.setData(val_x, rate_coefficient);
 }
 

--- a/src/materials/EEDFRateConstant.C
+++ b/src/materials/EEDFRateConstant.C
@@ -20,11 +20,11 @@ InputParameters
 EEDFRateConstant::validParams()
 {
   InputParameters params = Material::validParams();
-  params.addRequiredParam<FileName>(
+  params.addRequiredParam<RelativeFileName>(
       "property_file", "The file containing interpolation tables for material properties.");
   params.addRequiredParam<std::string>("reaction", "The full reaction equation.");
-  params.addRequiredParam<std::string>(
-      "file_location", "The name of the file that stores the reaction rate tables.");
+  params.addRequiredParam<FileName>("file_location",
+                                    "The name of the file that stores the reaction rate tables.");
   params.addParam<bool>("elastic_collision", false, "If the reaction is elastic (true/false).");
   params.addCoupledVar("sampler", "The variable used to sample.");
   params.addCoupledVar("target_species", "The target species in this collision.");
@@ -55,7 +55,7 @@ EEDFRateConstant::EEDFRateConstant(const InputParameters & parameters)
   std::vector<Real> val_x;
   std::vector<Real> rate_coefficient;
   std::string file_name =
-      getParam<std::string>("file_location") + "/" + getParam<FileName>("property_file");
+      getParam<FileName>("file_location") + "/" + getParam<RelativeFileName>("property_file");
   MooseUtils::checkFileReadable(file_name);
   const char * charPath = file_name.c_str();
   std::ifstream myfile(charPath);

--- a/src/materials/EEDFRateConstantTownsend.C
+++ b/src/materials/EEDFRateConstantTownsend.C
@@ -20,11 +20,11 @@ InputParameters
 EEDFRateConstantTownsend::validParams()
 {
   InputParameters params = Material::validParams();
-  params.addRequiredParam<FileName>(
+  params.addRequiredParam<RelativeFileName>(
       "property_file", "The file containing interpolation tables for material properties.");
   params.addRequiredParam<std::string>("reaction", "The full reaction equation.");
-  params.addRequiredParam<std::string>(
-      "file_location", "The name of the file that stores the reaction rate tables.");
+  params.addRequiredParam<FileName>("file_location",
+                                    "The name of the file that stores the reaction rate tables.");
   params.addParam<bool>("elastic_collision",
                         false,
                         "Determining whether or not a collision is elastic. Energy change for "
@@ -63,7 +63,7 @@ EEDFRateConstantTownsend::EEDFRateConstantTownsend(const InputParameters & param
   std::vector<Real> actual_mean_energy;
   std::vector<Real> rate_coefficient;
   std::string file_name =
-      getParam<std::string>("file_location") + "/" + getParam<FileName>("property_file");
+      getParam<FileName>("file_location") + "/" + getParam<RelativeFileName>("property_file");
   MooseUtils::checkFileReadable(file_name);
   const char * charPath = file_name.c_str();
   std::ifstream myfile(charPath);

--- a/src/materials/ElectricField.C
+++ b/src/materials/ElectricField.C
@@ -20,7 +20,8 @@ InputParameters
 ElectricField::validParams()
 {
   InputParameters params = Material::validParams();
-  params.addRequiredParam<std::string>("file_location", "The name of the file that stores the mobility table.");
+  params.addRequiredParam<FileName>("file_location",
+                                    "The name of the file that stores the mobility table.");
   params.addParam<bool>("use_log", false, "Whether or not to use logarithmic form.");
   params.addCoupledVar("electron_density", "The electron density.");
   params.addCoupledVar("neutral_density", "The neutral gas density.");
@@ -41,7 +42,7 @@ ElectricField::ElectricField(const InputParameters & parameters)
   _use_log(getParam<bool>("use_log")),
   _n_gas(getMaterialProperty<Real>("n_gas"))
 {
-  std::string file_name = getParam<std::string>("file_location") + "/" + "electron_mobility.txt";
+  std::string file_name = getParam<FileName>("file_location") + "/" + "electron_mobility.txt";
   MooseUtils::checkFileReadable(file_name);
   const char * charPath = file_name.c_str();
   std::ifstream myfile(charPath);

--- a/src/materials/HeatCapacityRatio.C
+++ b/src/materials/HeatCapacityRatio.C
@@ -9,7 +9,8 @@
 //* https://www.gnu.org/licenses/lgpl-2.1.html
 
 #include "HeatCapacityRatio.h"
-#include "MooseUtils.h"
+
+#include "CraneUtils.h"
 
 // MOOSE includes
 #include "MooseVariable.h"
@@ -20,9 +21,12 @@ InputParameters
 HeatCapacityRatio::validParams()
 {
   InputParameters params = SpeciesSum::validParams();
+  params += CraneUtils::propertyPathParams();
   params.addRequiredParam<std::vector<std::string>>("species", "The list of gaseous species contributing to gas temperature.");
-  params.addRequiredParam<FileName>("file_location",
-                                    "The name of the file that stores the reaction rate tables.");
+  params.addParam<FileName>(
+      "file_location",
+      ".",
+      "The name of the file that stores reaction rate tables (defaults to the current directory).");
   params.addCoupledVar("gas_temperature", "The temperature of the background gas. Needed for rate constant calculation. Default: 300 K.");
   // params.addCoupledVar("all_species", "The coupled variables to sum.");
   return params;
@@ -45,30 +49,11 @@ HeatCapacityRatio::HeatCapacityRatio(const InputParameters & parameters)
   // {
   //   _vals[i] = &coupledValue("coupled_vars", i);
   // }
-  std::string file_name;
+
   _polynomial_coefficients.resize(_species.size());
   _molar_heat_capacity.resize(_species.size());
   for (unsigned int i = 0; i < _species.size(); ++i)
-  {
-    file_name = getParam<FileName>("file_location") + "/" + _species[i] + ".txt";
-    MooseUtils::checkFileReadable(file_name);
-    const char * charPath = file_name.c_str();
-    std::ifstream myfile(charPath);
-    Real value;
-
-    if (myfile.is_open())
-    {
-      while (myfile >> value)
-      {
-        _polynomial_coefficients[i].push_back(value);
-      }
-      myfile.close();
-    }
-    else
-    {
-      mooseError("Unable to open file: " + file_name);
-    }
-  }
+    _polynomial_coefficients[i] = CraneUtils::getCoefficients(*this, _species[i] + ".txt");
 }
 
 void

--- a/src/materials/HeatCapacityRatio.C
+++ b/src/materials/HeatCapacityRatio.C
@@ -21,7 +21,8 @@ HeatCapacityRatio::validParams()
 {
   InputParameters params = SpeciesSum::validParams();
   params.addRequiredParam<std::vector<std::string>>("species", "The list of gaseous species contributing to gas temperature.");
-  params.addRequiredParam<std::string>("file_location", "The name of the file that stores the reaction rate tables.");
+  params.addRequiredParam<FileName>("file_location",
+                                    "The name of the file that stores the reaction rate tables.");
   params.addCoupledVar("gas_temperature", "The temperature of the background gas. Needed for rate constant calculation. Default: 300 K.");
   // params.addCoupledVar("all_species", "The coupled variables to sum.");
   return params;
@@ -49,7 +50,7 @@ HeatCapacityRatio::HeatCapacityRatio(const InputParameters & parameters)
   _molar_heat_capacity.resize(_species.size());
   for (unsigned int i = 0; i < _species.size(); ++i)
   {
-    file_name = getParam<std::string>("file_location") + "/" + _species[i] + ".txt";
+    file_name = getParam<FileName>("file_location") + "/" + _species[i] + ".txt";
     MooseUtils::checkFileReadable(file_name);
     const char * charPath = file_name.c_str();
     std::ifstream myfile(charPath);

--- a/src/materials/InterpolatedCoefficientLinear.C
+++ b/src/materials/InterpolatedCoefficientLinear.C
@@ -20,11 +20,11 @@ InputParameters
 InterpolatedCoefficientLinear::validParams()
 {
   InputParameters params = ADMaterial::validParams();
-  params.addRequiredParam<FileName>(
+  params.addRequiredParam<RelativeFileName>(
       "property_file", "The file containing interpolation tables for material properties.");
   params.addRequiredParam<std::string>("reaction", "The full reaction equation.");
-  params.addRequiredParam<std::string>(
-      "file_location", "The name of the file that stores the reaction rate tables.");
+  params.addRequiredParam<FileName>("file_location",
+                                    "The name of the file that stores the reaction rate tables.");
   params.addRequiredCoupledVar("mean_energy", "The electron mean energy in log form.");
   params.addRequiredCoupledVar("electrons", "The electron density.");
   params.addParam<bool>("townsend",
@@ -60,7 +60,7 @@ InterpolatedCoefficientLinear::InterpolatedCoefficientLinear(const InputParamete
   std::vector<Real> val_x;
   std::vector<Real> rate_coefficient;
   std::string file_name =
-      getParam<std::string>("file_location") + "/" + getParam<FileName>("property_file");
+      getParam<FileName>("file_location") + "/" + getParam<RelativeFileName>("property_file");
   MooseUtils::checkFileReadable(file_name);
   const char * charPath = file_name.c_str();
   std::ifstream myfile(charPath);

--- a/src/materials/InterpolatedCoefficientLinear.C
+++ b/src/materials/InterpolatedCoefficientLinear.C
@@ -9,7 +9,8 @@
 //* https://www.gnu.org/licenses/lgpl-2.1.html
 
 #include "InterpolatedCoefficientLinear.h"
-#include "MooseUtils.h"
+
+#include "CraneUtils.h"
 
 // MOOSE includes
 #include "MooseVariable.h"
@@ -20,11 +21,8 @@ InputParameters
 InterpolatedCoefficientLinear::validParams()
 {
   InputParameters params = ADMaterial::validParams();
-  params.addRequiredParam<RelativeFileName>(
-      "property_file", "The file containing interpolation tables for material properties.");
+  params += CraneUtils::propertyFileParams();
   params.addRequiredParam<std::string>("reaction", "The full reaction equation.");
-  params.addRequiredParam<FileName>("file_location",
-                                    "The name of the file that stores the reaction rate tables.");
   params.addRequiredCoupledVar("mean_energy", "The electron mean energy in log form.");
   params.addRequiredCoupledVar("electrons", "The electron density.");
   params.addParam<bool>("townsend",
@@ -57,28 +55,7 @@ InterpolatedCoefficientLinear::InterpolatedCoefficientLinear(const InputParamete
     _em(adCoupledValue("electrons")),
     _mean_en(adCoupledValue("mean_energy"))
 {
-  std::vector<Real> val_x;
-  std::vector<Real> rate_coefficient;
-  std::string file_name =
-      getParam<FileName>("file_location") + "/" + getParam<RelativeFileName>("property_file");
-  MooseUtils::checkFileReadable(file_name);
-  const char * charPath = file_name.c_str();
-  std::ifstream myfile(charPath);
-  Real value;
-
-  if (myfile.is_open())
-  {
-    while (myfile >> value)
-    {
-      val_x.push_back(value);
-      myfile >> value;
-      rate_coefficient.push_back(value);
-    }
-    myfile.close();
-  }
-  else
-    mooseError("Unable to open file");
-
+  const auto [val_x, rate_coefficient] = CraneUtils::getReactionRates(*this);
   _coefficient_interpolation =
       std::make_unique<LinearInterpolation>(val_x, rate_coefficient, true);
 }

--- a/src/materials/InterpolatedCoefficientSpline.C
+++ b/src/materials/InterpolatedCoefficientSpline.C
@@ -20,11 +20,11 @@ InputParameters
 InterpolatedCoefficientSpline::validParams()
 {
   InputParameters params = ADMaterial::validParams();
-  params.addRequiredParam<FileName>(
+  params.addRequiredParam<RelativeFileName>(
       "property_file", "The file containing interpolation tables for material properties.");
   params.addRequiredParam<std::string>("reaction", "The full reaction equation.");
-  params.addRequiredParam<std::string>(
-      "file_location", "The name of the file that stores the reaction rate tables.");
+  params.addRequiredParam<FileName>("file_location",
+                                    "The name of the file that stores the reaction rate tables.");
   params.addRequiredCoupledVar("mean_energy", "The electron mean energy in log form.");
   params.addRequiredCoupledVar("electrons", "The electron density.");
   params.addParam<bool>("townsend",
@@ -60,7 +60,7 @@ InterpolatedCoefficientSpline::InterpolatedCoefficientSpline(const InputParamete
   std::vector<Real> val_x;
   std::vector<Real> rate_coefficient;
   std::string file_name =
-      getParam<std::string>("file_location") + "/" + getParam<FileName>("property_file");
+      getParam<FileName>("file_location") + "/" + getParam<RelativeFileName>("property_file");
   MooseUtils::checkFileReadable(file_name);
   const char * charPath = file_name.c_str();
   std::ifstream myfile(charPath);

--- a/src/materials/SuperelasticReactionRate.C
+++ b/src/materials/SuperelasticReactionRate.C
@@ -24,7 +24,8 @@ SuperelasticReactionRate::validParams()
   params.addRequiredParam<std::string>("original_reaction", "The original (reversible) reaction from which this reaction was derived.");
   params.addRequiredParam<std::vector<Real>>("stoichiometric_coeff", "The coefficients of each reactant and product.");
   params.addRequiredParam<std::vector<std::string>>("participants", "All reaction participants.");
-  params.addRequiredParam<std::string>("file_location", "The name of the file that stores the reaction rate tables.");
+  params.addRequiredParam<FileName>("file_location",
+                                    "The name of the file that stores the reaction rate tables.");
   params.addCoupledVar("gas_temperature", "The temperature of the background gas. Needed for rate constant calculation. Default: 300 K.");
   return params;
 }
@@ -50,7 +51,7 @@ SuperelasticReactionRate::SuperelasticReactionRate(const InputParameters & param
   for (unsigned int i = 0; i < _participants.size(); ++i)
   {
     _power_coefficient += _coefficients[i];  // Finko, equation 7
-    file_name = getParam<std::string>("file_location") + "/" + _participants[i] + ".txt";
+    file_name = getParam<FileName>("file_location") + "/" + _participants[i] + ".txt";
     MooseUtils::checkFileReadable(file_name);
     const char * charPath = file_name.c_str();
     std::ifstream myfile(charPath);

--- a/src/materials/ZapdosEEDFRateConstant.C
+++ b/src/materials/ZapdosEEDFRateConstant.C
@@ -20,11 +20,11 @@ InputParameters
 ZapdosEEDFRateConstant::validParams()
 {
   InputParameters params = Material::validParams();
-  params.addRequiredParam<FileName>(
+  params.addRequiredParam<RelativeFileName>(
       "property_file", "The file containing interpolation tables for material properties.");
   params.addRequiredParam<std::string>("reaction", "The full reaction equation.");
-  params.addRequiredParam<std::string>(
-      "file_location", "The name of the file that stores the reaction rate tables.");
+  params.addRequiredParam<FileName>("file_location",
+                                    "The name of the file that stores the reaction rate tables.");
   params.addCoupledVar("mean_energy", "The electron mean energy in log form.");
   params.addCoupledVar("electrons", "The electron density.");
   params.addParam<std::string>(
@@ -52,7 +52,7 @@ ZapdosEEDFRateConstant::ZapdosEEDFRateConstant(const InputParameters & parameter
   std::vector<Real> val_x;
   std::vector<Real> rate_coefficient;
   std::string file_name =
-      getParam<std::string>("file_location") + "/" + getParam<FileName>("property_file");
+      getParam<FileName>("file_location") + "/" + getParam<RelativeFileName>("property_file");
   MooseUtils::checkFileReadable(file_name);
   const char * charPath = file_name.c_str();
   std::ifstream myfile(charPath);

--- a/src/materials/ZapdosEEDFRateConstant.C
+++ b/src/materials/ZapdosEEDFRateConstant.C
@@ -9,7 +9,7 @@
 //* https://www.gnu.org/licenses/lgpl-2.1.html
 
 #include "ZapdosEEDFRateConstant.h"
-#include "MooseUtils.h"
+#include "CraneUtils.h"
 
 // MOOSE includes
 #include "MooseVariable.h"
@@ -20,11 +20,8 @@ InputParameters
 ZapdosEEDFRateConstant::validParams()
 {
   InputParameters params = Material::validParams();
-  params.addRequiredParam<RelativeFileName>(
-      "property_file", "The file containing interpolation tables for material properties.");
+  params += CraneUtils::propertyFileParams();
   params.addRequiredParam<std::string>("reaction", "The full reaction equation.");
-  params.addRequiredParam<FileName>("file_location",
-                                    "The name of the file that stores the reaction rate tables.");
   params.addCoupledVar("mean_energy", "The electron mean energy in log form.");
   params.addCoupledVar("electrons", "The electron density.");
   params.addParam<std::string>(
@@ -49,28 +46,8 @@ ZapdosEEDFRateConstant::ZapdosEEDFRateConstant(const InputParameters & parameter
   if (!isParamValid("sampler") && !isParamValid("mean_energy"))
     mooseError("Material ZapdosEEDFRateConstant requires either a sampling variable or the "
                "electron and mean energy variables to be set!");
-  std::vector<Real> val_x;
-  std::vector<Real> rate_coefficient;
-  std::string file_name =
-      getParam<FileName>("file_location") + "/" + getParam<RelativeFileName>("property_file");
-  MooseUtils::checkFileReadable(file_name);
-  const char * charPath = file_name.c_str();
-  std::ifstream myfile(charPath);
-  Real value;
 
-  if (myfile.is_open())
-  {
-    while (myfile >> value)
-    {
-      val_x.push_back(value);
-      myfile >> value;
-      rate_coefficient.push_back(value);
-    }
-    myfile.close();
-  }
-  else
-    mooseError("Unable to open file");
-
+  const auto [val_x, rate_coefficient] = CraneUtils::getReactionRates(*this);
   _coefficient_interpolation.setData(val_x, rate_coefficient);
 }
 

--- a/src/scalarkernels/ParsedScalarReaction.C
+++ b/src/scalarkernels/ParsedScalarReaction.C
@@ -17,10 +17,10 @@ InputParameters
 ParsedScalarReaction::validParams()
 {
   InputParameters params = ParsedODEKernel::validParams();
+  params.addRequiredParam<RelativeFileName>(
+      "property_file", "The file containing interpolation tables for material properties.");
   params.addParam<FileName>(
-      "property_file", "", "The file containing interpolation tables for material properties.");
-  params.addParam<std::string>(
-      "file_location", "", "The name of the file that stores the reaction rate tables.");
+      "file_location", ".", "The name of the file that stores the reaction rate tables.");
   params.addParam<std::string>("sampling_format",
                                "reduced_field",
                                "The format that the rate constant files are in. Options: "
@@ -43,7 +43,7 @@ ParsedScalarReaction::ParsedScalarReaction(const InputParameters & parameters)
   std::vector<Real> reduced_field;
   std::vector<Real> electron_temperature;
   std::string file_name =
-      getParam<std::string>("file_location") + "/" + getParam<FileName>("property_file");
+      getParam<FileName>("file_location") + "/" + getParam<RelativeFileName>("property_file");
   MooseUtils::checkFileReadable(file_name);
   const char * charPath = file_name.c_str();
   std::ifstream myfile(charPath);

--- a/src/userobjects/PolynomialCoefficients.C
+++ b/src/userobjects/PolynomialCoefficients.C
@@ -19,7 +19,8 @@ PolynomialCoefficients::validParams()
   InputParameters params = GeneralUserObject::validParams();
   params.addRequiredParam<std::vector<Real>>("stoichiometric_coeff", "The coefficients of each reactant and product.");
   params.addRequiredParam<std::vector<std::string>>("participants", "All reaction participants.");
-  params.addRequiredParam<std::string>("file_location", "The name of the file that stores the reaction rate tables.");
+  params.addRequiredParam<FileName>("file_location",
+                                    "The name of the file that stores the reaction rate tables.");
   return params;
 }
 
@@ -57,7 +58,7 @@ PolynomialCoefficients::initialize()
   for (unsigned int i = 0; i < _participants.size(); ++i)
   {
     _power_coefficient += _coefficients[i];  // Finko, equation 7
-    file_name = getParam<std::string>("file_location") + "/" + _participants[i] + ".txt";
+    file_name = getParam<FileName>("file_location") + "/" + _participants[i] + ".txt";
     MooseUtils::checkFileReadable(file_name);
     const char * charPath = file_name.c_str();
     std::ifstream myfile(charPath);

--- a/src/userobjects/PolynomialCoefficients.C
+++ b/src/userobjects/PolynomialCoefficients.C
@@ -10,6 +10,7 @@
 
 #include "PolynomialCoefficients.h"
 #include "Function.h"
+#include "CraneUtils.h"
 
 registerMooseObject("CraneApp", PolynomialCoefficients);
 
@@ -17,10 +18,9 @@ InputParameters
 PolynomialCoefficients::validParams()
 {
   InputParameters params = GeneralUserObject::validParams();
+  params += CraneUtils::propertyPathParams();
   params.addRequiredParam<std::vector<Real>>("stoichiometric_coeff", "The coefficients of each reactant and product.");
   params.addRequiredParam<std::vector<std::string>>("participants", "All reaction participants.");
-  params.addRequiredParam<FileName>("file_location",
-                                    "The name of the file that stores the reaction rate tables.");
   return params;
 }
 
@@ -51,31 +51,12 @@ PolynomialCoefficients::initialize()
   // Section 2.2, Equation 13
 
   // Read the participant species' coefficients from files
-  std::string file_name;
-  // std::vector<std::vector<Real>> polynomial_coefficients;
   _polynomial_coefficients.resize(_participants.size());
   _power_coefficient = 0.0;
   for (unsigned int i = 0; i < _participants.size(); ++i)
   {
     _power_coefficient += _coefficients[i];  // Finko, equation 7
-    file_name = getParam<FileName>("file_location") + "/" + _participants[i] + ".txt";
-    MooseUtils::checkFileReadable(file_name);
-    const char * charPath = file_name.c_str();
-    std::ifstream myfile(charPath);
-    Real value;
-
-    if (myfile.is_open())
-    {
-      while (myfile >> value)
-      {
-        _polynomial_coefficients[i].push_back(value);
-      }
-      myfile.close();
-    }
-    else
-    {
-      mooseError("Unable to open file: " + file_name);
-    }
+    _polynomial_coefficients[i] = CraneUtils::getCoefficients(*this, _participants[i] + ".txt");
   }
 }
 

--- a/src/userobjects/RateCoefficientProvider.C
+++ b/src/userobjects/RateCoefficientProvider.C
@@ -18,10 +18,10 @@ RateCoefficientProvider::validParams()
 {
   InputParameters params = GeneralUserObject::validParams();
   params.addCoupledVar("reduced_field", 0, "The value of the reduced electric field [V m^2].");
+  params.addRequiredParam<RelativeFileName>(
+      "property_file", "The file containing interpolation tables for material properties.");
   params.addParam<FileName>(
-      "property_file", "", "The file containing interpolation tables for material properties.");
-  params.addParam<std::string>(
-      "file_location", "", "The name of the file that stores the reaction rate tables.");
+      "file_location", ".", "The name of the file that stores the reaction rate tables.");
   params.addParam<std::string>("sampling_format",
                                "reduced_field",
                                "The format that the rate constant files are in. Options: "
@@ -57,7 +57,7 @@ RateCoefficientProvider::RateCoefficientProvider(const InputParameters & paramet
     std::vector<Real> reduced_field;
     std::vector<Real> rate_coefficient;
     std::string file_name =
-        getParam<std::string>("file_location") + "/" + getParam<FileName>("property_file");
+        getParam<FileName>("file_location") + "/" + getParam<RelativeFileName>("property_file");
     MooseUtils::checkFileReadable(file_name);
     const char * charPath = file_name.c_str();
     std::ifstream myfile(charPath);

--- a/src/userobjects/RateCoefficientProvider.C
+++ b/src/userobjects/RateCoefficientProvider.C
@@ -9,6 +9,7 @@
 //* https://www.gnu.org/licenses/lgpl-2.1.html
 
 #include "RateCoefficientProvider.h"
+#include "CraneUtils.h"
 // #include "Function.h"
 
 registerMooseObject("CraneApp", RateCoefficientProvider);
@@ -17,11 +18,9 @@ InputParameters
 RateCoefficientProvider::validParams()
 {
   InputParameters params = GeneralUserObject::validParams();
+  params += CraneUtils::propertyFileParams();
+  params.makeParamNotRequired("property_file");
   params.addCoupledVar("reduced_field", 0, "The value of the reduced electric field [V m^2].");
-  params.addRequiredParam<RelativeFileName>(
-      "property_file", "The file containing interpolation tables for material properties.");
-  params.addParam<FileName>(
-      "file_location", ".", "The name of the file that stores the reaction rate tables.");
   params.addParam<std::string>("sampling_format",
                                "reduced_field",
                                "The format that the rate constant files are in. Options: "
@@ -54,28 +53,10 @@ RateCoefficientProvider::RateCoefficientProvider(const InputParameters & paramet
 {
   if (_rate_format == "EEDF")
   {
-    std::vector<Real> reduced_field;
-    std::vector<Real> rate_coefficient;
-    std::string file_name =
-        getParam<FileName>("file_location") + "/" + getParam<RelativeFileName>("property_file");
-    MooseUtils::checkFileReadable(file_name);
-    const char * charPath = file_name.c_str();
-    std::ifstream myfile(charPath);
-    Real value;
-
-    if (myfile.is_open())
-    {
-      while (myfile >> value)
-      {
-        reduced_field.push_back(value);
-        myfile >> value;
-        rate_coefficient.push_back(value);
-      }
-      myfile.close();
-    }
-    else
-      mooseError("Unable to open file");
-
+    if (!isParamValid("property_file"))
+      paramError("rate_format",
+                 "The parameter 'property_file' must be specified with rate_format=EEDF");
+    const auto [reduced_field, rate_coefficient] = CraneUtils::getReactionRates(*this);
     _coefficient_interpolation.setData(reduced_field, rate_coefficient);
   }
   else if (_rate_format == "Constant")

--- a/src/userobjects/ValueProvider.C
+++ b/src/userobjects/ValueProvider.C
@@ -17,9 +17,10 @@ InputParameters
 ValueProvider::validParams()
 {
   InputParameters params = GeneralUserObject::validParams();
-  params.addParam<FileName>("property_file", "",
-      "The file containing interpolation tables for material properties.");
-  params.addParam<std::string>("file_location", "", "The name of the file that stores the reaction rate tables.");
+  params.addRequiredParam<RelativeFileName>(
+      "property_file", "The file containing interpolation tables for material properties.");
+  params.addParam<FileName>(
+      "file_location", ".", "The name of the file that stores the reaction rate tables.");
   params.addParam<std::string>("sampling_format", "reduced_field",
     "The format that the rate constant files are in. Options: reduced_field and electron_energy.");
   return params;
@@ -31,7 +32,8 @@ ValueProvider::ValueProvider(const InputParameters & parameters)
 {
     std::vector<Real> reduced_field;
     std::vector<Real> electron_temperature;
-    std::string file_name = getParam<std::string>("file_location") + "/" + getParam<FileName>("property_file");
+    std::string file_name =
+        getParam<FileName>("file_location") + "/" + getParam<RelativeFileName>("property_file");
     MooseUtils::checkFileReadable(file_name);
     const char * charPath = file_name.c_str();
     std::ifstream myfile(charPath);

--- a/src/utils/CraneUtils.C
+++ b/src/utils/CraneUtils.C
@@ -1,0 +1,117 @@
+//* This file is part of Crane, an open-source
+//* application for plasma chemistry and thermochemistry
+//* https://github.com/lcpp-org/crane
+//*
+//* Crane is powered by the MOOSE Framework
+//* https://www.mooseframework.org
+//*
+//* Licensed under LGPL 2.1, please see LICENSE for details
+//* https://www.gnu.org/licenses/lgpl-2.1.html
+
+#include "CraneUtils.h"
+
+#include "MooseUtils.h"
+#include "MooseObject.h"
+
+#include "libmesh/libmesh_common.h"
+
+#include <fstream>
+
+namespace CraneUtils
+{
+InputParameters
+propertyPathParams()
+{
+  auto params = emptyInputParameters();
+  params.addParam<FileName>(
+      "file_location",
+      ".",
+      "The name of the file that stores reaction rate tables (defaults to the current directory).");
+  return params;
+}
+
+InputParameters
+propertyFileParams()
+{
+  auto params = propertyPathParams();
+  params.addRequiredParam<RelativeFileName>(
+      "property_file",
+      "The file containing interpolation tables for material "
+      "properties (within the directory specified by 'file_location').");
+  return params;
+}
+
+std::pair<std::vector<Real>, std::vector<Real>>
+getReactionRates(const MooseObject & object)
+{
+  const auto & property_file = object.getParam<RelativeFileName>("property_file");
+  const auto file_name = internal::getReactionRateFileName(object, property_file);
+
+  std::pair<std::vector<Real>, std::vector<Real>> values;
+  auto & [x, y] = values;
+
+  try
+  {
+    std::ifstream file(file_name.c_str());
+    Real value;
+    while (file >> value)
+    {
+      x.push_back(value);
+      file >> value;
+      y.push_back(value);
+    }
+    file.close();
+  }
+  catch (...)
+  {
+    object.mooseError("Failed to parse the file '", file_name, "'");
+  }
+
+  return values;
+}
+
+std::vector<Real>
+getCoefficients(const MooseObject & object, const std::string & property_file)
+{
+  const auto file_name = internal::getReactionRateFileName(object, property_file);
+
+  std::vector<Real> values;
+
+  try
+  {
+    std::ifstream file(file_name.c_str());
+    Real value;
+    while (file >> value)
+    {
+      values.push_back(value);
+    }
+    file.close();
+  }
+  catch (...)
+  {
+    object.mooseError("Failed to parse the file '", file_name, "'");
+  }
+
+  return values;
+}
+
+namespace internal
+{
+std::string
+getReactionRateFileName(const MooseObject & object, const std::string & property_file)
+{
+  const auto & file_location = object.getParam<FileName>("file_location");
+  if (file_location.empty())
+    object.paramError(
+        "file_location",
+        "Parameter is empty; if you wish to use the current working directory, use '.'");
+
+  std::string file_name = file_location + "/" + property_file;
+  if (!MooseUtils::checkFileReadable(file_name, false, false))
+    object.mooseError("Failed to find the reaction rate file '", file_name, "'");
+
+  return file_name;
+}
+
+} // namespace internal
+} // namespace CraneUtils


### PR DESCRIPTION
refs idaholab/moose#26947

Requires https://github.com/idaholab/moose/pull/27143 and is in support of https://github.com/idaholab/moose/issues/26947

All `file_location` parameters are set to the `FileName` type, which eventually will be auto filled with the correct absolute path to the file base. For objects that have a default, the default is set to `.` (cwd of the input file). All `property_file` parameters are set to the `RelativeFileName` type, which means don't have their absolute paths resolved so you can do `<file_location>/<property_file>`.