### PR TITLE
Corrections to CraneApp for MOOSE Language Support

### DIFF
--- a/include/base/CraneApp.h
+++ b/include/base/CraneApp.h
@@ -15,7 +15,7 @@
 class CraneApp : public MooseApp
 {
 public:
-  CraneApp(InputParameters parameters);
+  CraneApp(const InputParameters & parameters);
   static InputParameters validParams();
 
   virtual ~CraneApp();

--- a/src/base/CraneApp.C
+++ b/src/base/CraneApp.C
@@ -21,7 +21,7 @@ CraneApp::validParams()
   return params;
 }
 
-CraneApp::CraneApp(InputParameters parameters) : MooseApp(parameters)
+CraneApp::CraneApp(const InputParameters & parameters) : MooseApp(parameters)
 {
   CraneApp::registerAll(_factory, _action_factory, _syntax);
 }


### PR DESCRIPTION
Changes made to CraneApp.h and CraneApp.c to allow for the use of MOOSE Language Support VSCode extension. See a similar issue and correction to MALAMUTE at [https://github.com/idaholab/malamute/pull/199](url).