### PR TITLE
Simple fix: mamba -> conda in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ After installing MOOSE, make sure you have the following folder on your local ma
 
 `git submodule update --init moose`
 
-`mamba activate moose` 
+`conda activate moose` 
 
 `make -jn` 
 


### PR DESCRIPTION
Looks like 'conda activate moose' is the standard command again, so replaced 'mamba activate moose'